### PR TITLE
fix(l10n): correct the prefix string for notecards in zh-TW locale

### DIFF
--- a/crates/rari-md/src/node_card.rs
+++ b/crates/rari-md/src/node_card.rs
@@ -37,9 +37,9 @@ impl NoteCard {
             (Self::Callout, Locale::ZhCn) => "标注：",
             (Self::Warning, Locale::ZhCn) => "警告：",
             (Self::Note, Locale::ZhCn) => "备注：",
-            (Self::Callout, Locale::ZhTw) => "标注：",
+            (Self::Callout, Locale::ZhTw) => "標註：",
             (Self::Warning, Locale::ZhTw) => "警告：",
-            (Self::Note, Locale::ZhTw) => "备注：",
+            (Self::Note, Locale::ZhTw) => "備註：",
         }
     }
     pub fn new_prefix(&self) -> &str {


### PR DESCRIPTION
### Description

correct the prefix string for notecards in zh-TW locale.

### Motivation

The prefix string for ntoecards in zh-TW locale appears to be identical to the zh-CN locale. Fix them by copying those prefix strings from [yari](https://github.com/mdn/yari/blob/0b5276be8dc2b10992f1fe91ebdc8f7c0285430e/markdown/localizations/zh-TW.json)

### Additional details

A screenshot from https://developer.mozilla.org/zh-TW/docs/Web/CSS/@font-face#%E6%8F%8F%E8%BF%B0:

![image](https://github.com/user-attachments/assets/340feeb8-9f1a-4e56-8eac-150c91b1cac2)

/cc @mdn/yari-content-zh