### PR TITLE
fix: html in featured articles

### DIFF
--- a/crates/rari-doc/src/pages/build.rs
+++ b/crates/rari-doc/src/pages/build.rs
@@ -133,7 +133,7 @@ impl BuildSection<'_> {
 pub struct PageContent {
     body: Vec<Section>,
     toc: Vec<TocEntry>,
-    summary: Option<String>,
+    pub summary: Option<String>,
     sidebar: Option<String>,
 }
 
@@ -144,7 +144,7 @@ pub fn make_toc(sections: &[BuildSection], with_h3: bool) -> Vec<TocEntry> {
         .collect()
 }
 
-fn build_content<T: PageLike>(page: &T) -> Result<PageContent, DocError> {
+pub fn build_content<T: PageLike>(page: &T) -> Result<PageContent, DocError> {
     let (ks_rendered_doc, templs, sidebars) = if let Some(rari_env) = &page.rari_env() {
         let Rendered {
             content,

--- a/crates/rari-doc/src/pages/types/spa_homepage.rs
+++ b/crates/rari-doc/src/pages/types/spa_homepage.rs
@@ -11,7 +11,7 @@ use regex::Regex;
 use crate::cached_readers::contributor_spotlight_files;
 use crate::error::DocError;
 use crate::helpers::parents::parents;
-use crate::helpers::summary_hack::get_hacky_summary_md;
+use crate::pages::build::build_content;
 use crate::pages::json::{
     HomePageFeaturedArticle, HomePageFeaturedContributor, HomePageLatestNewsItem,
     HomePageRecentContribution, NameUrl, Parent,
@@ -62,7 +62,10 @@ pub fn featured_articles(
                 })),
                 Ok(ref page @ Page::Doc(ref doc)) => Some(Ok(HomePageFeaturedArticle {
                     mdn_url: doc.url().to_string(),
-                    summary: get_hacky_summary_md(page).unwrap_or_default(),
+                    summary: build_content(doc)
+                        .ok()
+                        .and_then(|x| x.summary)
+                        .unwrap_or_default(),
                     title: doc.title().to_string(),
                     tag: parents(page).get(1).cloned(),
                 })),


### PR DESCRIPTION
This feels a bit hacky, as I had to make a couple of private things public: yet it replaces a function which literally has "hacky" in the name, so I'm not sure :)

Tested locally to ensure no html tags make it into the `index.json`