### PR TITLE
fix(macros/CSSSyntaxRaw): decode entities in parameter

### DIFF
--- a/crates/rari-doc/src/templ/templs/csssyntax.rs
+++ b/crates/rari-doc/src/templ/templs/csssyntax.rs
@@ -68,8 +68,9 @@ pub fn csssyntax(name: Option<String>) -> Result<String, DocError> {
 
 #[rari_f]
 pub fn csssyntaxraw(syntax: String) -> Result<String, DocError> {
+    let decoded_syntax = html_escape::decode_html_entities(&syntax);
     Ok(write_formal_syntax_from_syntax(
-        syntax,
+        decoded_syntax,
         env.locale.as_url_str(),
         &format!(
             "/{}/docs/Web/CSS/Value_definition_syntax",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Decodes entities in the parameter passed to the new `CSSSyntaxRaw` macro.

### Motivation

The markdown inter in content requires `<` and `>` to be converted to HTML entities, so we need to decode these first.

### Additional details

Tested locally:

1. Ran `cargo run serve` on this branch.
2. Ran `yarn start:rari-external` in yari.
3. Checked out https://github.com/mdn/content/pull/37787 in content.
4. Looked at http://localhost:5042/en-US/docs/Web/CSS/repeat#formal_syntax

<img width="1134" alt="image" src="https://github.com/user-attachments/assets/69e57250-0f6c-44e9-9e2e-70ad861b1277" />


### Related issues and pull requests

Relates to https://github.com/mdn/rari/issues/89.
