### PR TITLE
fix(cli): print env_file path to stderr

### DIFF
--- a/crates/rari-cli/main.rs
+++ b/crates/rari-cli/main.rs
@@ -211,7 +211,7 @@ fn main() -> Result<(), Error> {
             .unwrap_or(Cow::Borrowed(".env"))
             .as_ref(),
     ) {
-        println!("Using env_file: {}", env_file.display())
+        eprintln!("Using env_file: {}", env_file.display())
     }
     let cli = Cli::parse();
     if !cli.skip_updates {


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Print the `Using env_file: …` message to stderr, not stdout.

### Motivation

The `tool inventory` command prints JSON, which becomes invalid with this message.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

See also: https://github.com/mdn/content/pull/37841

Fixes https://github.com/mdn/rari/issues/104.