### PR TITLE
fix(tool): make `status` frontmatter serialize like in yari

### DIFF
--- a/crates/rari-doc/src/pages/types/doc.rs
+++ b/crates/rari-doc/src/pages/types/doc.rs
@@ -52,12 +52,7 @@ pub struct FrontMatter {
     pub slug: String,
     #[serde(rename = "page-type", skip_serializing_if = "is_page_type_none")]
     pub page_type: PageType,
-    #[serde(
-        deserialize_with = "t_or_vec",
-        serialize_with = "serialize_t_or_vec",
-        default,
-        skip_serializing_if = "Vec::is_empty"
-    )]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub status: Vec<FeatureStatus>,
     #[serde(
         rename = "browser-compat",

--- a/crates/rari-doc/src/pages/types/doc.rs
+++ b/crates/rari-doc/src/pages/types/doc.rs
@@ -404,7 +404,8 @@ mod tests {
         assert_eq!(meta.status.len(), 2);
 
         let fm = r#"
-        status: experimental
+        status:
+          - experimental
       "#;
         let meta = serde_yaml_ng::from_str::<FrontMatter>(fm).unwrap();
         assert_eq!(meta.status.len(), 1);


### PR DESCRIPTION
### Description

Frontmatter `status` key is now behaving like in yari, i.e. value are always wriiten as an array and not as a simple string if it is a single value.

### Motivation

yar/rari compatibility

