### PR TITLE
chore(generic-content): rename generic pages to match repo name

### DIFF
--- a/crates/rari-doc/src/build.rs
+++ b/crates/rari-doc/src/build.rs
@@ -16,7 +16,7 @@ use sha2::{Digest, Sha256};
 use tracing::{span, Level};
 
 use crate::cached_readers::{
-    blog_files, contributor_spotlight_files, curriculum_files, generic_pages_files, wiki_histories,
+    blog_files, contributor_spotlight_files, curriculum_files, generic_content_files, wiki_histories,
 };
 use crate::contributors::contributors_txt;
 use crate::error::DocError;
@@ -202,7 +202,7 @@ pub fn build_blog_pages() -> Result<Vec<Cow<'static, str>>, DocError> {
 /// This function will return an error if:
 /// - An error occurs while building any of the generic pages.
 pub fn build_generic_pages() -> Result<Vec<Cow<'static, str>>, DocError> {
-    generic_pages_files()
+    generic_content_files()
         .values()
         .map(|page| build_single_page(page).map(|_| Cow::Owned(page.url().to_string())))
         .collect()

--- a/crates/rari-doc/src/error.rs
+++ b/crates/rari-doc/src/error.rs
@@ -26,8 +26,8 @@ pub enum DocError {
     NoSuchPrefix(#[from] StripPrefixError),
     #[error("No curricm root set")]
     NoCurriculumRoot,
-    #[error("No generic pages roots set")]
-    NoGenericPagesRoot,
+    #[error("No generic content root set")]
+    NoGenericContentRoot,
     #[error("No H1 found")]
     NoH1,
     #[error(transparent)]

--- a/crates/rari-doc/src/pages/types/generic.rs
+++ b/crates/rari-doc/src/pages/types/generic.rs
@@ -2,14 +2,14 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use rari_types::fm_types::{FeatureStatus, PageType};
-use rari_types::globals::generic_pages_root;
+use rari_types::globals::generic_content_root;
 use rari_types::locale::Locale;
 use rari_types::RariEnv;
 use rari_utils::concat_strs;
 use rari_utils::io::read_to_string;
 use serde::Deserialize;
 
-use crate::cached_readers::generic_pages_files;
+use crate::cached_readers::generic_content_files;
 use crate::error::DocError;
 use crate::pages::page::{Page, PageLike, PageReader};
 use crate::utils::split_fm;
@@ -68,7 +68,7 @@ impl PageReader for GenericPage {
         locale: Option<Locale>,
     ) -> Result<crate::pages::page::Page, DocError> {
         let path = path.into();
-        let root = generic_pages_root().ok_or(DocError::NoGenericPagesRoot)?;
+        let root = generic_content_root().ok_or(DocError::NoGenericContentRoot)?;
         let without_root: &Path = path.strip_prefix(root)?;
         let (slug_prefix, title_suffix, root) = if without_root.starts_with("plus/") {
             (Some("plus/docs"), "MDN Plus", root.join("plus"))
@@ -106,7 +106,7 @@ pub struct GenericPage {
 impl GenericPage {
     pub fn from_slug(slug: &str, locale: Locale) -> Option<Page> {
         let url = concat_strs!("/", locale.as_url_str(), "/", slug).to_ascii_lowercase();
-        generic_pages_files().get(&url).cloned()
+        generic_content_files().get(&url).cloned()
     }
 
     pub fn as_locale(&self, locale: Locale) -> Self {
@@ -126,7 +126,7 @@ impl GenericPage {
 
     pub fn is_generic(slug: &str, locale: Locale) -> bool {
         let url = concat_strs!("/", locale.as_url_str(), "/", slug).to_ascii_lowercase();
-        generic_pages_files().contains_key(&url)
+        generic_content_files().contains_key(&url)
     }
 }
 

--- a/crates/rari-types/src/globals.rs
+++ b/crates/rari-types/src/globals.rs
@@ -21,8 +21,8 @@ pub fn blog_root() -> Option<&'static Path> {
 }
 
 #[inline(always)]
-pub fn generic_pages_root() -> Option<&'static Path> {
-    settings().generic_pages_root.as_deref()
+pub fn generic_content_root() -> Option<&'static Path> {
+    settings().generic_content_root.as_deref()
 }
 #[inline(always)]
 pub fn curriculum_root() -> Option<&'static Path> {

--- a/crates/rari-types/src/settings.rs
+++ b/crates/rari-types/src/settings.rs
@@ -12,7 +12,7 @@ pub struct Settings {
     pub content_translated_root: Option<PathBuf>,
     pub build_out_root: Option<PathBuf>,
     pub blog_root: Option<PathBuf>,
-    pub generic_pages_root: Option<PathBuf>,
+    pub generic_content_root: Option<PathBuf>,
     pub curriculum_root: Option<PathBuf>,
     pub contributor_spotlight_root: Option<PathBuf>,
     pub deny_warnings: bool,


### PR DESCRIPTION
https://github.com/mdn/generic-content is the name of the repo, rather than generic-pages, so updating the environment variable and all relevant types, functions, etc. to "content" too

Will need an update in `rari_beta` branch on `yari` to change the environment variable in the build once this is merged