### PR TITLE
feature(npm): export ts types, json schema

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -19,6 +19,12 @@ jobs:
           registry-url: "https://registry.npmjs.org/"
           node-version-file: "./rari-npm/package.json"
 
+      - name: Generate Schema
+        working-directory: ./rari-npm
+        run: npm install && npm run export-schema && npm run generate-types
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Publish
         working-directory: ./rari-npm
         run: npm publish --access public

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,3 @@ tests/data/content/files/*
 !tests/data/content/files/.keep
 tests/data/translated_content/files/*
 !tests/data/translated_content/files/.keep
-rari-npm/schema.json
-rari-npm/lib/rari-types.d.ts

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ tests/data/content/files/*
 !tests/data/content/files/.keep
 tests/data/translated_content/files/*
 !tests/data/translated_content/files/.keep
+rari-npm/schema.json
+rari-npm/lib/rari-types.d.ts

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -941,6 +941,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
+
+[[package]]
 name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2589,6 +2595,7 @@ dependencies = [
  "rari-tools",
  "rari-types",
  "rari-utils",
+ "schemars",
  "self_update",
  "serde",
  "serde_json",
@@ -2606,6 +2613,7 @@ dependencies = [
  "chrono",
  "indexmap",
  "rari-utils",
+ "schemars",
  "serde",
  "serde_json",
  "thiserror",
@@ -2662,6 +2670,7 @@ dependencies = [
  "rari-utils",
  "rayon",
  "regex",
+ "schemars",
  "scraper",
  "serde",
  "serde_json",
@@ -2747,6 +2756,7 @@ dependencies = [
  "dirs",
  "indexmap",
  "normalize-path",
+ "schemars",
  "serde",
  "serde_json",
  "serde_variant",
@@ -3032,6 +3042,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3154,6 +3189,17 @@ name = "serde_derive"
 version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ console = "0.15"
 sha2 = "0.10"
 dashmap = "6"
 serde_yaml_ng = "0.10"
+schemars = { version = "0.8", features = ["chrono"] }
 pretty_yaml = "0.5"
 yaml_parser = "0.2"
 const_format = "0.2"
@@ -109,6 +110,7 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 anyhow.workspace = true
 dashmap.workspace = true
+schemars.workspace = true
 
 self_update = { version = "0.41", default-features = false, features = [
   "rustls",

--- a/crates/rari-cli/main.rs
+++ b/crates/rari-cli/main.rs
@@ -15,6 +15,7 @@ use rari_doc::build::{
 };
 use rari_doc::cached_readers::{read_and_cache_doc_pages, CACHED_DOC_PAGE_FILES};
 use rari_doc::issues::{issues_by, InMemoryLayer};
+use rari_doc::pages::json::BuiltPage;
 use rari_doc::pages::types::doc::Doc;
 use rari_doc::reader::read_docs_parallel;
 use rari_doc::search_index::build_search_index;
@@ -29,6 +30,7 @@ use rari_tools::sync_translated_content::sync_translated_content;
 use rari_types::globals::{build_out_root, content_root, content_translated_root, SETTINGS};
 use rari_types::locale::Locale;
 use rari_types::settings::Settings;
+use schemars::schema_for;
 use self_update::cargo_crate_version;
 use tabwriter::TabWriter;
 use tracing::Level;
@@ -61,8 +63,14 @@ enum Commands {
     GitHistory,
     Popularities,
     Update(UpdateArgs),
+    ExportSchema(ExportSchemaArgs),
     #[command(subcommand)]
     Content(ContentSubcommand),
+}
+
+#[derive(Args)]
+struct ExportSchemaArgs {
+    output_file: Option<PathBuf>,
 }
 
 #[derive(Subcommand)]
@@ -386,7 +394,17 @@ fn main() -> Result<(), Error> {
             }
         },
         Commands::Update(args) => update(args.version)?,
+        Commands::ExportSchema(args) => export_schema(args)?,
     }
+    Ok(())
+}
+
+fn export_schema(args: ExportSchemaArgs) -> Result<(), Error> {
+    let out_path = args
+        .output_file
+        .unwrap_or_else(|| PathBuf::from("schema.json"));
+    let schema = schema_for!(BuiltPage);
+    fs::write(out_path, serde_json::to_string_pretty(&schema)?)?;
     Ok(())
 }
 

--- a/crates/rari-data/Cargo.toml
+++ b/crates/rari-data/Cargo.toml
@@ -14,3 +14,4 @@ serde_json.workspace = true
 url.workspace = true
 chrono.workspace = true
 indexmap.workspace = true
+schemars.workspace = true

--- a/crates/rari-data/src/baseline.rs
+++ b/crates/rari-data/src/baseline.rs
@@ -4,6 +4,7 @@ use std::marker::PhantomData;
 use std::path::Path;
 
 use rari_utils::io::read_to_string;
+use schemars::JsonSchema;
 use serde::de::{self, value, SeqAccess, Visitor};
 use serde::{Deserialize, Deserializer, Serialize};
 use url::Url;
@@ -98,7 +99,7 @@ pub enum BrowserIdentifier {
     SafariIos,
 }
 
-#[derive(Deserialize, Serialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, Clone, Copy, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum BaselineHighLow {
     High,
@@ -107,7 +108,7 @@ pub enum BaselineHighLow {
     False(bool),
 }
 
-#[derive(Deserialize, Serialize, Clone, Debug)]
+#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
 pub struct SupportStatus {
     /// Whether the feature is Baseline (low substatus), Baseline (high substatus), or not (false)
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -122,7 +123,7 @@ pub struct SupportStatus {
     pub support: BTreeMap<BrowserIdentifier, String>,
 }
 
-#[derive(Deserialize, Serialize, Clone, Debug)]
+#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
 pub struct SupportStatusWithByKey {
     /// Whether the feature is Baseline (low substatus), Baseline (high substatus), or not (false)
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/rari-doc/Cargo.toml
+++ b/crates/rari-doc/Cargo.toml
@@ -28,6 +28,7 @@ dashmap.workspace = true
 pretty_yaml.workspace = true
 serde_yaml_ng.workspace = true
 yaml_parser.workspace = true
+schemars.workspace = true
 
 yaml-rust = "0.4"
 percent-encoding = "2"
@@ -35,7 +36,6 @@ pest = "2"
 pest_derive = "2"
 validator = { version = "0.19", features = ["derive"] }
 chrono = { version = "0.4", features = ["serde"] }
-
 scraper = { version = "0.21", features = ["deterministic"] }
 lol_html = "2"
 html-escape = "0.2"

--- a/crates/rari-doc/src/issues.rs
+++ b/crates/rari-doc/src/issues.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use std::sync::atomic::AtomicI64;
 use std::sync::{Arc, Mutex};
 
+use schemars::JsonSchema;
 use serde::Serialize;
 use tracing::field::{Field, Visit};
 use tracing::span::{Attributes, Id};
@@ -232,7 +233,7 @@ where
     }
 }
 
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Debug, Default, Clone, JsonSchema)]
 #[serde(untagged)]
 pub enum Additional {
     BrokenLink {
@@ -245,7 +246,7 @@ pub enum Additional {
     None,
 }
 
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Debug, Default, Clone, JsonSchema)]
 pub struct DisplayIssue {
     pub id: i64,
     pub explanation: Option<String>,

--- a/crates/rari-doc/src/pages/json.rs
+++ b/crates/rari-doc/src/pages/json.rs
@@ -10,6 +10,7 @@ use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
 use rari_data::baseline::SupportStatusWithByKey;
 use rari_types::fm_types::PageType;
 use rari_types::locale::{Locale, Native};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use super::types::contributors::Usernames;
@@ -32,7 +33,7 @@ use crate::utils::modified_dt;
 ///   contain HTML.
 /// * `id` - The `id` attribute of the target element in the page.
 /// ```
-#[derive(Debug, Clone, Serialize, Default)]
+#[derive(Debug, Clone, Serialize, Default, JsonSchema)]
 pub struct TocEntry {
     pub text: String,
     pub id: String,
@@ -49,7 +50,7 @@ pub struct TocEntry {
 /// * `github_url` - A `String` that holds the GitHUb URL to the spource file.
 /// * `last_commit_url` - A `String` that holds the URL to the last commit in the GitHub repository.
 /// * `filename` - A `String` that specifies the name of the source file.
-#[derive(Debug, Clone, Serialize, Default)]
+#[derive(Debug, Clone, Serialize, Default, JsonSchema)]
 pub struct Source {
     pub folder: PathBuf,
     pub github_url: String,
@@ -67,7 +68,7 @@ pub struct Source {
 ///
 /// * `uri` - A `String` that holds the URL of the parent entity.
 /// * `title` - A `String` that holds the title of the parent entity.
-#[derive(Debug, Clone, Serialize, Default)]
+#[derive(Debug, Clone, Serialize, Default, JsonSchema)]
 pub struct Parent {
     pub uri: String,
     pub title: String,
@@ -84,7 +85,7 @@ pub struct Parent {
 /// * `locale` - A `Locale` that specifies the locale of the translation.
 /// * `title` - A `String` that holds the translated title.
 /// * `native` - A `Native` representing the locale in a locale-native spelling, ie. "Deutsch".
-#[derive(Debug, Clone, Serialize, Default)]
+#[derive(Debug, Clone, Serialize, Default, JsonSchema)]
 pub struct Translation {
     pub locale: Locale,
     pub title: String,
@@ -104,7 +105,7 @@ pub struct Translation {
 /// * `is_h3` - A `bool` that indicates whether the prose section's `title` will be rendered as a &lt;H3&gt;
 ///    heading. This field is serialized as `isH3`.
 /// * `content` - A `String` that holds the actual prose HTML content.
-#[derive(Debug, Clone, Serialize, Default)]
+#[derive(Debug, Clone, Serialize, Default, JsonSchema)]
 pub struct Prose {
     pub id: Option<String>,
     pub title: Option<String>,
@@ -129,7 +130,7 @@ pub struct Prose {
 /// * `query` - A `String` that holds the query string for BCD data.
 /// * `content` - An `Option<String>` that holds the optional content of the compatibility section. This field
 ///    is skipped during serialization if it is `None`.
-#[derive(Debug, Clone, Serialize, Default)]
+#[derive(Debug, Clone, Serialize, Default, JsonSchema)]
 pub struct Compat {
     pub id: Option<String>,
     pub title: Option<String>,
@@ -155,7 +156,7 @@ pub struct Compat {
 /// * `query` - A `String` that holds the BCD query string associated with the specification section.
 /// * `content` - An `Option<String>` that holds the optional content of the specification section. This field is
 ///   skipped during serialization if it is `None`.
-#[derive(Debug, Clone, Serialize, Default)]
+#[derive(Debug, Clone, Serialize, Default, JsonSchema)]
 pub struct SpecificationSection {
     pub id: Option<String>,
     pub title: Option<String>,
@@ -184,7 +185,7 @@ pub struct SpecificationSection {
 /// * `BrowserCompatibility(Compat)` - A variant that holds a `Compat` struct, which includes compatibility information.
 /// * `Specifications(SpecificationSection)` - A variant that holds a `SpecificationSection` struct, which includes
 ///   one or more specifications.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, JsonSchema)]
 #[serde(tag = "type", content = "value", rename_all = "snake_case")]
 pub enum Section {
     Prose(Prose),
@@ -229,7 +230,7 @@ pub enum Section {
 ///    during serialization if it is empty.
 /// * `page_type` - A `PageType` that specifies the type of the page, for example `LandingPage`, `LearnModule`, `CssAtRule` or
 ///    `HtmlAttribute`. Serialized as `pageType`.
-#[derive(Debug, Clone, Serialize, Default)]
+#[derive(Debug, Clone, Serialize, Default, JsonSchema)]
 pub struct JsonDoc {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub body: Vec<Section>,
@@ -343,7 +344,7 @@ pub struct JsonDocMetadata<'a> {
 ///
 /// * `doc` - A `JsonDoc` that holds the main content and metadata of the documentation page.
 /// * `url` - A `String` that holds the URL of the documentation page.
-#[derive(Debug, Clone, Serialize, Default)]
+#[derive(Debug, Clone, Serialize, Default, JsonSchema)]
 pub struct JsonDocPage {
     pub doc: JsonDoc,
     pub url: String,
@@ -357,7 +358,7 @@ pub struct JsonDocPage {
 /// # Fields
 ///
 /// * `posts` - A `Vec<BlogMeta>` that holds the metadata for each blog post.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct BlogIndex {
     pub posts: Vec<BlogMeta>,
 }
@@ -388,7 +389,7 @@ pub struct BlogIndex {
 /// * `prev_next` - An `Option<PrevNextByUrl>` that holds the previous and next URLs for navigation. Serialized as `prevNext` and skipped during
 ///    serialization if it is `None`.
 /// * `template` - A `Template` that specifies the template used for rendering the document.
-#[derive(Debug, Clone, Serialize, Default)]
+#[derive(Debug, Clone, Serialize, Default, JsonSchema)]
 pub struct JsonCurriculumDoc {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub body: Vec<Section>,
@@ -429,7 +430,7 @@ pub struct JsonCurriculumDoc {
 /// * `url` - A `String` that holds the URL of the curriculum page.
 /// * `page_title` - A `String` that holds the title of the curriculum page. Serialized as `pageTitle`.
 /// * `locale` - A `Locale` that specifies the locale of the curriculum page.
-#[derive(Debug, Clone, Serialize, Default)]
+#[derive(Debug, Clone, Serialize, Default, JsonSchema)]
 pub struct JsonCurriculumPage {
     pub doc: JsonCurriculumDoc,
     pub url: String,
@@ -461,7 +462,7 @@ pub struct JsonCurriculumPage {
 /// * `title` - A `String` that holds the title of the blog post.
 /// * `toc` - A `Vec<TocEntry>` that holds the table of contents entries for the blog post. This field is
 ///   skipped during serialization if it is empty.
-#[derive(Debug, Clone, Serialize, Default)]
+#[derive(Debug, Clone, Serialize, Default, JsonSchema)]
 pub struct JsonBlogPostDoc {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub body: Vec<Section>,
@@ -499,7 +500,7 @@ pub struct JsonBlogPostDoc {
 ///   Serialized as `blogMeta` and skipped during serialization if it is `None`.
 /// * `hy_data` - An `Option<BlogIndex>` that holds data related to the blog index, if available.
 ///   Serialized as `hyData` and skipped during serialization if it is `None`.
-#[derive(Debug, Clone, Serialize, Default)]
+#[derive(Debug, Clone, Serialize, Default, JsonSchema)]
 pub struct JsonBlogPostPage {
     pub doc: JsonBlogPostDoc,
     pub locale: Locale,
@@ -529,7 +530,7 @@ pub struct JsonBlogPostPage {
 /// * `profile_img_alt` - A `String` that holds the alt text for the contributor's profile image. Serialized as `profileImgAlt`.
 /// * `usernames` - A `Usernames` struct that holds the usernames associated with the contributor.
 /// * `quote` - A `String` that holds a quote from the contributor.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct ContributorSpotlightHyData {
     pub sections: Vec<Section>,
     #[serde(rename = "contributorName")]
@@ -557,7 +558,7 @@ pub struct ContributorSpotlightHyData {
 /// * `url` - A `String` that holds the URL of the contributor spotlight page.
 /// * `page_title` - A `String` that holds the title of the contributor spotlight page. Serialized as `pageTitle`.
 /// * `hy_data` - A `ContributorSpotlightHyData` that holds the data related to the contributor. Serialized as `hyData`.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct JsonContributorSpotlightPage {
     pub url: String,
     #[serde(rename = "pageTitle")]
@@ -571,7 +572,7 @@ pub struct JsonContributorSpotlightPage {
 /// The `BuiltPage` enum is used to classify various types of built pages that can be
 /// generated by the system. Each variant corresponds to a specific type of page,
 /// encapsulated in a `Box` to allow for efficient memory management and dynamic dispatch.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, JsonSchema)]
 #[serde(untagged)]
 pub enum BuiltPage {
     /// Represents a standard documentation page, backed by a Markdown source.
@@ -600,7 +601,7 @@ pub enum BuiltPage {
 ///
 /// * `previous` - An `Option<SlugNTitle>` that holds the the slug and title for the previous page, if available.
 /// * `next` - An `Option<SlugNTitle>` that holds the the slug and title for the next page, if available.
-#[derive(Deserialize, Serialize, Clone, Debug, Default)]
+#[derive(Deserialize, Serialize, Clone, Debug, Default, JsonSchema)]
 #[serde(default)]
 pub struct PrevNextBySlug {
     pub previous: Option<SlugNTitle>,
@@ -622,7 +623,7 @@ impl PrevNextBySlug {
 ///
 /// * `title` - A `String` that holds the title of the navigation link.
 /// * `slug` - A `String` that holds the slug of the navigation link.
-#[derive(Deserialize, Serialize, Clone, Debug, Default)]
+#[derive(Deserialize, Serialize, Clone, Debug, Default, JsonSchema)]
 pub struct SlugNTitle {
     pub title: String,
     pub slug: String,
@@ -638,7 +639,7 @@ pub struct SlugNTitle {
 ///
 /// * `previous` - An `Option<UrlNTitle>` that holds the the URL and title for the previous page, if available.
 /// * `next` - An `Option<UrlNTitle>` that holds the the URL and title for the next page, if available.
-#[derive(Deserialize, Serialize, Clone, Debug, Default)]
+#[derive(Deserialize, Serialize, Clone, Debug, Default, JsonSchema)]
 #[serde(default)]
 pub struct PrevNextByUrl {
     pub prev: Option<UrlNTitle>,
@@ -653,7 +654,7 @@ pub struct PrevNextByUrl {
 ///
 /// * `title` - A `String` that holds the title of the navigation link.
 /// * `url` - A `String` that holds the URL of the navigation link.
-#[derive(Deserialize, Serialize, Clone, Debug, Default)]
+#[derive(Deserialize, Serialize, Clone, Debug, Default, JsonSchema)]
 pub struct UrlNTitle {
     pub title: String,
     pub url: String,
@@ -674,7 +675,7 @@ pub struct UrlNTitle {
 /// * `no_indexing` - A `bool` that indicates whether the page should be excluded from indexing by search engines.
 /// * `page_not_found` - A `bool` that indicates whether the page represents a "Page Not Found" (404) error.
 /// * `url` - A `String` that holds the URL of the page.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct JsonSPAPage {
     pub slug: &'static str,
@@ -699,7 +700,7 @@ pub struct JsonSPAPage {
 /// * `title` - A `String` that holds the title of the featured article.
 /// * `tag` - An `Option<Parent>` that holds an optional parent for the featured article, which is
 ///   used for categorization.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct HomePageFeaturedArticle {
     pub mdn_url: String,
@@ -717,7 +718,7 @@ pub struct HomePageFeaturedArticle {
 /// * `contributor_name` - A `String` that holds the name of the featured contributor.
 /// * `url` - A `String` that holds the URL to the contributor's profile or related content.
 /// * `quote` - A `String` that holds a quote from the featured contributor.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct HomePageFeaturedContributor {
     pub contributor_name: String,
@@ -732,7 +733,7 @@ pub struct HomePageFeaturedContributor {
 ///
 /// * `name` - A `String` that holds the name or title of the entity.
 /// * `url` - A `String` that holds the URL associated with the entity.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct NameUrl {
     pub name: String,
     pub url: String,
@@ -751,7 +752,7 @@ pub struct NameUrl {
 /// * `author` - An `Option<String>` that holds the name of the author of the news item, if available.
 /// * `source` - A `NameUrl` that holds the source of the news item, including the name and URL of the source.
 /// * `published_at` - A `NaiveDate` that specifies the publication date of the news item.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct HomePageLatestNewsItem {
     pub url: String,
     pub title: String,
@@ -773,7 +774,7 @@ pub struct HomePageLatestNewsItem {
 /// * `updated_at` - A `DateTime<Utc>` that specifies the time of the contribution.
 /// * `url` - A `String` that holds the URL to the contribution.
 /// * `repo` - A `NameUrl` that holds the repository information, including the name and URL of the repository.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct HomePageRecentContribution {
     pub number: i64,
     pub title: String,
@@ -795,7 +796,7 @@ pub struct HomePageRecentContribution {
 /// # Fields
 ///
 /// * `items` - A `Vec<T>` that holds the collection of items.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct ItemContainer<T>
 where
     T: Clone + Serialize,
@@ -815,7 +816,7 @@ where
 /// * `featured_contributor` - An `Option<HomePageFeaturedContributor>` that holds information about a featured contributor, if available.
 /// * `latest_news` - An `ItemContainer<HomePageLatestNewsItem>` that holds the latest news items to be displayed on the home page.
 /// * `recent_contributions` - An `ItemContainer<HomePageRecentContribution>` that holds the recent contributions to be displayed on the home page.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct JsonHomePageSPAHyData {
     pub page_description: Option<&'static str>,
@@ -837,7 +838,7 @@ pub struct JsonHomePageSPAHyData {
 ///   including featured articles, contributors, latest news, and recent contributions.
 /// * `page_title` - A `&'static str` that holds the title of the home page.
 /// * `url` - A `String` that holds the URL of the page.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct JsonHomePage {
     pub hy_data: JsonHomePageSPAHyData,
@@ -857,7 +858,7 @@ pub struct JsonHomePage {
 /// * `sections` - A `Vec<Section>` that holds the content sections of the generic page.
 /// * `title` - A `String` that holds the title of the generic page.
 /// * `toc` - A `Vec<TocEntry>` that holds the table of contents entries for the generic page.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct JsonGenericHyData {
     pub sections: Vec<Section>,
@@ -879,7 +880,7 @@ pub struct JsonGenericHyData {
 /// * `page_title` - A `String` that holds the title of the generic page.
 /// * `url` - A `String` that holds the URL of the generic page.
 /// * `id` - A `String` that holds the unique identifier for the generic page.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct JsonGenericPage {
     pub hy_data: JsonGenericHyData,

--- a/crates/rari-doc/src/pages/types/blog.rs
+++ b/crates/rari-doc/src/pages/types/blog.rs
@@ -8,6 +8,7 @@ use rari_types::globals::blog_root;
 use rari_types::locale::Locale;
 use rari_types::RariEnv;
 use rari_utils::io::read_to_string;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::cached_readers::{blog_author_by_name, blog_files};
@@ -23,7 +24,7 @@ pub struct Author {
     pub path: PathBuf,
 }
 
-#[derive(Deserialize, Serialize, Clone, Debug, Default)]
+#[derive(Deserialize, Serialize, Clone, Debug, Default, JsonSchema)]
 pub struct AuthorLink {
     pub name: Option<String>,
     pub link: Option<String>,
@@ -45,14 +46,14 @@ impl AuthorLink {
     }
 }
 
-#[derive(Deserialize, Serialize, Clone, Debug, Default)]
+#[derive(Deserialize, Serialize, Clone, Debug, Default, JsonSchema)]
 pub struct AuthorFrontmatter {
     pub name: Option<String>,
     pub link: Option<String>,
     pub avatar: Option<String>,
 }
 
-#[derive(Deserialize, Serialize, Clone, Debug, Default)]
+#[derive(Deserialize, Serialize, Clone, Debug, Default, JsonSchema)]
 #[serde(default)]
 pub struct AuthorMetadata {
     pub name: String,
@@ -60,7 +61,7 @@ pub struct AuthorMetadata {
     pub avatar_url: Option<String>,
 }
 
-#[derive(Deserialize, Serialize, Clone, Debug, Default)]
+#[derive(Deserialize, Serialize, Clone, Debug, Default, JsonSchema)]
 #[serde(default)]
 pub struct BlogImage {
     pub file: String,
@@ -69,7 +70,7 @@ pub struct BlogImage {
     pub creator: Option<AuthorMetadata>,
 }
 
-#[derive(Serialize, Clone, Debug)]
+#[derive(Serialize, Clone, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct BlogMeta {
     pub slug: String,

--- a/crates/rari-doc/src/pages/types/contributors.rs
+++ b/crates/rari-doc/src/pages/types/contributors.rs
@@ -9,13 +9,14 @@ use rari_types::locale::Locale;
 use rari_types::RariEnv;
 use rari_utils::concat_strs;
 use rari_utils::io::read_to_string;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::error::DocError;
 use crate::pages::page::{Page, PageLike, PageReader};
 use crate::utils::split_fm;
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct Usernames {
     pub github: String,

--- a/crates/rari-doc/src/pages/types/curriculum.rs
+++ b/crates/rari-doc/src/pages/types/curriculum.rs
@@ -9,6 +9,7 @@ use rari_types::locale::Locale;
 use rari_types::RariEnv;
 use rari_utils::io::read_to_string;
 use regex::Regex;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::cached_readers::curriculum_files;
@@ -16,7 +17,7 @@ use crate::error::DocError;
 use crate::pages::json::{Parent, PrevNextBySlug, PrevNextByUrl, UrlNTitle};
 use crate::pages::page::{Page, PageCategory, PageLike, PageReader};
 use crate::utils::{as_null, split_fm};
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub enum Template {
     Module,
@@ -28,7 +29,7 @@ pub enum Template {
     Default,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize, Default)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize, Default, JsonSchema)]
 pub enum Topic {
     #[serde(rename = "Web Standards & Semantics")]
     WebStandards,
@@ -42,7 +43,7 @@ pub enum Topic {
     None,
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct CurriculumSidebarEntry {
     pub url: String,
@@ -52,7 +53,7 @@ pub struct CurriculumSidebarEntry {
     pub children: Vec<CurriculumSidebarEntry>,
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct CurriculumIndexEntry {
     pub url: String,

--- a/crates/rari-doc/src/specs.rs
+++ b/crates/rari-doc/src/specs.rs
@@ -8,6 +8,7 @@ use std::sync::LazyLock;
 
 use rari_data::specs::{BCDSpecUrls, WebSpecs};
 use rari_types::globals::{data_dir, json_spec_data_lookup};
+use schemars::JsonSchema;
 use serde::Serialize;
 use tracing::warn;
 
@@ -52,7 +53,7 @@ static SPECS: LazyLock<SpecsData> = LazyLock::new(|| {
 ///
 /// * `bcd_specification_url` - A `String` that holds the URL to the BCD specification.
 /// * `title` - A `&'static str` that holds the title of the specification.
-#[derive(Debug, Clone, Serialize, Default)]
+#[derive(Debug, Clone, Serialize, Default, JsonSchema)]
 pub struct Specification {
     #[serde(rename = "bcdSpecificationURL")]
     pub bcd_specification_url: String,

--- a/crates/rari-types/Cargo.toml
+++ b/crates/rari-types/Cargo.toml
@@ -16,7 +16,7 @@ serde.workspace = true
 serde_json.workspace = true
 indexmap.workspace = true
 chrono.workspace = true
-
+schemars.workspace = true
 
 serde_variant = "0.1"
 normalize-path = "0.2"

--- a/crates/rari-types/src/fm_types.rs
+++ b/crates/rari-types/src/fm_types.rs
@@ -1,3 +1,4 @@
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use strum::EnumString;
 
@@ -10,7 +11,9 @@ pub enum FeatureStatus {
     Deprecated,
 }
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, EnumString)]
+#[derive(
+    Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, EnumString, JsonSchema,
+)]
 #[serde(rename_all = "kebab-case")]
 #[strum(serialize_all = "kebab-case")]
 pub enum PageType {

--- a/crates/rari-types/src/locale.rs
+++ b/crates/rari-types/src/locale.rs
@@ -3,13 +3,16 @@ use std::iter::once;
 use std::str::FromStr;
 use std::sync::LazyLock;
 
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_variant::to_variant_name;
 use thiserror::Error;
 
 use crate::globals::{content_translated_root, settings};
 
-#[derive(PartialEq, Debug, Clone, Copy, Deserialize, Serialize, Default, PartialOrd, Eq, Ord)]
+#[derive(
+    PartialEq, Debug, Clone, Copy, Deserialize, Serialize, Default, PartialOrd, Eq, Ord, JsonSchema,
+)]
 pub enum Native {
     #[default]
     #[serde(rename = "English (US)")]
@@ -62,7 +65,18 @@ pub enum LocaleError {
 }
 
 #[derive(
-    PartialEq, Eq, PartialOrd, Ord, Debug, Clone, Copy, Deserialize, Serialize, Default, Hash,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Debug,
+    Clone,
+    Copy,
+    Deserialize,
+    Serialize,
+    Default,
+    Hash,
+    JsonSchema,
 )]
 pub enum Locale {
     #[default]

--- a/rari-npm/.gitignore
+++ b/rari-npm/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 binary/
+schema.json
+lib/rari-types.d.ts

--- a/rari-npm/lib/generate-types.js
+++ b/rari-npm/lib/generate-types.js
@@ -1,0 +1,12 @@
+import { compile, compileFromFile } from 'json-schema-to-typescript'
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import fs from 'node:fs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const schemaPath = join(__dirname, '..', 'schema.json');
+const typesPath = join(__dirname, 'rari-types.d.ts');
+
+compileFromFile(schemaPath)
+  .then(ts => fs.writeFileSync(typesPath, ts))
+

--- a/rari-npm/lib/index.d.ts
+++ b/rari-npm/lib/index.d.ts
@@ -1,1 +1,2 @@
 export declare const rariBin: string;
+export * from "./rari-types.d";

--- a/rari-npm/package-lock.json
+++ b/rari-npm/package-lock.json
@@ -12,6 +12,7 @@
       "dependencies": {
         "extract-zip": "^2.0.1",
         "https-proxy-agent": "^7.0.2",
+        "json-schema-to-typescript": "^15.0.0",
         "proxy-from-env": "^1.1.0",
         "tar": "^7.4.3"
       },
@@ -20,6 +21,22 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "11.7.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.7.2.tgz",
+      "integrity": "sha512-4gY54eEGEstClvEkGnwVkTkrx0sqwemEFG5OSRRn3tD91XH0+Q8XIkYIfo7IwEWPpJZwILb9GUXeShtplRc/eA==",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.15",
+        "js-yaml": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/philsturgeon"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -51,6 +68,11 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -60,6 +82,16 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.13.tgz",
+      "integrity": "sha512-lfx+dftrEZcdBPczf9d0Qv0x+j/rfNCMuC6OcfXmO8gkfeNAY88PgKUbvG56whcN23gc27yenwF6oJZXGFpYxg=="
     },
     "node_modules/@types/node": {
       "version": "22.7.6",
@@ -116,6 +148,11 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -249,6 +286,19 @@
         "pend": "~1.2.0"
       }
     },
+    "node_modules/fdir": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.2.tgz",
+      "integrity": "sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==",
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
@@ -313,6 +363,14 @@
         "node": ">= 14"
       }
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -320,6 +378,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/isexe": {
@@ -343,6 +412,44 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-schema-to-typescript": {
+      "version": "15.0.3",
+      "resolved": "https://registry.npmjs.org/json-schema-to-typescript/-/json-schema-to-typescript-15.0.3.tgz",
+      "integrity": "sha512-iOKdzTUWEVM4nlxpFudFsWyUiu/Jakkga4OZPEt7CGoSEsAsUgdOZqR6pcgx2STBek9Gm4hcarJpXSzIvZ/hKA==",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^11.5.5",
+        "@types/json-schema": "^7.0.15",
+        "@types/lodash": "^4.17.7",
+        "is-glob": "^4.0.3",
+        "js-yaml": "^4.1.0",
+        "lodash": "^4.17.21",
+        "minimist": "^1.2.8",
+        "prettier": "^3.2.5",
+        "tinyglobby": "^0.2.9"
+      },
+      "bin": {
+        "json2ts": "dist/src/cli.js"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
     "node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
@@ -362,6 +469,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/minipass": {
@@ -452,6 +567,31 @@
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "license": "MIT"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
     },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
@@ -628,6 +768,18 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.10.tgz",
+      "integrity": "sha512-Zc+8eJlFMvgatPZTl6A9L/yht8QqdmUNtURHaKZLmKBE12hNPSrqNkUp2cs3M/UKmNVVAMFQYSjYIVHDjW5zew==",
+      "dependencies": {
+        "fdir": "^6.4.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/undici-types": {

--- a/rari-npm/package.json
+++ b/rari-npm/package.json
@@ -11,7 +11,9 @@
   },
   "homepage": "https://github.com/mdn/rari/tree/main/rari-npm",
   "scripts": {
-    "postinstall": "node ./lib/postinstall.js"
+    "postinstall": "node ./lib/postinstall.js",
+    "export-schema": "node ./lib/cli.js export-schema",
+    "generate-types": "node ./lib/generate-types.js"
   },
   "bin": {
     "rari": "lib/cli.js"
@@ -25,6 +27,7 @@
     "extract-zip": "^2.0.1",
     "https-proxy-agent": "^7.0.2",
     "proxy-from-env": "^1.1.0",
-    "tar": "^7.4.3"
+    "tar": "^7.4.3",
+    "json-schema-to-typescript": "^15.0.0"
   }
 }


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Export a JSON-schema file and a typescript types file on npm publish
(MP-1744)

### Motivation

`schema.json` a good thing to have for any non-js/ts related integration, typescript types file for us in yari (and other contexts)
