### PR TITLE
fix(build/parser): parse empty string args for macros as `None`s

### DIFF
--- a/crates/rari-doc/src/templ/parser.rs
+++ b/crates/rari-doc/src/templ/parser.rs
@@ -76,6 +76,7 @@ fn to_arg(pair: Pair<'_, Rule>) -> Option<Arg> {
         Rule::single_quoted_string => pair.into_inner().next().and_then(to_arg),
         Rule::double_quoted_string => pair.into_inner().next().and_then(to_arg),
         Rule::backquoted_quoted_string => pair.into_inner().next().and_then(to_arg),
+        Rule::empty_string => None,
         Rule::sq_string => {
             let s = pair.as_span().as_str();
             Some(Arg::String(
@@ -129,21 +130,7 @@ pub fn parse(input: &str) -> Result<Vec<Token>, DocError> {
         .into_inner()
         .filter_map(|t| match t.as_rule() {
             Rule::text => Some(Token::Text(t.into())),
-            Rule::macro_tag => {
-                let mut macro_roken: MacroToken = t.into();
-                // replace empty string args with None
-                // this is because we will use some judgements like `if let Some(arg) = arg`
-                // to determine whether the arg is empty or not
-                macro_roken.args = macro_roken
-                    .args
-                    .into_iter()
-                    .map(|arg| match arg {
-                        Some(Arg::String(s, _)) if s.is_empty() => None,
-                        _ => arg,
-                    })
-                    .collect();
-                Some(Token::Macro(macro_roken))
-            }
+            Rule::macro_tag => Some(Token::Macro(t.into())),
             _ => None,
         })
         .collect();
@@ -196,8 +183,8 @@ mod test {
     fn with_empty_string_arg() {
         let p = parse(r#"{{foo("")}}"#);
         assert!(matches!(
-            p.unwrap().get(0),
-            Some(Token::Macro(macro_token)) if macro_token.args.get(0) == Some(&None)
+            p.unwrap().first(),
+            Some(Token::Macro(macro_token)) if macro_token.args.first() == Some(&None)
         ));
     }
 }

--- a/crates/rari-doc/src/templ/parser.rs
+++ b/crates/rari-doc/src/templ/parser.rs
@@ -137,14 +137,12 @@ pub fn parse(input: &str) -> Result<Vec<Token>, DocError> {
                 macro_roken.args = macro_roken
                     .args
                     .into_iter()
-                    .map(|arg| {
-                        match arg {
-                            Some(Arg::String(s, _)) if s.is_empty() => None,
-                            _ => arg,
-                        }
+                    .map(|arg| match arg {
+                        Some(Arg::String(s, _)) if s.is_empty() => None,
+                        _ => arg,
                     }).collect();
                 Some(Token::Macro(macro_roken))
-            },
+            }
             _ => None,
         })
         .collect();

--- a/crates/rari-doc/src/templ/parser.rs
+++ b/crates/rari-doc/src/templ/parser.rs
@@ -140,7 +140,8 @@ pub fn parse(input: &str) -> Result<Vec<Token>, DocError> {
                     .map(|arg| match arg {
                         Some(Arg::String(s, _)) if s.is_empty() => None,
                         _ => arg,
-                    }).collect();
+                    })
+                    .collect();
                 Some(Token::Macro(macro_roken))
             }
             _ => None,

--- a/crates/rari-doc/src/templ/rari-templ.pest
+++ b/crates/rari-doc/src/templ/rari-templ.pest
@@ -39,6 +39,7 @@ string = _{
 
 boolean = { "true" | "false" }
 none = { "" }
+empty_string = { "\"\"" | "''" | "``" }
 
 
 all_chars = _{'a'..'z' | 'A'..'Z' | "_" | "-" | '0'..'9'}
@@ -47,7 +48,7 @@ ident = ${
     all_chars*
 }
 
-arg = _{ string | float | int | boolean | none }
+arg = _{ empty_string | string | float | int | boolean | none }
 kwargs  = !{ arg ~ ("," ~ arg )* ~ ","? }
 fn_call = !{ ident ~ "(" ~ kwargs? ~ ")" }
 

--- a/crates/rari-doc/src/templ/templs/embeds/embed_gh_live_sample.rs
+++ b/crates/rari-doc/src/templ/templs/embeds/embed_gh_live_sample.rs
@@ -14,14 +14,10 @@ pub fn embed_gh_live_sample(
     let mut out = String::new();
     out.push_str("<iframe ");
     if let Some(width) = width {
-        if !width.is_empty() {
-            write!(&mut out, r#"width="{}" "#, width)?;
-        }
+        write!(&mut out, r#"width="{}" "#, width)?;
     }
     if let Some(height) = height {
-        if !height.is_empty() {
-            write!(&mut out, r#"height="{}" "#, height)?;
-        }
+        write!(&mut out, r#"height="{}" "#, height)?;
     }
 
     out.extend([

--- a/crates/rari-doc/src/templ/templs/embeds/embed_live_sample.rs
+++ b/crates/rari-doc/src/templ/templs/embeds/embed_live_sample.rs
@@ -29,18 +29,14 @@ pub fn embed_live_sample(
         r#"" "#
     ]);
     if let Some(width) = width {
-        if !width.is_empty() {
-            write!(&mut out, r#"width="{}" "#, width)?;
-        }
+        write!(&mut out, r#"width="{}" "#, width)?;
     }
     if let Some(height) = height {
-        if !height.is_empty() {
-            // TODO: fix this
-            if height.as_int() < 60 {
-                write!(&mut out, r#"height="60" "#)?;
-            } else {
-                write!(&mut out, r#"height="{}" "#, height)?;
-            }
+        // TODO: fix this
+        if height.as_int() < 60 {
+            write!(&mut out, r#"height="60" "#)?;
+        } else {
+            write!(&mut out, r#"height="{}" "#, height)?;
         }
     }
     out.extend([

--- a/crates/rari-doc/src/templ/templs/embeds/jsfiddle_embed.rs
+++ b/crates/rari-doc/src/templ/templs/embeds/jsfiddle_embed.rs
@@ -14,19 +14,17 @@ pub fn embded_jsfiddle(
     let mut out = String::new();
     out.push_str(r#"<p><iframe allowfullscreen="allowfullscreen" width="756" "#);
     if let Some(height) = height {
-        if !height.is_empty() {
-            write!(&mut out, r#"height="{}" "#, height)?;
-        }
+        write!(&mut out, r#"height="{}" "#, height)?;
     }
     out.extend([
         r#"src=""#,
         url.as_str(),
         "embedded/",
         options.as_deref().unwrap_or_default(),
-        if options.as_ref().map(|s| s.is_empty()).unwrap_or_default() {
-            ""
-        } else {
+        if options.as_ref().map(|s| !s.is_empty()).unwrap_or_default() {
             "/"
+        } else {
+            ""
         },
         r#""></iframe></p>"#,
     ]);

--- a/crates/rari-doc/src/templ/templs/links/domxref.rs
+++ b/crates/rari-doc/src/templ/templs/links/domxref.rs
@@ -34,15 +34,13 @@ pub fn domxref(
         &api[first_char_index..],
     );
     if let Some(anchor) = anchor {
-        if !anchor.is_empty() {
-            if !anchor.starts_with('#') {
-                url.push('#');
-                display_with_fallback = Cow::Owned(format!("{}.{}", display_with_fallback, anchor));
-            }
-            url.push_str(&anchor);
-            if let Some(anchor) = anchor.strip_prefix('#') {
-                display_with_fallback = Cow::Owned(format!("{}.{}", display_with_fallback, anchor));
-            }
+        if !anchor.starts_with('#') {
+            url.push('#');
+            display_with_fallback = Cow::Owned(format!("{}.{}", display_with_fallback, anchor));
+        }
+        url.push_str(&anchor);
+        if let Some(anchor) = anchor.strip_prefix('#') {
+            display_with_fallback = Cow::Owned(format!("{}.{}", display_with_fallback, anchor));
         }
     }
 

--- a/crates/rari-doc/src/templ/templs/links/rfc.rs
+++ b/crates/rari-doc/src/templ/templs/links/rfc.rs
@@ -10,9 +10,7 @@ pub fn rfc(
     content: Option<String>,
     anchor: Option<AnyArg>,
 ) -> Result<String, DocError> {
-    let content = content.and_then(|c| if c.is_empty() { None } else { Some(c) });
-    let anchor_str = anchor.and_then(|a| if a.is_empty() { None } else { Some(a) });
-    let (content, anchor): (String, String) = match (content, anchor_str) {
+    let (content, anchor): (String, String) = match (content, anchor) {
         (None, None) => Default::default(),
         (None, Some(anchor)) => (
             format!(

--- a/crates/rari-types/src/lib.rs
+++ b/crates/rari-types/src/lib.rs
@@ -47,13 +47,6 @@ pub struct AnyArg {
 }
 
 impl AnyArg {
-    pub fn is_empty(&self) -> bool {
-        if let Arg::String(s, _) = &self.value {
-            s.is_empty()
-        } else {
-            false
-        }
-    }
     pub fn as_int(&self) -> i64 {
         match &self.value {
             Arg::String(s, _) => s


### PR DESCRIPTION
### Description

replace empty string args for macos with `None`s

### Motivation

In mdn/content, we are used to use empty string to represent the argument is not provided, which should be `None` instead of `Some(EmptyString)`. But we have use some judgement like `if let Some(anchor) = anchor` to check if the string argument is provided. This will evaluate to `true` as the judgement encounters a string.

I found an incorrect case in `/en-US/docs/Mozilla/Add-ons/WebExtensions/API/pageAction/onClicked` page:

![image](https://github.com/user-attachments/assets/376d211e-38bc-4423-9ab7-38d87c64a31b)

There is a hash symbol at the end of the link text.

I think the easiest solution is to replace the empty string args with `None`s. As we use similar logic to the above to determine whether the parameters are provided in many macos. Some cases (Maybe not all of them):

- crates/rari-doc/src/templ/templs/links/domxref.rs (we have checked whether the arg is an empty string)
- crates/rari-doc/src/templ/templs/links/htmlxref.rs
- crates/rari-doc/src/templ/templs/links/http.rs
- crates/rari-doc/src/templ/templs/links/jsxref.rs
- crates/rari-doc/src/templ/templs/links/webextapixref.rs (the one I found the issue)

I haven't fully tested this change, so I'm not sure if it will break any pages. If you have any ideas, please let me know.
