### PR TITLE
Add a scrolling container around block math elements

### DIFF
--- a/crates/rari-doc/src/html/rewriter.rs
+++ b/crates/rari-doc/src/html/rewriter.rs
@@ -274,7 +274,12 @@ pub fn post_process_html<T: PageLike>(
             );
             Ok(())
         }),
-        element!("table, math[display=block]", |el| {
+        element!("table", |el| {
+            el.before("<figure class=\"table-container\">", ContentType::Html);
+            el.after("</figure>", ContentType::Html);
+            Ok(())
+        }),
+        element!("math[display=block]", |el| {
             el.before("<figure class=\"table-container\">", ContentType::Html);
             el.after("</figure>", ContentType::Html);
             Ok(())

--- a/crates/rari-doc/src/html/rewriter.rs
+++ b/crates/rari-doc/src/html/rewriter.rs
@@ -274,7 +274,7 @@ pub fn post_process_html<T: PageLike>(
             );
             Ok(())
         }),
-        element!("table", |el| {
+        element!("table, math[display=block]", |el| {
             el.before("<figure class=\"table-container\">", ContentType::Html);
             el.after("</figure>", ContentType::Html);
             Ok(())


### PR DESCRIPTION
### Description

Adds `<figure class="table-container">` around `<math display="block">` to contain oversized formulas, just like it does for oversized tables.

### Motivation

Before

https://github.com/user-attachments/assets/29c63df5-102d-4115-a142-7e9cb1e5aea1

After

https://github.com/user-attachments/assets/164bb081-8a58-4545-a854-aa94b5cc4a2e

### Additional details

In the next step, it would make sense to rename it to `overflow-container` since it’s not exclusive to tables anymore.