### PR TITLE
feat(templ): add csssyntaxraw 

### DIFF
--- a/crates/rari-doc/src/templ/templs/csssyntax.rs
+++ b/crates/rari-doc/src/templ/templs/csssyntax.rs
@@ -1,7 +1,9 @@
 use std::collections::HashMap;
 use std::sync::LazyLock;
 
-use css_syntax::syntax::{write_formal_syntax, CssType, LinkedToken};
+use css_syntax::syntax::{
+    write_formal_syntax, write_formal_syntax_from_syntax, CssType, LinkedToken,
+};
 use rari_templ_func::rari_f;
 use tracing::{error, warn};
 

--- a/crates/rari-doc/src/templ/templs/csssyntax.rs
+++ b/crates/rari-doc/src/templ/templs/csssyntax.rs
@@ -1,12 +1,8 @@
 use std::collections::HashMap;
-use std::str::FromStr;
 use std::sync::LazyLock;
 
-use css_syntax::syntax::{
-    write_formal_syntax, write_formal_syntax_from_syntax, CssType, LinkedToken,
-};
+use css_syntax::syntax::{write_formal_syntax, CssType, LinkedToken};
 use rari_templ_func::rari_f;
-use rari_types::fm_types::PageType;
 use tracing::{error, warn};
 
 use crate::error::DocError;
@@ -25,15 +21,8 @@ static TOOLTIPS: LazyLock<HashMap<LinkedToken, String>> = LazyLock::new(|| {
 });
 
 #[rari_f]
-pub fn csssyntax(name: Option<String>, page_type: Option<String>) -> Result<String, DocError> {
-    let page_type = if let Some(page_type) = page_type {
-        PageType::from_str(&page_type).map_err(|_| {
-            tracing::warn!(source = "invalid_templ_arg");
-            DocError::ArgError(rari_types::ArgError::MustBeX("valid css page type"))
-        })?
-    } else {
-        env.page_type
-    };
+pub fn csssyntax(name: Option<String>) -> Result<String, DocError> {
+    let page_type = env.page_type;
     let mut slug_rev_iter = env.slug.rsplitn(3, '/');
     let slug_name = slug_rev_iter.next().unwrap();
     let name = name.as_deref().unwrap_or(slug_name);

--- a/crates/rari-doc/src/templ/templs/csssyntax.rs
+++ b/crates/rari-doc/src/templ/templs/csssyntax.rs
@@ -1,8 +1,12 @@
 use std::collections::HashMap;
+use std::str::FromStr;
 use std::sync::LazyLock;
 
-use css_syntax::syntax::{write_formal_syntax, CssType, LinkedToken};
+use css_syntax::syntax::{
+    write_formal_syntax, write_formal_syntax_from_syntax, CssType, LinkedToken,
+};
 use rari_templ_func::rari_f;
+use rari_types::fm_types::PageType;
 use tracing::{error, warn};
 
 use crate::error::DocError;
@@ -21,8 +25,15 @@ static TOOLTIPS: LazyLock<HashMap<LinkedToken, String>> = LazyLock::new(|| {
 });
 
 #[rari_f]
-pub fn csssyntax(name: Option<String>) -> Result<String, DocError> {
-    let page_type = env.page_type;
+pub fn csssyntax(name: Option<String>, page_type: Option<String>) -> Result<String, DocError> {
+    let page_type = if let Some(page_type) = page_type {
+        PageType::from_str(&page_type).map_err(|_| {
+            tracing::warn!(source = "invalid_templ_arg");
+            DocError::ArgError(rari_types::ArgError::MustBeX("valid css page type"))
+        })?
+    } else {
+        env.page_type
+    };
     let mut slug_rev_iter = env.slug.rsplitn(3, '/');
     let slug_name = slug_rev_iter.next().unwrap();
     let name = name.as_deref().unwrap_or(slug_name);
@@ -55,6 +66,19 @@ pub fn csssyntax(name: Option<String>) -> Result<String, DocError> {
 
     Ok(write_formal_syntax(
         typ,
+        env.locale.as_url_str(),
+        &format!(
+            "/{}/docs/Web/CSS/Value_definition_syntax",
+            env.locale.as_url_str()
+        ),
+        &TOOLTIPS,
+    )?)
+}
+
+#[rari_f]
+pub fn csssyntaxraw(syntax: String) -> Result<String, DocError> {
+    Ok(write_formal_syntax_from_syntax(
+        syntax,
         env.locale.as_url_str(),
         &format!(
             "/{}/docs/Web/CSS/Value_definition_syntax",

--- a/crates/rari-doc/src/templ/templs/mod.rs
+++ b/crates/rari-doc/src/templ/templs/mod.rs
@@ -69,6 +69,7 @@ pub fn invoke(
         "specifications" => specification::specification_any,
         "glossary" => glossary::glossary_any,
         "csssyntax" => csssyntax::csssyntax_any,
+        "csssyntaxraw" => csssyntax::csssyntaxraw_any,
         "listsubpages" => listsubpages::list_sub_pages_any,
         "cssinfo" => cssinfo::cssinfo_any,
         "inheritancediagram" => inheritance_diagram::inheritance_diagram_any,

--- a/crates/rari-types/src/lib.rs
+++ b/crates/rari-types/src/lib.rs
@@ -24,8 +24,6 @@ pub enum ArgError {
     MustBeBool,
     #[error("must be provided")]
     MustBeProvided,
-    #[error("must be {0}")]
-    MustBeX(&'static str),
 }
 
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]

--- a/crates/rari-types/src/lib.rs
+++ b/crates/rari-types/src/lib.rs
@@ -24,6 +24,8 @@ pub enum ArgError {
     MustBeBool,
     #[error("must be provided")]
     MustBeProvided,
+    #[error("must be {0}")]
+    MustBeX(&'static str),
 }
 
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
### Description

Add `csssyntaxraw` to fix #89 

Examples usage:

```
## Formal syntax

{{CSSSyntaxRaw("<track-repeat> <auto-repeat> <fixed-repeat> <name-repeat>")}}
```

![image](https://github.com/user-attachments/assets/2aaff72d-911b-4aad-b51b-fa2136067328)
