### PR TITLE
fix(issue-template): make `CONTRIBUTING.md` link absolute

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -9,7 +9,7 @@ body:
 
         **Want to fix the problem yourself?** This project is open source and we welcome fixes and improvements from the community!
 
-        ↩ Check the project [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) guide to see how to get started.
+        ↩ Check the project [CONTRIBUTING.md](./blob/main/CONTRIBUTING.md) guide to see how to get started.
 
         ---
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -9,7 +9,7 @@ body:
 
         **Want to fix the problem yourself?** This project is open source and we welcome fixes and improvements from the community!
 
-        ↩ Check the project [CONTRIBUTING.md](./blob/main/CONTRIBUTING.md) guide to see how to get started.
+        ↩ Check the project [CONTRIBUTING.md](https://github.com/mdn/rari/blob/main/CONTRIBUTING.md) guide to see how to get started.
 
         ---
   - type: textarea


### PR DESCRIPTION
### Description

The link to `CONTRIBUTING.md` is broken, GitHub may use the `path/to/repo` as the base URL for the issue template. This PR corrected the relative path.

I've tested in my repo (switching the default branch to this one `broken-contributing-link`):

![image](https://github.com/user-attachments/assets/c8a7543a-fe55-4397-8700-05aa7248df27)

### Related issues and pull requests

The issue which has mentioned the problem: #140
