### PR TITLE
fix(homepage): use text content for summary on homepage

### DIFF
--- a/crates/rari-doc/src/helpers/summary_hack.rs
+++ b/crates/rari-doc/src/helpers/summary_hack.rs
@@ -1,5 +1,6 @@
 use itertools::Itertools;
 use rari_md::{m2h_internal, M2HOptions};
+use scraper::Html;
 
 use crate::error::DocError;
 use crate::pages::page::{Page, PageLike};
@@ -45,4 +46,9 @@ pub fn strip_paragraph_unchecked(input: &str) -> &str {
     let out = out.trim().strip_suffix("</p>").unwrap_or(out);
 
     out
+}
+
+pub fn text_content(html_str: &str) -> String {
+    let fragment = Html::parse_fragment(html_str);
+    fragment.root_element().text().collect()
 }

--- a/crates/rari-doc/src/pages/types/spa_homepage.rs
+++ b/crates/rari-doc/src/pages/types/spa_homepage.rs
@@ -11,7 +11,7 @@ use regex::Regex;
 use crate::cached_readers::contributor_spotlight_files;
 use crate::error::DocError;
 use crate::helpers::parents::parents;
-use crate::helpers::summary_hack::get_hacky_summary_md;
+use crate::helpers::summary_hack::{get_hacky_summary_md, text_content};
 use crate::pages::json::{
     HomePageFeaturedArticle, HomePageFeaturedContributor, HomePageLatestNewsItem,
     HomePageRecentContribution, NameUrl, Parent,
@@ -62,7 +62,9 @@ pub fn featured_articles(
                 })),
                 Ok(ref page @ Page::Doc(ref doc)) => Some(Ok(HomePageFeaturedArticle {
                     mdn_url: doc.url().to_string(),
-                    summary: get_hacky_summary_md(page).unwrap_or_default(),
+                    summary: get_hacky_summary_md(page)
+                        .map(|summary| text_content(&summary))
+                        .unwrap_or_default(),
                     title: doc.title().to_string(),
                     tag: parents(page).get(1).cloned(),
                 })),


### PR DESCRIPTION
### Description

The summary for the homepage should be text rather than html.