### PR TITLE
fix: update paths for HTTP section move

### DIFF
--- a/crates/rari-doc/src/templ/templs/links/csp.rs
+++ b/crates/rari-doc/src/templ/templs/links/csp.rs
@@ -6,7 +6,7 @@ use crate::templ::api::RariApi;
 #[rari_f]
 pub fn csp(directive: String) -> Result<String, DocError> {
     let url = format!(
-        "/{}/docs/Web/HTTP/Headers/Content-Security-Policy/{directive}",
+        "/{}/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/{directive}",
         env.locale.as_url_str()
     );
     RariApi::link(

--- a/crates/rari-doc/src/templ/templs/links/http.rs
+++ b/crates/rari-doc/src/templ/templs/links/http.rs
@@ -13,7 +13,7 @@ pub fn http_status(
     no_code: Option<AnyArg>,
 ) -> Result<String, DocError> {
     let url = format!(
-        "/{}/docs/Web/HTTP/Status/{}",
+        "/{}/docs/Web/HTTP/Reference/Status/{}",
         env.locale.as_url_str(),
         status
     );
@@ -28,7 +28,7 @@ pub fn http_header(
     no_code: Option<AnyArg>,
 ) -> Result<String, DocError> {
     let url = format!(
-        "/{}/docs/Web/HTTP/Headers/{}",
+        "/{}/docs/Web/HTTP/Reference/Headers/{}",
         env.locale.as_url_str(),
         status
     );
@@ -43,7 +43,7 @@ pub fn http_method(
     no_code: Option<AnyArg>,
 ) -> Result<String, DocError> {
     let url = format!(
-        "/{}/docs/Web/HTTP/Methods/{}",
+        "/{}/docs/Web/HTTP/Reference/Methods/{}",
         env.locale.as_url_str(),
         status
     );

--- a/crates/rari-tools/src/sidebars.rs
+++ b/crates/rari-tools/src/sidebars.rs
@@ -453,7 +453,7 @@ mod test {
                   - /Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model
                   - /Web/CSS/CSS_Box_Model/Mastering_margin_collapsing
               - type: listSubPages
-                path: /en-US/docs/Web/HTTP/Headers
+                path: /en-US/docs/Web/HTTP/Reference/Headers
                 title: Headers
                 tags: []
                 details: closed
@@ -487,8 +487,8 @@ mod test {
                 Some(Cow::Borrowed("Web/CSS/CSS_Box_Alignment/Also_New")),
             ),
             (
-                Cow::Borrowed("Web/HTTP/Headers"),
-                Some(Cow::Borrowed("Web/HTTP/Headers_New")),
+                Cow::Borrowed("Web/HTTP/Reference/Headers"),
+                Some(Cow::Borrowed("Web/HTTP/Reference/Headers_New")),
             ),
             (
                 Cow::Borrowed("/Web/CSS/CSS_Box_Alignment/Box_Alignment_in_Multi-column_Layout"),
@@ -541,7 +541,7 @@ mod test {
 
         // replacement of the path of the fifth item in the sidebar (listSubPages)
         if let SidebarEntry::ListSubPages(SubPageEntry { path, .. }) = &sb.sidebar[4] {
-            assert_eq!(path, "/en-US/docs/Web/HTTP/Headers_New");
+            assert_eq!(path, "/en-US/docs/Web/HTTP/Reference/Headers_New");
         } else {
             panic!("Expected a listSubPages entry with a path field as the fifth entry");
         };


### PR DESCRIPTION
### Description

We've recently moved some docs in the HTTP section. This updates some paths so we don't have unnecessary redirects.

__related issues and PRs:__

- [x] https://github.com/mdn/content/pull/38555