### PR TITLE
fix(npm): rename types to remove `Json` prefix

### DIFF
--- a/crates/rari-doc/src/pages/json.rs
+++ b/crates/rari-doc/src/pages/json.rs
@@ -231,6 +231,7 @@ pub enum Section {
 /// * `page_type` - A `PageType` that specifies the type of the page, for example `LandingPage`, `LearnModule`, `CssAtRule` or
 ///    `HtmlAttribute`. Serialized as `pageType`.
 #[derive(Debug, Clone, Serialize, Default, JsonSchema)]
+#[schemars(rename = "Doc")]
 pub struct JsonDoc {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub body: Vec<Section>,
@@ -367,6 +368,7 @@ pub struct JsonDocMetadata {
 /// * `doc` - A `JsonDoc` that holds the main content and metadata of the documentation page.
 /// * `url` - A `String` that holds the URL of the documentation page.
 #[derive(Debug, Clone, Serialize, Default, JsonSchema)]
+#[schemars(rename = "DocPage")]
 pub struct JsonDocPage {
     pub doc: JsonDoc,
     pub url: String,
@@ -412,6 +414,7 @@ pub struct BlogIndex {
 ///    serialization if it is `None`.
 /// * `template` - A `Template` that specifies the template used for rendering the document.
 #[derive(Debug, Clone, Serialize, Default, JsonSchema)]
+#[schemars(rename = "CurriculumDoc")]
 pub struct JsonCurriculumDoc {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub body: Vec<Section>,
@@ -453,6 +456,7 @@ pub struct JsonCurriculumDoc {
 /// * `page_title` - A `String` that holds the title of the curriculum page. Serialized as `pageTitle`.
 /// * `locale` - A `Locale` that specifies the locale of the curriculum page.
 #[derive(Debug, Clone, Serialize, Default, JsonSchema)]
+#[schemars(rename = "CurriculumPage")]
 pub struct JsonCurriculumPage {
     pub doc: JsonCurriculumDoc,
     pub url: String,
@@ -485,6 +489,7 @@ pub struct JsonCurriculumPage {
 /// * `toc` - A `Vec<TocEntry>` that holds the table of contents entries for the blog post. This field is
 ///   skipped during serialization if it is empty.
 #[derive(Debug, Clone, Serialize, Default, JsonSchema)]
+#[schemars(rename = "BlogPostDoc")]
 pub struct JsonBlogPostDoc {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub body: Vec<Section>,
@@ -523,6 +528,7 @@ pub struct JsonBlogPostDoc {
 /// * `hy_data` - An `Option<BlogIndex>` that holds data related to the blog index, if available.
 ///   Serialized as `hyData` and skipped during serialization if it is `None`.
 #[derive(Debug, Clone, Serialize, Default, JsonSchema)]
+#[schemars(rename = "BlogPostPage")]
 pub struct JsonBlogPostPage {
     pub doc: JsonBlogPostDoc,
     pub locale: Locale,
@@ -581,6 +587,7 @@ pub struct ContributorSpotlightHyData {
 /// * `page_title` - A `String` that holds the title of the contributor spotlight page. Serialized as `pageTitle`.
 /// * `hy_data` - A `ContributorSpotlightHyData` that holds the data related to the contributor. Serialized as `hyData`.
 #[derive(Debug, Clone, Serialize, JsonSchema)]
+#[schemars(rename = "ContributorSpotlightPage")]
 pub struct JsonContributorSpotlightPage {
     pub url: String,
     #[serde(rename = "pageTitle")]
@@ -699,6 +706,7 @@ pub struct UrlNTitle {
 /// * `url` - A `String` that holds the URL of the page.
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
+#[schemars(rename = "SPAPage")]
 pub struct JsonSPAPage {
     pub slug: &'static str,
     pub page_title: &'static str,
@@ -839,6 +847,7 @@ where
 /// * `recent_contributions` - An `ItemContainer<HomePageRecentContribution>` that holds the recent contributions to be displayed on the home page.
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
+#[schemars(rename = "HomePageSPAHyData")]
 pub struct JsonHomePageSPAHyData {
     pub page_description: Option<&'static str>,
     pub featured_articles: Vec<HomePageFeaturedArticle>,
@@ -861,6 +870,7 @@ pub struct JsonHomePageSPAHyData {
 /// * `url` - A `String` that holds the URL of the page.
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
+#[schemars(rename = "HomePage")]
 pub struct JsonHomePage {
     pub hy_data: JsonHomePageSPAHyData,
     pub page_title: &'static str,
@@ -881,6 +891,7 @@ pub struct JsonHomePage {
 /// * `toc` - A `Vec<TocEntry>` that holds the table of contents entries for the generic page.
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
+#[schemars(rename = "GenericHyData")]
 pub struct JsonGenericHyData {
     pub sections: Vec<Section>,
     pub title: String,
@@ -903,6 +914,7 @@ pub struct JsonGenericHyData {
 /// * `id` - A `String` that holds the unique identifier for the generic page.
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
+#[schemars(rename = "GenericPage")]
 pub struct JsonGenericPage {
     pub hy_data: JsonGenericHyData,
     pub page_title: String,

--- a/rari-npm/lib/generate-types.js
+++ b/rari-npm/lib/generate-types.js
@@ -1,4 +1,4 @@
-import { compile, compileFromFile } from 'json-schema-to-typescript'
+import { compileFromFile } from 'json-schema-to-typescript'
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import fs from 'node:fs';
@@ -7,6 +7,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const schemaPath = join(__dirname, '..', 'schema.json');
 const typesPath = join(__dirname, 'rari-types.d.ts');
 
-compileFromFile(schemaPath)
-  .then(ts => fs.writeFileSync(typesPath, ts))
+compileFromFile(schemaPath, {
+  additionalProperties: false,
+}).then(ts => fs.writeFileSync(typesPath, ts))
 


### PR DESCRIPTION
also remove `unknown` additionalProperties which breaks type narrowing

diff of exported typescript types:

```diff
diff --git a/../../fer/node_modules/@mdn/rari/lib/rari-types.d.ts b/lib/rari-types.d.ts
index d222fdc..5e07440 100644
--- a/../../fer/node_modules/@mdn/rari/lib/rari-types.d.ts
+++ b/lib/rari-types.d.ts
@@ -11,13 +11,13 @@
  * The `BuiltPage` enum is used to classify various types of built pages that can be generated by the system. Each variant corresponds to a specific type of page, encapsulated in a `Box` to allow for efficient memory management and dynamic dispatch.
  */
 export type BuiltPage =
-  | JsonDocPage
-  | JsonCurriculumPage
-  | JsonBlogPostPage
-  | JsonContributorSpotlightPage
-  | JsonGenericPage
-  | JsonSPAPage
-  | JsonHomePage;
+  | DocPage
+  | CurriculumPage
+  | BlogPostPage
+  | ContributorSpotlightPage
+  | GenericPage
+  | SPAPage
+  | HomePage;
 export type BaselineHighLow =
   | ("high" | "low")
   | {
@@ -40,17 +40,14 @@ export type Section =
   | {
       type: "prose";
       value: Prose;
-      [k: string]: unknown;
     }
   | {
       type: "browser_compatibility";
       value: Compat;
-      [k: string]: unknown;
     }
   | {
       type: "specifications";
       value: SpecificationSection;
-      [k: string]: unknown;
     };
 export type DIssue =
   | {
@@ -66,7 +63,6 @@ export type DIssue =
       sourceContext?: string | null;
       suggestion?: string | null;
       type: "brokenLink";
-      [k: string]: unknown;
     }
   | {
       column?: number | null;
@@ -82,7 +78,6 @@ export type DIssue =
       sourceContext?: string | null;
       suggestion?: string | null;
       type: "macros";
-      [k: string]: unknown;
     }
   | {
       column?: number | null;
@@ -96,7 +91,6 @@ export type DIssue =
       sourceContext?: string | null;
       suggestion?: string | null;
       type: "unknown";
-      [k: string]: unknown;
     };
 export type IssueType =
   | "TemplRedirectedLink"
@@ -227,10 +221,9 @@ export type Template = "module" | "overview" | "landing" | "about" | "default";
  *
  * * `doc` - A `JsonDoc` that holds the main content and metadata of the documentation page. * `url` - A `String` that holds the URL of the documentation page.
  */
-export interface JsonDocPage {
-  doc: JsonDoc;
+export interface DocPage {
+  doc: Doc;
   url: string;
-  [k: string]: unknown;
 }
 /**
  * Represents a documentation page in the system, holding the majority of content in MDN.
@@ -241,7 +234,7 @@ export interface JsonDocPage {
  *
  * * `body` - A `Vec<Section>` that holds the content sections of the document. This field is skipped during serialization if it is empty. This is the main content of the page, containing a list of prose, compatibility, and specification sections. * `is_active` - A `bool` that indicates whether the document is active. Serialized as `isActive`. * `is_markdown` - A `bool` that indicates whether the document is in Markdown format. Serialized as `isMarkdown`. * `is_translated` - A `bool` that indicates whether the document has been translated. Serialized as `isTranslated`. * `locale` - A `Locale` that specifies the locale of the document. * `mdn_url` - A `String` that holds the MDN URL of the document. * `modified` - A `NaiveDateTime` that specifies the last modified date and time of the document. Serialized using the `modified_dt` function. * `native` - A `Native` that holds the native representation of the locale, i.e. "Deutsch", "Español" etc. * `no_indexing` - A `bool` that indicates whether the document should be excluded from indexing. Serialized as `noIndexing`. * `other_translations` - A `Vec<Translation>` that holds translations of the document. * `page_title` - A `String` that holds the title of the page. Serialized as `pageTitle`. * `parents` - A `Vec<Parent>` that holds the parent entities of the document. This field is skipped during serialization if it is empty. * `popularity` - An `Option<f64>` that holds the popularity score of the document. * `short_title` - A `String` that holds the short title of the document. * `sidebar_html` - An `Option<String>` that holds the HTML content for the sidebar. Serialized as `sidebarHTML` and skipped during serialization if it is `None`. * `sidebar_macro` - An `Option<String>` that holds the macro content for the sidebar. Serialized as `sidebarMacro` and skipped during serialization if it is `None`. * `source` - A `Source` that holds the git source control information of the document. * `summary` - An `Option<String>` that holds the summary of the document. This field is skipped during serialization if it is `None`. * `title` - A `String` that holds the title of the document. * `toc` - A `Vec<TocEntry>` that holds the table of contents entries for the document. * `baseline` - An `Option<&'static SupportStatusWithByKey>` that holds the baseline support status. This field is skipped during serialization if it is `None`. * `browser_compat` - A `Vec<String>` that holds the browser compatibility information. Serialized as `browserCompat` and skipped during serialization if it is empty. * `page_type` - A `PageType` that specifies the type of the page, for example `LandingPage`, `LearnModule`, `CssAtRule` or `HtmlAttribute`. Serialized as `pageType`.
  */
-export interface JsonDoc {
+export interface Doc {
   baseline?: Baseline | null;
   body: Section[];
   browserCompat: string[];
@@ -268,7 +261,6 @@ export interface JsonDoc {
   summary?: string | null;
   title: string;
   toc: TocEntry[];
-  [k: string]: unknown;
 }
 export interface Baseline {
   asterisk: boolean;
@@ -291,7 +283,6 @@ export interface Baseline {
    * Browser versions that most-recently introduced the feature
    */
   support: Support;
-  [k: string]: unknown;
 }
 export interface SupportStatus {
   /**
@@ -310,7 +301,6 @@ export interface SupportStatus {
    * Browser versions that most-recently introduced the feature
    */
   support: Support;
-  [k: string]: unknown;
 }
 export interface Support {
   chrome?: string | null;
@@ -320,7 +310,6 @@ export interface Support {
   firefox_android?: string | null;
   safari?: string | null;
   safari_ios?: string | null;
-  [k: string]: unknown;
 }
 /**
  * Represents a prose section on a page, one of the possible `Section` items in the list of body sections.
@@ -336,7 +325,6 @@ export interface Prose {
   id?: string | null;
   isH3: boolean;
   title?: string | null;
-  [k: string]: unknown;
 }
 /**
  * Represents a browser compatibility (BCD) section on a page, one of the possible `Section` items in the list of body sections.
@@ -353,7 +341,6 @@ export interface Compat {
   isH3: boolean;
   query: string;
   title?: string | null;
-  [k: string]: unknown;
 }
 /**
  * Represents a specifications section on a page, one of the possible `Section` items in the list of body sections.
@@ -371,7 +358,6 @@ export interface SpecificationSection {
   query: string;
   specifications: Specification[];
   title?: string | null;
-  [k: string]: unknown;
 }
 /**
  * Represents a web technology specification.
@@ -385,7 +371,6 @@ export interface SpecificationSection {
 export interface Specification {
   bcdSpecificationURL: string;
   title: string;
-  [k: string]: unknown;
 }
 /**
  * Represents a translation entry in the list of other available translations for a page.
@@ -400,7 +385,6 @@ export interface Translation {
   locale: Locale;
   native: Native;
   title: string;
-  [k: string]: unknown;
 }
 /**
  * Represents a parent entity in a page structure.
@@ -414,7 +398,6 @@ export interface Translation {
 export interface Parent {
   title: string;
   uri: string;
-  [k: string]: unknown;
 }
 /**
  * Represents the git source control information for a documentation page.
@@ -430,7 +413,6 @@ export interface Source {
   folder: string;
   github_url: string;
   last_commit_url: string;
-  [k: string]: unknown;
 }
 /**
  * Represents an entry in a Table of Contents (ToC), used to navigate a single page. This is used on the right side of a typical page and allows users to quickly jump to a specific heading in the page.
@@ -444,7 +426,6 @@ export interface Source {
 export interface TocEntry {
   id: string;
   text: string;
-  [k: string]: unknown;
 }
 /**
  * Represents the outermost structure of the serialized JSON for a curriculum page. This struct is written to the `index.json` file during a build.
@@ -455,12 +436,11 @@ export interface TocEntry {
  *
  * * `doc` - A `JsonCurriculumDoc` that holds the main content and metadata of the curriculum page. * `url` - A `String` that holds the URL of the curriculum page. * `page_title` - A `String` that holds the title of the curriculum page. Serialized as `pageTitle`. * `locale` - A `Locale` that specifies the locale of the curriculum page.
  */
-export interface JsonCurriculumPage {
-  doc: JsonCurriculumDoc;
+export interface CurriculumPage {
+  doc: CurriculumDoc;
   locale: Locale;
   pageTitle: string;
   url: string;
-  [k: string]: unknown;
 }
 /**
  * Represents a curriculum document in the system.
@@ -471,7 +451,7 @@ export interface JsonCurriculumPage {
  *
  * * `body` - A `Vec<Section>` that holds the list of content sections of the document. This field is skipped during serialization if it is empty. * `locale` - A `Locale` that specifies the locale of the document. * `mdn_url` - A `String` that holds the MDN URL of the document. * `native` - A `Native` that holds the native representation of the locale. * `no_indexing` - A `bool` that indicates whether the document should be excluded from indexing by search engines. Serialized as `noIndexing`. * `page_title` - A `String` that holds the title of the page. Serialized as `pageTitle`. * `parents` - A `Vec<Parent>` that holds the parent entities of the document. This field is skipped during serialization if it is empty. * `title` - A `String` that holds the title of the document. * `summary` - An `Option<String>` that holds the summary of the document. This field is skipped during serialization if it is `None`. * `toc` - A `Vec<TocEntry>` that holds the table of contents entries for the document. * `sidebar` - An `Option<Vec<CurriculumSidebarEntry>>` that holds the sidebar entries for the curriculum. This field is skipped during serialization if it is `None`. * `topic` - An `Option<Topic>` that holds the topic of the curriculum. This field is skipped during serialization if it is `None`. * `group` - An `Option<String>` that holds the group of the curriculum. This field is skipped during serialization if it is `None`. * `modules` - A `Vec<CurriculumIndexEntry>` that holds the modules of the curriculum. This field is skipped during serialization if it is empty. * `prev_next` - An `Option<PrevNextByUrl>` that holds the previous and next URLs for navigation. Serialized as `prevNext` and skipped during serialization if it is `None`. * `template` - A `Template` that specifies the template used for rendering the document.
  */
-export interface JsonCurriculumDoc {
+export interface CurriculumDoc {
   body: Section[];
   group?: string | null;
   locale: Locale;
@@ -488,7 +468,6 @@ export interface JsonCurriculumDoc {
   title: string;
   toc: TocEntry[];
   topic?: Topic | null;
-  [k: string]: unknown;
 }
 export interface CurriculumIndexEntry {
   children: CurriculumIndexEntry[];
@@ -497,7 +476,6 @@ export interface CurriculumIndexEntry {
   title: string;
   topic: Topic;
   url: string;
-  [k: string]: unknown;
 }
 /**
  * Represents the previous and next navigation links by URL.
@@ -511,7 +489,6 @@ export interface CurriculumIndexEntry {
 export interface PrevNextByUrl {
   next?: UrlNTitle | null;
   prev?: UrlNTitle | null;
-  [k: string]: unknown;
 }
 /**
  * Represents a navigation link with a title and URL.
@@ -525,14 +502,12 @@ export interface PrevNextByUrl {
 export interface UrlNTitle {
   title: string;
   url: string;
-  [k: string]: unknown;
 }
 export interface CurriculumSidebarEntry {
   children: CurriculumSidebarEntry[];
   slug: string;
   title: string;
   url: string;
-  [k: string]: unknown;
 }
 /**
  * Represents the outermost structure of the serialized JSON for a blog post. This struct is written to the `index.json` file during a build.
@@ -543,15 +518,14 @@ export interface CurriculumSidebarEntry {
  *
  * * `doc` - A `JsonBlogPostDoc` that holds the main content and metadata of the blog post. * `locale` - A `Locale` that specifies the locale of the blog post page. * `url` - A `String` that holds the URL of the blog post page. * `image` - An `Option<String>` that holds the URL of an image associated with the blog post, if available. * `page_title` - A `String` that holds the title of the blog post page. Serialized as `pageTitle`. * `blog_meta` - An `Option<BlogMeta>` that holds additional metadata about the blog post, if available. Serialized as `blogMeta` and skipped during serialization if it is `None`. * `hy_data` - An `Option<BlogIndex>` that holds data related to the blog index, if available. Serialized as `hyData` and skipped during serialization if it is `None`.
  */
-export interface JsonBlogPostPage {
+export interface BlogPostPage {
   blogMeta?: BlogMeta | null;
-  doc: JsonBlogPostDoc;
+  doc: BlogPostDoc;
   hyData?: BlogIndex | null;
   image?: string | null;
   locale: Locale;
   pageTitle: string;
   url: string;
-  [k: string]: unknown;
 }
 export interface BlogMeta {
   author: AuthorLink;
@@ -564,26 +538,22 @@ export interface BlogMeta {
   slug: string;
   sponsored: boolean;
   title: string;
-  [k: string]: unknown;
 }
 export interface AuthorLink {
   avatar_url?: string | null;
   link?: string | null;
   name?: string | null;
-  [k: string]: unknown;
 }
 export interface BlogImage {
   alt?: string | null;
   creator?: AuthorMetadata | null;
   file?: string;
   source?: AuthorMetadata | null;
-  [k: string]: unknown;
 }
 export interface AuthorMetadata {
   avatar_url?: string | null;
   link?: string | null;
   name?: string;
-  [k: string]: unknown;
 }
 /**
  * Represents the previous and next navigation links by slug.
@@ -597,7 +567,6 @@ export interface AuthorMetadata {
 export interface PrevNextBySlug {
   next?: SlugNTitle | null;
   previous?: SlugNTitle | null;
-  [k: string]: unknown;
 }
 /**
  * Represents a navigation link with a title and slug.
@@ -611,7 +580,6 @@ export interface PrevNextBySlug {
 export interface SlugNTitle {
   slug: string;
   title: string;
-  [k: string]: unknown;
 }
 /**
  * Represents a blog post in the system.
@@ -622,7 +590,7 @@ export interface SlugNTitle {
  *
  * * `body` - A `Vec<Section>` that holds the content sections of the blog post. This field is skipped during serialization if it is empty. * `mdn_url` - A `String` that holds the MDN URL of the blog post. * `native` - A `Native` that holds the native representation of the locale. * `locale` - A `Locale` that specifies the locale of the blog post. * `no_indexing` - A `bool` that indicates whether the blog post should be excluded from indexing by search engines. Serialized as `noIndexing`. * `page_title` - A `String` that holds the title of the blog post. Serialized as `pageTitle`. * `parents` - A `Vec<Parent>` that holds the parent entities of the blog post. This field is skipped during serialization if it is empty. * `summary` - An `Option<String>` that holds the summary of the blog post. This field is skipped during serialization if it is `None`. * `title` - A `String` that holds the title of the blog post. * `toc` - A `Vec<TocEntry>` that holds the table of contents entries for the blog post. This field is skipped during serialization if it is empty.
  */
-export interface JsonBlogPostDoc {
+export interface BlogPostDoc {
   body: Section[];
   locale: Locale;
   mdn_url: string;
@@ -633,7 +601,6 @@ export interface JsonBlogPostDoc {
   summary?: string | null;
   title: string;
   toc: TocEntry[];
-  [k: string]: unknown;
 }
 /**
  * Represents an index of blog posts in the documentation system.
@@ -646,7 +613,6 @@ export interface JsonBlogPostDoc {
  */
 export interface BlogIndex {
   posts: BlogMeta[];
-  [k: string]: unknown;
 }
 /**
  * Represents the outermost structure of the serialized JSON for a contributor spotlight page. This struct is written to the `index.json` file during a build.
@@ -657,11 +623,10 @@ export interface BlogIndex {
  *
  * * `url` - A `String` that holds the URL of the contributor spotlight page. * `page_title` - A `String` that holds the title of the contributor spotlight page. Serialized as `pageTitle`. * `hy_data` - A `ContributorSpotlightHyData` that holds the data related to the contributor. Serialized as `hyData`.
  */
-export interface JsonContributorSpotlightPage {
+export interface ContributorSpotlightPage {
   hyData: ContributorSpotlightHyData;
   pageTitle: string;
   url: string;
-  [k: string]: unknown;
 }
 /**
  * Represents a contributor spotlight page in the documentation system.
@@ -681,11 +646,9 @@ export interface ContributorSpotlightHyData {
   quote: string;
   sections: Section[];
   usernames: Usernames;
-  [k: string]: unknown;
 }
 export interface Usernames {
   github: string;
-  [k: string]: unknown;
 }
 /**
  * Represents the outermost generic page structure in the documentation system. This is written to the `index.json` file during a build.
@@ -696,12 +659,11 @@ export interface Usernames {
  *
  * * `hy_data` - A `JsonGenericHyData` that holds the content data related to the generic page, including sections, title, and table of contents (ToC) entries. * `page_title` - A `String` that holds the title of the generic page. * `url` - A `String` that holds the URL of the generic page. * `id` - A `String` that holds the unique identifier for the generic page.
  */
-export interface JsonGenericPage {
-  hyData: JsonGenericHyData;
+export interface GenericPage {
+  hyData: GenericHyData;
   id: string;
   pageTitle: string;
   url: string;
-  [k: string]: unknown;
 }
 /**
  * Represents the data for a generic page in the system. Generic pages are used for various purposes, such as the Observatory FAQ, About pages, etc.
@@ -712,11 +674,10 @@ export interface JsonGenericPage {
  *
  * * `sections` - A `Vec<Section>` that holds the content sections of the generic page. * `title` - A `String` that holds the title of the generic page. * `toc` - A `Vec<TocEntry>` that holds the table of contents entries for the generic page.
  */
-export interface JsonGenericHyData {
+export interface GenericHyData {
   sections: Section[];
   title: string;
   toc: TocEntry[];
-  [k: string]: unknown;
 }
 /**
  * Represents a Single Page Application (SPA) page in the documentation system, i.e. AI Help, Observatory, etc.
@@ -727,7 +688,7 @@ export interface JsonGenericHyData {
  *
  * * `slug` - A `&'static str` that holds the unique identifier for the SPA page. * `page_title` - A `&'static str` that holds the title of the SPA page. * `page_description` - An `Option<&'static str>` that holds the description of the SPA page, if available. * `only_follow` - A `bool` that indicates whether the page should only be followed by search engines. * `no_indexing` - A `bool` that indicates whether the page should be excluded from indexing by search engines. * `page_not_found` - A `bool` that indicates whether the page represents a "Page Not Found" (404) error. * `url` - A `String` that holds the URL of the page.
  */
-export interface JsonSPAPage {
+export interface SPAPage {
   noIndexing: boolean;
   onlyFollow: boolean;
   pageDescription?: string | null;
@@ -735,7 +696,6 @@ export interface JsonSPAPage {
   pageTitle: string;
   slug: string;
   url: string;
-  [k: string]: unknown;
 }
 /**
  * Represents the outermost home page structure in the documentation system. This is written to the `index.json` file during a build.
@@ -746,11 +706,10 @@ export interface JsonSPAPage {
  *
  * * `hy_data` - A `JsonHomePageSPAHyData` that holds the content data related to the home page, including featured articles, contributors, latest news, and recent contributions. * `page_title` - A `&'static str` that holds the title of the home page. * `url` - A `String` that holds the URL of the page.
  */
-export interface JsonHomePage {
-  hyData: JsonHomePageSPAHyData;
+export interface HomePage {
+  hyData: HomePageSPAHyData;
   pageTitle: string;
   url: string;
-  [k: string]: unknown;
 }
 /**
  * Represents all data that is displayed on the home page.
@@ -761,13 +720,12 @@ export interface JsonHomePage {
  *
  * * `page_description` - An `Option<&'static str>` that holds the description of the home page, if available. * `featured_articles` - A `Vec<HomePageFeaturedArticle>` that holds a list of featured articles to be displayed on the home page. * `featured_contributor` - An `Option<HomePageFeaturedContributor>` that holds information about a featured contributor, if available. * `latest_news` - An `ItemContainer<HomePageLatestNewsItem>` that holds the latest news items to be displayed on the home page. * `recent_contributions` - An `ItemContainer<HomePageRecentContribution>` that holds the recent contributions to be displayed on the home page.
  */
-export interface JsonHomePageSPAHyData {
+export interface HomePageSPAHyData {
   featuredArticles: HomePageFeaturedArticle[];
   featuredContributor?: HomePageFeaturedContributor | null;
   latestNews: ItemContainerFor_HomePageLatestNewsItem;
   pageDescription?: string | null;
   recentContributions: ItemContainerFor_HomePageRecentContribution;
-  [k: string]: unknown;
 }
 /**
  * Represents a featured article (usually a blog post or documentation page) on the home page.
@@ -783,7 +741,6 @@ export interface HomePageFeaturedArticle {
   summary: string;
   tag?: Parent | null;
   title: string;
-  [k: string]: unknown;
 }
 /**
  * The `HomePageFeaturedContributor` struct contains metadata about a featured contributor item on the home page, including their name, a URL to their profile or related content, and the displayed quote.
@@ -796,7 +753,6 @@ export interface HomePageFeaturedContributor {
   contributorName: string;
   quote: string;
   url: string;
-  [k: string]: unknown;
 }
 /**
  * A container for holding a collection of items, used to hold latest news items and recent contributions on the home page.
@@ -813,7 +769,6 @@ export interface HomePageFeaturedContributor {
  */
 export interface ItemContainerFor_HomePageLatestNewsItem {
   items: HomePageLatestNewsItem[];
-  [k: string]: unknown;
 }
 /**
  * Represents an item in the latest news section on the home page.
@@ -830,7 +785,6 @@ export interface HomePageLatestNewsItem {
   source: NameUrl;
   title: string;
   url: string;
-  [k: string]: unknown;
 }
 /**
  * The `NameUrl` struct is used to store a pair of a name and a corresponding URL. This is used in the "Latest news" and "Recent contributions" sections of the home page.
@@ -842,7 +796,6 @@ export interface HomePageLatestNewsItem {
 export interface NameUrl {
   name: string;
   url: string;
-  [k: string]: unknown;
 }
 /**
  * A container for holding a collection of items, used to hold latest news items and recent contributions on the home page.
@@ -859,7 +812,6 @@ export interface NameUrl {
  */
 export interface ItemContainerFor_HomePageRecentContribution {
   items: HomePageRecentContribution[];
-  [k: string]: unknown;
 }
 /**
  * Represents a recent contribution item on the home page.
@@ -876,5 +828,4 @@ export interface HomePageRecentContribution {
   title: string;
   updated_at: string;
   url: string;
-  [k: string]: unknown;
 }

```
