### PR TITLE
fix(html): trim the first empty line in `<pre>` tag

### DIFF
--- a/crates/rari-doc/src/html/rewriter.rs
+++ b/crates/rari-doc/src/html/rewriter.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 use std::collections::HashSet;
 
 use lol_html::html_content::ContentType;
-use lol_html::{element, rewrite_str, HtmlRewriter, RewriteStrSettings, Settings};
+use lol_html::{element, rewrite_str, text, HtmlRewriter, RewriteStrSettings, Settings};
 use rari_md::ext::DELIM_START;
 use rari_md::node_card::NoteCard;
 use rari_types::fm_types::PageType;
@@ -104,6 +104,14 @@ pub fn post_process_html<T: PageLike>(
             let mut class = el.get_attribute("class").unwrap_or_default();
             class.push_str(" notranslate");
             el.set_attribute("class", &class)?;
+            Ok(())
+        }),
+        text!("pre[class*=brush]", |text| {
+            // trim the first _empty_ line,
+            // fixes issue: https://github.com/mdn/yari/issues/12364
+            if let Some('\n') = text.as_str().chars().next() {
+                text.as_mut_str().drain(..1);
+            }
             Ok(())
         }),
         element!("pre[class*=brush]", |el| {

--- a/crates/rari-doc/src/html/rewriter.rs
+++ b/crates/rari-doc/src/html/rewriter.rs
@@ -48,6 +48,7 @@ pub fn post_process_html<T: PageLike>(
     ))?;
     let base_url = options.base_url(Some(&base));
     let data_issues = settings().data_issues;
+    let mut in_pre = false;
 
     let mut element_content_handlers = vec![
         element!("*[id]", |el| {
@@ -109,8 +110,12 @@ pub fn post_process_html<T: PageLike>(
         text!("pre[class*=brush]", |text| {
             // trim the first _empty_ line,
             // fixes issue: https://github.com/mdn/yari/issues/12364
-            if let Some('\n') = text.as_str().chars().next() {
-                text.as_mut_str().drain(..1);
+            if !in_pre && text.as_str().starts_with('\n') {
+                text.as_mut_str().remove(0);
+            }
+            in_pre = true;
+            if text.last_in_text_node() {
+                in_pre = false;
             }
             Ok(())
         }),


### PR DESCRIPTION
### Description

trim the first empty line in `<pre>` tag

### Motivation

The adding of `<code>` tag makes the first empty line would not be ignored by User Agent, see the [spec](https://www.w3.org/MarkUp/1995-archive/Elements/PRE.html). Ref: https://github.com/mdn/yari/issues/12364#issuecomment-2561133409

So trimming the first empty line in `<pre>` tag to simulate the semantics.

### Related issues and pull requests

Fixes: mdn/yari#12364

Test: check the rendered html in `/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_action`:

Before:

![image](https://github.com/user-attachments/assets/89f24eb8-a5d1-4a4b-8b03-15ce1c8b3ce0)

After:

![image](https://github.com/user-attachments/assets/a865a262-3f0e-492f-837b-fb8f5c9c274a)
