### PR TITLE
chore(ci): set the auth token for the update API when provided through the env variable

### DIFF
--- a/crates/rari-cli/main.rs
+++ b/crates/rari-cli/main.rs
@@ -478,6 +478,10 @@ fn update(version: Option<String>) -> Result<(), Error> {
         .no_confirm(true)
         .show_download_progress(true)
         .current_version(cargo_crate_version!());
+    // Use GITHUB_TOKEN if it's set to avoid rate limiting
+    if let Ok(gh_token) = env::var("GITHUB_TOKEN") {
+        update_builder.auth_token(gh_token.as_str());
+    }
     let target_release = if let Some(version) = version {
         if let Some(release) = releases.iter().find(|release| release.version == version) {
             update_builder.target_version_tag(&release.name);


### PR DESCRIPTION
### Description

Previously, we often encountered installation issues with vscode-ripgrep when installing the Node.js environment in GitHub workflow (caused by the rate limit of anonymous GitHub API calls). So we uses GitHub Token to avoid this problem: https://github.com/mdn/content/blob/452d2ecc73ecde2253bbfdfbb10f45cf6022257d/.github/workflows/pr-test.yml#L60-L62

I think we may also face this problem if we try to [update rari in workflows](https://github.com/mdn/content/blob/452d2ecc73ecde2253bbfdfbb10f45cf6022257d/.github/workflows/pr-test.yml#L104). The best solution is to try to use GitHub Token to call the update API during self-updating in workflows.

I've tested the function with [Fine-grained PAT](https://github.blog/security/application-security/introducing-fine-grained-personal-access-tokens-for-github/) and classic PAT. It should also work with GitHub Token in workflows.
