### PR TITLE
fix: change "Guides" to "Learn" for bread crumb navigation

### DIFF
--- a/crates/rari-doc/src/helpers/title.rs
+++ b/crates/rari-doc/src/helpers/title.rs
@@ -4,7 +4,7 @@ use crate::pages::page::{Page, PageLike};
 pub fn transform_title(title: &str) -> &str {
     match title {
         "Web technology for developers" => "References",
-        "Learn web development" => "Guides",
+        "Learn web development" => "Learn",
         "HTML: HyperText Markup Language" => "HTML",
         "CSS: Cascading Style Sheets" => "CSS",
         "Graphics on the Web" => "Graphics",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

The breadcrumb navigation still had the "Guides" entry indtead ofg the new "Learn"

### Motivation

Complete the content revamp
