### PR TITLE
fix(l10n): correct the repo name to translated content

### DIFF
--- a/crates/rari-doc/src/pages/types/spa_homepage.rs
+++ b/crates/rari-doc/src/pages/types/spa_homepage.rs
@@ -85,7 +85,7 @@ pub fn recent_contributions() -> Result<Vec<HomePageRecentContribution>, DocErro
     if let Some(translated_root) = content_translated_root() {
         content.extend(recent_contributions_from_git(
             translated_root,
-            "mdn/translated_content",
+            "mdn/translated-content",
         )?);
     };
     content.sort_by(|a, b| a.updated_at.cmp(&b.updated_at));


### PR DESCRIPTION
### Description

The repo name of translated content is `mdn/translated-content`, not `mdn/translated_content`.

### Motivation

Check the "Recent contributions" section in the [Home page](https://developer.mozilla.org/). The 
URLs to translated-content's PRs are broken. It's also reported in the MDN official Discord channel.
