### PR TITLE
fix(sidebars): strip "_static" suffix

### DIFF
--- a/crates/rari-doc/src/sidebars/apiref.rs
+++ b/crates/rari-doc/src/sidebars/apiref.rs
@@ -130,7 +130,7 @@ fn build_sublist(entries: &mut Vec<SidebarMetaEntry>, sub_pages: &[Page], label:
             details: Details::Open,
             content: SidebarMetaEntryContent::Link {
                 link: None,
-                title: Some(label.to_string()),
+                title: Some(label.replace("_static", "").to_string()),
             },
             children: MetaChildren::Children(
                 sub_pages
@@ -168,7 +168,7 @@ fn build_interface_list(entries: &mut Vec<SidebarMetaEntry>, interfaces: &[&str]
                     .map(|interface| SidebarMetaEntry {
                         code: true,
                         content: SidebarMetaEntryContent::Link {
-                            title: Some(interface.to_string()),
+                            title: Some(interface.replace("_static", "").to_string()),
                             link: Some(format!(
                                 "/Web/API/{}",
                                 interface.replace("()", "").replace('.', "/")

--- a/crates/rari-doc/src/sidebars/default_api_sidebar.rs
+++ b/crates/rari-doc/src/sidebars/default_api_sidebar.rs
@@ -53,7 +53,7 @@ pub fn sidebar(group: &str, locale: Locale) -> Result<MetaSidebar, DocError> {
         &mut entries,
         &web_api_groups.methods,
         methods_label,
-        APILink::from,
+        APILink::from_method,
     );
     build_interface_list(
         &mut entries,
@@ -85,6 +85,13 @@ impl APILink {
         ev.split_once(": ").map(|(interface, event)| Self {
             link: format!("/Web/API/{interface}/{event}_event"),
             title: Some(ev.to_string()),
+        })
+    }
+
+    pub fn from_method(s: &str) -> Option<Self> {
+        Some(Self {
+            title: Some(s.replace("_static", "").to_string()),
+            link: format!("/Web/API/{}", s.replace("()", "").replace('.', "/")),
         })
     }
 }


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Strips the `_static` suffix from page titles displayed in the `APIRef` and `DefaultAPISidebar` sidebars.

### Motivation

The suffixes are confusing, as they aren't part of the API name.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Fixes https://github.com/mdn/rari/issues/140.
