### PR TITLE
fix(search-index): use en-US popularities for German

### DIFF
--- a/crates/rari-doc/src/search_index.rs
+++ b/crates/rari-doc/src/search_index.rs
@@ -61,7 +61,7 @@ pub fn build_search_index(docs: &[Page]) -> Result<(), DocError> {
             doc,
             popularities
                 .popularities
-                .get(doc.url())
+                .get(&doc.url().replace("/de/docs/", "/en-US/docs/"))
                 .cloned()
                 .unwrap_or_default(),
         ));


### PR DESCRIPTION
### Description

Use the page views from en-US to determine the order of pages in the German search index.

### Motivation

The German quick search does not show results in a very useful order, because it is based on page views in the previous month, and the German locale did not have any page views in the last month (October).

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Port of https://github.com/mdn/yari/pull/12212.
