### PR TITLE
fix(interactive-example): missing quote at start of height attribute

### DIFF
--- a/crates/rari-doc/src/templ/templs/embeds/interactive_example.rs
+++ b/crates/rari-doc/src/templ/templs/embeds/interactive_example.rs
@@ -21,7 +21,7 @@ pub fn interactive_example(name: String, height: Option<String>) -> Result<Strin
     let height = height
         .map(|height| {
             concat_strs!(
-                r#" height="#,
+                r#" height=""#,
                 &encode_double_quoted_attribute(&height).as_ref(),
                 r#"""#
             )


### PR DESCRIPTION
Small fix to https://github.com/mdn/rari/pull/84

Was rendering as `height=taller"`