### PR TITLE
feat(sidebars): add depth option to listSubPages[Grouped]

### DIFF
--- a/crates/rari-doc/src/helpers/subpages.rs
+++ b/crates/rari-doc/src/helpers/subpages.rs
@@ -189,6 +189,7 @@ pub fn list_sub_pages_grouped_internal(
     out: &mut String,
     url: &str,
     locale: Locale,
+    depth: Option<usize>,
     ListSubPagesContext {
         sorter,
         page_types,
@@ -196,7 +197,7 @@ pub fn list_sub_pages_grouped_internal(
         include_parent,
     }: ListSubPagesContext<'_>,
 ) -> Result<(), DocError> {
-    let sub_pages = get_sub_pages(url, None, sorter.unwrap_or_default())?;
+    let sub_pages = get_sub_pages(url, depth, sorter.unwrap_or_default())?;
 
     let mut grouped = BTreeMap::new();
     for sub_page in sub_pages.iter() {

--- a/crates/rari-doc/src/html/sidebar.rs
+++ b/crates/rari-doc/src/html/sidebar.rs
@@ -297,6 +297,8 @@ pub struct SubPageEntry {
     pub code: bool,
     #[serde(default, skip_serializing_if = "is_default")]
     pub include_parent: bool,
+    #[serde(default, skip_serializing_if = "is_default")]
+    pub recursive: bool,
 }
 
 #[derive(Serialize, Deserialize, Default, Debug, PartialEq, Clone)]
@@ -328,12 +330,14 @@ pub enum MetaChildren {
         tags: Vec<PageType>,
         code: bool,
         include_parent: bool,
+        recursive: bool,
     },
     ListSubPagesGrouped {
         path: String,
         tags: Vec<PageType>,
         code: bool,
         include_parent: bool,
+        recursive: bool,
     },
     WebExtApi,
     #[default]
@@ -440,6 +444,7 @@ impl TryFrom<SidebarEntry> for SidebarMetaEntry {
                 path,
                 code,
                 include_parent,
+                recursive,
             }) => SidebarMetaEntry {
                 section: false,
                 details,
@@ -450,6 +455,7 @@ impl TryFrom<SidebarEntry> for SidebarMetaEntry {
                     tags,
                     code,
                     include_parent,
+                    recursive,
                 },
             },
             SidebarEntry::ListSubPagesGrouped(SubPageEntry {
@@ -461,6 +467,7 @@ impl TryFrom<SidebarEntry> for SidebarMetaEntry {
                 path,
                 code,
                 include_parent,
+                recursive,
             }) => SidebarMetaEntry {
                 section: false,
                 details,
@@ -471,6 +478,7 @@ impl TryFrom<SidebarEntry> for SidebarMetaEntry {
                     tags,
                     code,
                     include_parent,
+                    recursive,
                 },
             },
             SidebarEntry::Default(BasicEntry {
@@ -596,6 +604,7 @@ impl SidebarMetaEntry {
                 tags,
                 code,
                 include_parent,
+                recursive,
             } => {
                 let url = if path.starts_with(concat!("/", default_locale().as_url_str(), "/")) {
                     Cow::Borrowed(path)
@@ -611,7 +620,7 @@ impl SidebarMetaEntry {
                     out,
                     &url,
                     locale,
-                    Some(1),
+                    Some(if *recursive { usize::MAX - 1 } else { 1 }),
                     ListSubPagesContext {
                         sorter: None,
                         page_types: tags,
@@ -625,6 +634,7 @@ impl SidebarMetaEntry {
                 tags,
                 code,
                 include_parent,
+                recursive,
             } => {
                 let url = if path.starts_with(concat!("/", default_locale().as_url_str(), "/")) {
                     Cow::Borrowed(path)
@@ -640,6 +650,7 @@ impl SidebarMetaEntry {
                     out,
                     &url,
                     locale,
+                    Some(if *recursive { usize::MAX - 1 } else { 1 }),
                     ListSubPagesContext {
                         sorter: None,
                         page_types: tags,

--- a/crates/rari-doc/src/html/sidebar.rs
+++ b/crates/rari-doc/src/html/sidebar.rs
@@ -323,7 +323,12 @@ pub enum SidebarEntry {
 #[derive(Debug, Default)]
 pub enum MetaChildren {
     Children(Vec<SidebarMetaEntry>),
-    ListSubPages(String, Vec<PageType>, bool, bool),
+    ListSubPages {
+        path: String,
+        tags: Vec<PageType>,
+        code: bool,
+        include_parent: bool,
+    },
     ListSubPagesGrouped {
         path: String,
         tags: Vec<PageType>,
@@ -440,7 +445,12 @@ impl TryFrom<SidebarEntry> for SidebarMetaEntry {
                 details,
                 code: false,
                 content: SidebarMetaEntryContent::from_link_title_hash(link, title, hash),
-                children: MetaChildren::ListSubPages(path, tags, code, include_parent),
+                children: MetaChildren::ListSubPages {
+                    path,
+                    tags,
+                    code,
+                    include_parent,
+                },
             },
             SidebarEntry::ListSubPagesGrouped(SubPageEntry {
                 details,
@@ -581,15 +591,20 @@ impl SidebarMetaEntry {
                     child.render(out, locale, slug, l10n)?;
                 }
             }
-            MetaChildren::ListSubPages(url, page_types, code, include_parent) => {
-                let url = if url.starts_with(concat!("/", default_locale().as_url_str(), "/")) {
-                    Cow::Borrowed(url)
+            MetaChildren::ListSubPages {
+                path,
+                tags,
+                code,
+                include_parent,
+            } => {
+                let url = if path.starts_with(concat!("/", default_locale().as_url_str(), "/")) {
+                    Cow::Borrowed(path)
                 } else {
                     Cow::Owned(concat_strs!(
                         "/",
                         Locale::default().as_url_str(),
                         "/docs",
-                        url
+                        path
                     ))
                 };
                 list_sub_pages_internal(
@@ -599,7 +614,7 @@ impl SidebarMetaEntry {
                     Some(1),
                     ListSubPagesContext {
                         sorter: None,
-                        page_types,
+                        page_types: tags,
                         code: *code,
                         include_parent: *include_parent,
                     },

--- a/crates/rari-doc/src/html/sidebar.rs
+++ b/crates/rari-doc/src/html/sidebar.rs
@@ -297,8 +297,16 @@ pub struct SubPageEntry {
     pub code: bool,
     #[serde(default, skip_serializing_if = "is_default")]
     pub include_parent: bool,
-    #[serde(default, skip_serializing_if = "is_default")]
-    pub recursive: bool,
+    #[serde(default = "default_depth", skip_serializing_if = "is_default_depth")]
+    pub depth: usize,
+}
+
+fn default_depth() -> usize {
+    1
+}
+
+fn is_default_depth(value: &usize) -> bool {
+    *value == default_depth()
 }
 
 #[derive(Serialize, Deserialize, Default, Debug, PartialEq, Clone)]
@@ -330,14 +338,14 @@ pub enum MetaChildren {
         tags: Vec<PageType>,
         code: bool,
         include_parent: bool,
-        recursive: bool,
+        depth: usize,
     },
     ListSubPagesGrouped {
         path: String,
         tags: Vec<PageType>,
         code: bool,
         include_parent: bool,
-        recursive: bool,
+        depth: usize,
     },
     WebExtApi,
     #[default]
@@ -444,7 +452,7 @@ impl TryFrom<SidebarEntry> for SidebarMetaEntry {
                 path,
                 code,
                 include_parent,
-                recursive,
+                depth,
             }) => SidebarMetaEntry {
                 section: false,
                 details,
@@ -455,7 +463,7 @@ impl TryFrom<SidebarEntry> for SidebarMetaEntry {
                     tags,
                     code,
                     include_parent,
-                    recursive,
+                    depth,
                 },
             },
             SidebarEntry::ListSubPagesGrouped(SubPageEntry {
@@ -467,7 +475,7 @@ impl TryFrom<SidebarEntry> for SidebarMetaEntry {
                 path,
                 code,
                 include_parent,
-                recursive,
+                depth,
             }) => SidebarMetaEntry {
                 section: false,
                 details,
@@ -478,7 +486,7 @@ impl TryFrom<SidebarEntry> for SidebarMetaEntry {
                     tags,
                     code,
                     include_parent,
-                    recursive,
+                    depth,
                 },
             },
             SidebarEntry::Default(BasicEntry {
@@ -604,7 +612,7 @@ impl SidebarMetaEntry {
                 tags,
                 code,
                 include_parent,
-                recursive,
+                depth,
             } => {
                 let url = if path.starts_with(concat!("/", default_locale().as_url_str(), "/")) {
                     Cow::Borrowed(path)
@@ -620,7 +628,7 @@ impl SidebarMetaEntry {
                     out,
                     &url,
                     locale,
-                    Some(if *recursive { usize::MAX - 1 } else { 1 }),
+                    Some(*depth),
                     ListSubPagesContext {
                         sorter: None,
                         page_types: tags,
@@ -634,7 +642,7 @@ impl SidebarMetaEntry {
                 tags,
                 code,
                 include_parent,
-                recursive,
+                depth,
             } => {
                 let url = if path.starts_with(concat!("/", default_locale().as_url_str(), "/")) {
                     Cow::Borrowed(path)
@@ -650,7 +658,7 @@ impl SidebarMetaEntry {
                     out,
                     &url,
                     locale,
-                    Some(if *recursive { usize::MAX - 1 } else { 1 }),
+                    Some(*depth),
                     ListSubPagesContext {
                         sorter: None,
                         page_types: tags,

--- a/crates/rari-tools/src/sidebars.rs
+++ b/crates/rari-tools/src/sidebars.rs
@@ -263,7 +263,7 @@ fn process_entry(entry: SidebarEntry, pairs: Pairs<'_>) -> SidebarEntry {
             path,
             include_parent,
             code,
-            recursive,
+            depth,
         }) => {
             let new_path: Option<String> = replace_pairs(Some(path), pairs);
             if new_path.is_none() {
@@ -278,7 +278,7 @@ fn process_entry(entry: SidebarEntry, pairs: Pairs<'_>) -> SidebarEntry {
                 path: new_path.unwrap(),
                 include_parent,
                 code,
-                recursive,
+                depth,
             })
         }
         SidebarEntry::ListSubPagesGrouped(SubPageEntry {
@@ -290,7 +290,7 @@ fn process_entry(entry: SidebarEntry, pairs: Pairs<'_>) -> SidebarEntry {
             path,
             include_parent,
             code,
-            recursive,
+            depth,
         }) => {
             let new_path: Option<String> = replace_pairs(Some(path), pairs);
             if new_path.is_none() {
@@ -305,7 +305,7 @@ fn process_entry(entry: SidebarEntry, pairs: Pairs<'_>) -> SidebarEntry {
                 path: new_path.unwrap(),
                 include_parent,
                 code,
-                recursive,
+                depth,
             })
         }
         SidebarEntry::Default(BasicEntry {

--- a/crates/rari-tools/src/sidebars.rs
+++ b/crates/rari-tools/src/sidebars.rs
@@ -263,6 +263,7 @@ fn process_entry(entry: SidebarEntry, pairs: Pairs<'_>) -> SidebarEntry {
             path,
             include_parent,
             code,
+            recursive,
         }) => {
             let new_path: Option<String> = replace_pairs(Some(path), pairs);
             if new_path.is_none() {
@@ -277,6 +278,7 @@ fn process_entry(entry: SidebarEntry, pairs: Pairs<'_>) -> SidebarEntry {
                 path: new_path.unwrap(),
                 include_parent,
                 code,
+                recursive,
             })
         }
         SidebarEntry::ListSubPagesGrouped(SubPageEntry {
@@ -288,6 +290,7 @@ fn process_entry(entry: SidebarEntry, pairs: Pairs<'_>) -> SidebarEntry {
             path,
             include_parent,
             code,
+            recursive,
         }) => {
             let new_path: Option<String> = replace_pairs(Some(path), pairs);
             if new_path.is_none() {
@@ -302,6 +305,7 @@ fn process_entry(entry: SidebarEntry, pairs: Pairs<'_>) -> SidebarEntry {
                 path: new_path.unwrap(),
                 include_parent,
                 code,
+                recursive,
             })
         }
         SidebarEntry::Default(BasicEntry {


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Allows to `listSubPages` recursively.

### Motivation

Some CSS functions like [color-mix()](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/color-mix) are nested, so they currently no longer appear in the sidebar, because `depth` defaults to 1.

### Additional details

To test this, apply this change in content:

```diff
diff --git a/files/sidebars/cssref.yaml b/files/sidebars/cssref.yaml
index 3f2b20e1f8..a6b0e741d6 100644
--- a/files/sidebars/cssref.yaml
+++ b/files/sidebars/cssref.yaml
@@ -96,6 +96,7 @@ sidebar:
     path: /Web/CSS
     title: Functions
     tags: css-function
+    depth: 2
     details: closed
   - type: listSubPages
     path: /Web/CSS
```

### Related issues and pull requests

Fixes https://github.com/mdn/rari/issues/73.
