### PR TITLE
feat(sidebars/jsref): support temporal

### DIFF
--- a/crates/rari-doc/src/sidebars/jsref.rs
+++ b/crates/rari-doc/src/sidebars/jsref.rs
@@ -338,7 +338,7 @@ fn inheritance_data(obj: &str) -> Option<&str> {
 
 /// Intl and Temporal are big namespaces with many classes underneath it. The classes
 /// are shown as related pages.
-fn namespace_subpages<'a>(namespace: &'a str) -> Vec<String> {
+fn namespace_subpages(namespace: &str) -> Vec<String> {
     once(namespace.to_string())
         .chain(
             get_sub_pages(


### PR DESCRIPTION
As a part of https://github.com/mdn/content/pull/37344/, we need to support displaying `Temporal` in a similar fashion as `Intl`. To do so I made several refactors to avoid repeating myself.

As an aside I'm amused by how much we use `Cow` when most of the strings here are immutable anyway.