### PR TITLE
fix(notecard): workaround for prettier

### DIFF
--- a/crates/rari-doc/src/html/rewriter.rs
+++ b/crates/rari-doc/src/html/rewriter.rs
@@ -4,7 +4,7 @@ use std::collections::HashSet;
 use lol_html::html_content::ContentType;
 use lol_html::{element, rewrite_str, text, HtmlRewriter, RewriteStrSettings, Settings};
 use rari_md::ext::DELIM_START;
-use rari_md::node_card::NoteCard;
+use rari_md::note_card::NoteCard;
 use rari_types::fm_types::PageType;
 use rari_types::globals::settings;
 use rari_utils::concat_strs;

--- a/crates/rari-md/src/html.rs
+++ b/crates/rari-md/src/html.rs
@@ -23,7 +23,7 @@ use crate::anchor;
 use crate::character_set::character_set;
 use crate::ctype::isspace;
 use crate::ext::{Flag, DELIM_START};
-use crate::node_card::{alert_type_css_class, alert_type_default_title, is_callout, NoteCard};
+use crate::note_card::{alert_type_css_class, alert_type_default_title, is_callout, NoteCard};
 
 /// Formats an AST as HTML, modified by the given options.
 pub fn format_document<'a>(

--- a/crates/rari-md/src/lib.rs
+++ b/crates/rari-md/src/lib.rs
@@ -12,7 +12,7 @@ pub(crate) mod dl;
 pub mod error;
 pub mod ext;
 pub(crate) mod html;
-pub mod node_card;
+pub mod note_card;
 pub(crate) mod p;
 
 use dl::{convert_dl, is_dl};

--- a/crates/rari-md/src/note_card.rs
+++ b/crates/rari-md/src/note_card.rs
@@ -79,6 +79,11 @@ pub(crate) fn is_callout<'a>(block_quote: &'a AstNode<'a>, locale: Locale) -> Op
             let mut data = marker.data.borrow_mut();
             if let NodeValue::Text(ref text) = data.value {
                 if text.starts_with(NoteCard::Callout.new_prefix()) {
+                    if let Some(n) = child.children().nth(1) {
+                        if matches!(n.data.borrow().value, NodeValue::LineBreak) {
+                            n.data.borrow_mut().value = NodeValue::SoftBreak;
+                        }
+                    };
                     if text.trim() == NoteCard::Callout.new_prefix() {
                         marker.detach();
                     } else if let Some(tail) = text.strip_prefix(NoteCard::Callout.new_prefix()) {
@@ -87,6 +92,11 @@ pub(crate) fn is_callout<'a>(block_quote: &'a AstNode<'a>, locale: Locale) -> Op
                     return Some(NoteCard::Callout);
                 }
                 if text.starts_with(NoteCard::Warning.new_prefix()) {
+                    if let Some(n) = child.children().nth(1) {
+                        if matches!(n.data.borrow().value, NodeValue::LineBreak) {
+                            n.data.borrow_mut().value = NodeValue::SoftBreak;
+                        }
+                    };
                     if text.trim() == NoteCard::Warning.new_prefix() {
                         marker.detach();
                     } else if let Some(tail) = text.strip_prefix(NoteCard::Warning.new_prefix()) {
@@ -95,6 +105,11 @@ pub(crate) fn is_callout<'a>(block_quote: &'a AstNode<'a>, locale: Locale) -> Op
                     return Some(NoteCard::Warning);
                 }
                 if text.starts_with(NoteCard::Note.new_prefix()) {
+                    if let Some(n) = child.children().nth(1) {
+                        if matches!(n.data.borrow().value, NodeValue::LineBreak) {
+                            n.data.borrow_mut().value = NodeValue::SoftBreak;
+                        }
+                    };
                     if text.trim() == NoteCard::Note.new_prefix() {
                         marker.detach();
                     } else if let Some(tail) = text.strip_prefix(NoteCard::Note.new_prefix()) {


### PR DESCRIPTION
Support

```
> [!WARNING]\
> [Prettier](https://prettier.io) will break this.
```


> [!WARNING]\
> [Prettier](https://prettier.io) will break this.


to render as inline warning.



