### PR TITLE
fix: update paths for SVG/MathML section move

### DIFF
--- a/crates/rari-doc/src/templ/templs/links/mathmlxref.rs
+++ b/crates/rari-doc/src/templ/templs/links/mathmlxref.rs
@@ -12,7 +12,7 @@ pub fn mathmlxref(element_name: String) -> Result<String, DocError> {
     let url = concat_strs!(
         "/",
         env.locale.as_url_str(),
-        "/docs/Web/MathML/Element/",
+        "/docs/Web/MathML/Reference/Element/",
         element_name.as_str()
     );
 

--- a/crates/rari-doc/src/templ/templs/links/svgattr.rs
+++ b/crates/rari-doc/src/templ/templs/links/svgattr.rs
@@ -6,7 +6,7 @@ use crate::templ::api::RariApi;
 #[rari_f]
 pub fn svgattr(name: String) -> Result<String, DocError> {
     let url = format!(
-        "/{}/docs/Web/SVG/Attribute/{}",
+        "/{}/docs/Web/SVG/Reference/Attribute/{}",
         env.locale.as_url_str(),
         name,
     );

--- a/crates/rari-doc/src/templ/templs/links/svgxref.rs
+++ b/crates/rari-doc/src/templ/templs/links/svgxref.rs
@@ -13,7 +13,7 @@ pub fn svgxref(element_name: String, _: Option<AnyArg>) -> Result<String, DocErr
 pub fn svgxref_internal(element_name: &str, locale: Locale) -> Result<String, DocError> {
     let display = format!("&lt;{element_name}&gt;");
     let url = format!(
-        "/{}/docs/Web/SVG/Element/{}",
+        "/{}/docs/Web/Reference/SVG/Element/{}",
         locale.as_url_str(),
         element_name,
     );

--- a/crates/rari-doc/src/templ/templs/links/svgxref.rs
+++ b/crates/rari-doc/src/templ/templs/links/svgxref.rs
@@ -13,7 +13,7 @@ pub fn svgxref(element_name: String, _: Option<AnyArg>) -> Result<String, DocErr
 pub fn svgxref_internal(element_name: &str, locale: Locale) -> Result<String, DocError> {
     let display = format!("&lt;{element_name}&gt;");
     let url = format!(
-        "/{}/docs/Web/Reference/SVG/Element/{}",
+        "/{}/docs/Web/SVG/Reference/Element/{}",
         locale.as_url_str(),
         element_name,
     );


### PR DESCRIPTION
### Description

We've recently moved some docs in MathML and SVG sections.
This updates some paths so we don't have unnecessary redirects.

Depends one these PRs:

- [x] https://github.com/mdn/content/pull/38379
- [x] https://github.com/mdn/content/pull/38589