### PR TITLE
fix(npm): use `import` to dynamically load esm modules

### DIFF
--- a/rari-npm/lib/download.js
+++ b/rari-npm/lib/download.js
@@ -116,12 +116,12 @@ export async function do_download(url, dest, opts) {
  * @param {string} _url
  * @param {any} opts
  */
-function get(_url, opts) {
+async function get(_url, opts) {
   console.log(`GET ${_url}`);
 
   const proxy = getProxyForUrl(URLparse(_url));
   if (proxy !== "") {
-    var HttpsProxyAgent = require("https-proxy-agent");
+    const HttpsProxyAgent = await import("https-proxy-agent");
     opts = {
       ...opts,
       agent: new HttpsProxyAgent.HttpsProxyAgent(proxy),


### PR DESCRIPTION
### Description

`@mdn/rari` cannot be installed with Node.js v22.12+, as it using `require()` in .js files with `"type": "module"` in `package.json`, which is currently incompatible with Node.js v22.12.0 due to stricter module handling. See: nodejs/node#56155.

Use `import` to dynamically load esm modules, as we have already use this in the current file: https://github.com/mdn/rari/blob/03270403a060318163d8afff35c8a1275b2e6e56/rari-npm/lib/download.js#L68

### Motivation

I cannot successfully run `yarn install` in `mdn/content` with Node.js v22.13 installed.

### Additional details

I've run `npm install && npm run export-schema && npm run generate-types && npm pack` in `rari-npm`.
And replace the `@mdn/rari` package in mdn/content locally, which makes the installation with Node.js v22.13 successful.
