### PR TITLE
ci(workflows): pin 3rd party actions

### DIFF
--- a/.github/workflows/build-and-upload-binaries.yml
+++ b/.github/workflows/build-and-upload-binaries.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: taiki-e/upload-rust-binary-action@v1
+      - uses: taiki-e/upload-rust-binary-action@e7953b6078194a4ae5f5619632e3715db6275561 # v1.24.0
         with:
           bin: rari
           target: ${{ matrix.target }}

--- a/.github/workflows/lint-test-clippy.yaml
+++ b/.github/workflows/lint-test-clippy.yaml
@@ -18,9 +18,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@38b70195107dddab2c7bbd522bcf763bac00963b # stable
       - name: sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.6
+        uses: mozilla-actions/sccache-action@9e326ebed976843c9932b3aa0e021c6f50310eb4 # v0.0.6
 
       - name: Run fmt
         run: cargo fmt -- --check

--- a/.github/workflows/release-please-pr.yml
+++ b/.github/workflows/release-please-pr.yml
@@ -13,7 +13,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@7987652d64b4581673a76e33ad5e98e3dd56832f # v4.1.3
         with:
           skip-github-release: true
           repo-url: mdn/rari

--- a/.github/workflows/release-please-release.yml
+++ b/.github/workflows/release-please-release.yml
@@ -13,7 +13,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@7987652d64b4581673a76e33ad5e98e3dd56832f # v4.1.3
         with:
           skip-github-pull-request: true
           repo-url: mdn/rari


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Pin 3rd party actions to a commit hash to mitigate the risk of a supply chain attack.

### Motivation

Resolves [5 CodeQL code scanning alerts](https://github.com/mdn/rari/security/code-scanning?query=is%3Aopen+branch%3Amain+rule%3Aactions%2Funpinned-tag).

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Related:

- https://github.com/mdn/browser-compat-data/pull/25793
- https://github.com/mdn/content/pull/38016
- https://github.com/mdn/rumba/pull/602
- https://github.com/mdn/translated-content/pull/25752
- https://github.com/mdn/translated-content-de/pull/53
- https://github.com/mdn/workflows/pull/155