### PR TITLE
feat(content): support fix-flaws command

### DIFF
--- a/crates/rari-cli/main.rs
+++ b/crates/rari-cli/main.rs
@@ -29,6 +29,7 @@ use rari_doc::search_index::build_search_index;
 use rari_doc::utils::TEMPL_RECORDER_SENDER;
 use rari_sitemap::Sitemaps;
 use rari_tools::add_redirect::add_redirect;
+use rari_tools::fix::fixer::fix_all;
 use rari_tools::history::gather_history;
 use rari_tools::inventory::gather_inventory;
 use rari_tools::r#move::r#move;
@@ -82,6 +83,11 @@ enum Commands {
 }
 
 #[derive(Args)]
+struct FixFlawsArgs {
+    #[arg(short, long)]
+    locale: Option<Locale>,
+}
+#[derive(Args)]
 struct ExportSchemaArgs {
     output_file: Option<PathBuf>,
 }
@@ -111,6 +117,8 @@ enum ContentSubcommand {
     ValidateRedirects(ValidateRedirectArgs),
     /// Create content inventory as JSON
     Inventory,
+    /// Fix all flaws for a locale
+    FixFlaws(FixFlawsArgs),
 }
 
 #[derive(Args)]
@@ -502,6 +510,25 @@ fn main() -> Result<(), Error> {
             }
             ContentSubcommand::Inventory => {
                 gather_inventory()?;
+            }
+            ContentSubcommand::FixFlaws(args) => {
+                let start = std::time::Instant::now();
+                let mut settings = Settings::new()?;
+                settings.cache_content = true;
+                let _ = SETTINGS.set(settings);
+                let docs = read_and_cache_doc_pages()?;
+                info!(
+                    "Took: {: >10.3?} for reading {} docs",
+                    start.elapsed(),
+                    docs.len()
+                );
+                let start = std::time::Instant::now();
+                let fixed = fix_all(&docs, args.locale)?;
+                info!(
+                    "Took: {: >10.3?} for fixing {} docs",
+                    start.elapsed(),
+                    fixed.len()
+                );
             }
         },
         Commands::Update(args) => update(args.version)?,

--- a/crates/rari-cli/main.rs
+++ b/crates/rari-cli/main.rs
@@ -84,7 +84,7 @@ enum Commands {
 
 #[derive(Args)]
 struct FixFlawsArgs {
-    #[arg(short, long)]
+    #[arg(short, long, help = "Only fix flaws for <LOCALE>")]
     locale: Option<Locale>,
 }
 #[derive(Args)]
@@ -117,7 +117,7 @@ enum ContentSubcommand {
     ValidateRedirects(ValidateRedirectArgs),
     /// Create content inventory as JSON
     Inventory,
-    /// Fix all flaws for a locale
+    /// Fix all flaws (currently only broken_links)
     FixFlaws(FixFlawsArgs),
 }
 

--- a/crates/rari-doc/src/issues.rs
+++ b/crates/rari-doc/src/issues.rs
@@ -247,10 +247,20 @@ pub enum DIssue {
     },
 }
 
+impl DIssue {
+    pub fn display_issue(&self) -> &DisplayIssue {
+        match self {
+            DIssue::BrokenLink { display_issue, .. }
+            | DIssue::Macros { display_issue, .. }
+            | DIssue::Unknown { display_issue } => display_issue,
+        }
+    }
+}
+
 pub type DisplayIssues = BTreeMap<&'static str, Vec<DIssue>>;
 
 impl DIssue {
-    fn from_issue_with_id(issue: Issue, page: &Page, id: usize) -> Self {
+    pub fn from_issue_with_id(issue: Issue, page: &Page, id: usize) -> Self {
         let mut di = DisplayIssue {
             id: id as i64,
             column: if issue.col == 0 {

--- a/crates/rari-doc/src/pages/page.rs
+++ b/crates/rari-doc/src/pages/page.rs
@@ -250,6 +250,7 @@ pub trait PageLike {
     fn base_slug(&self) -> &str;
     fn trailing_slash(&self) -> bool;
     fn fm_offset(&self) -> usize;
+    fn raw_content(&self) -> &str;
 }
 
 impl<T: PageLike> PageLike for Arc<T> {
@@ -315,6 +316,10 @@ impl<T: PageLike> PageLike for Arc<T> {
 
     fn fm_offset(&self) -> usize {
         (**self).fm_offset()
+    }
+
+    fn raw_content(&self) -> &str {
+        (**self).raw_content()
     }
 }
 

--- a/crates/rari-doc/src/pages/types/blog.rs
+++ b/crates/rari-doc/src/pages/types/blog.rs
@@ -295,6 +295,10 @@ impl PageLike for BlogPost {
     fn fm_offset(&self) -> usize {
         self.raw[..self.content_start].lines().count()
     }
+
+    fn raw_content(&self) -> &str {
+        &self.raw
+    }
 }
 
 fn read_blog_post(path: impl Into<PathBuf>) -> Result<BlogPost, DocError> {

--- a/crates/rari-doc/src/pages/types/contributors.rs
+++ b/crates/rari-doc/src/pages/types/contributors.rs
@@ -237,6 +237,10 @@ impl PageLike for ContributorSpotlight {
     fn fm_offset(&self) -> usize {
         self.raw[..self.content_start].lines().count()
     }
+
+    fn raw_content(&self) -> &str {
+        &self.raw
+    }
 }
 
 fn read_contributor_spotlight(

--- a/crates/rari-doc/src/pages/types/curriculum.rs
+++ b/crates/rari-doc/src/pages/types/curriculum.rs
@@ -259,6 +259,10 @@ impl PageLike for CurriculumPage {
     fn fm_offset(&self) -> usize {
         0
     }
+
+    fn raw_content(&self) -> &str {
+        &self.raw_content
+    }
 }
 
 pub fn curriculum_group(parents: &[Parent]) -> Option<String> {

--- a/crates/rari-doc/src/pages/types/doc.rs
+++ b/crates/rari-doc/src/pages/types/doc.rs
@@ -283,6 +283,10 @@ impl PageLike for Doc {
     fn fm_offset(&self) -> usize {
         self.raw[..self.content_start].lines().count()
     }
+
+    fn raw_content(&self) -> &str {
+        &self.raw
+    }
 }
 
 fn read_doc(path: impl Into<PathBuf>) -> Result<Doc, DocError> {

--- a/crates/rari-doc/src/pages/types/generic.rs
+++ b/crates/rari-doc/src/pages/types/generic.rs
@@ -201,6 +201,10 @@ impl PageLike for GenericPage {
     fn fm_offset(&self) -> usize {
         self.raw[..self.content_start].lines().count()
     }
+
+    fn raw_content(&self) -> &str {
+        &self.raw
+    }
 }
 
 fn read_generic_page(

--- a/crates/rari-doc/src/pages/types/spa.rs
+++ b/crates/rari-doc/src/pages/types/spa.rs
@@ -243,6 +243,10 @@ impl PageLike for SPA {
     fn fm_offset(&self) -> usize {
         0
     }
+
+    fn raw_content(&self) -> &str {
+        ""
+    }
 }
 
 const MDN_PLUS_TITLE: &str = "MDN Plus";

--- a/crates/rari-tools/src/fix/fixer.rs
+++ b/crates/rari-tools/src/fix/fixer.rs
@@ -1,0 +1,20 @@
+use rari_doc::pages::page::{Page, PageLike};
+use rari_types::locale::Locale;
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
+
+use super::issues::fix_page;
+use crate::error::ToolError;
+
+pub fn fix_all(docs: &[Page], locale: Option<Locale>) -> Result<Vec<&Page>, ToolError> {
+    docs.into_par_iter()
+        .filter(|page| locale.map(|locale| page.locale() == locale).unwrap_or(true))
+        .map(|page| (fix_page(page), page))
+        .filter_map(|(res, page)| {
+            if matches!(res, Ok(false)) {
+                None
+            } else {
+                Some(res.map(|_| page))
+            }
+        })
+        .collect()
+}

--- a/crates/rari-tools/src/fix/issues.rs
+++ b/crates/rari-tools/src/fix/issues.rs
@@ -1,0 +1,151 @@
+use std::fs::File;
+use std::io::{BufWriter, Write};
+
+use rari_doc::issues::{DIssue, IN_MEMORY};
+use rari_doc::pages::page::{Page, PageBuilder, PageLike};
+use tracing::{span, Level};
+
+use crate::error::ToolError;
+
+#[derive(Default, Debug, Clone, Copy)]
+struct OLCMapper {
+    offset: usize,
+    line: usize,
+    column: usize,
+}
+
+pub fn fix_page(page: &Page) -> Result<bool, ToolError> {
+    let file = page.full_path().to_string_lossy();
+    let span = span!(
+        Level::ERROR,
+        "page",
+        locale = page.locale().as_url_str(),
+        slug = page.slug(),
+        file = file.as_ref()
+    );
+    let enter = span.enter();
+    let _ = page.build()?;
+    drop(enter);
+    let mut issues = {
+        let m = IN_MEMORY.get_events();
+        let (_, req_issues) = m
+            .remove(page.full_path().to_string_lossy().as_ref())
+            .unwrap_or_default();
+        req_issues
+            .into_iter()
+            .enumerate()
+            .filter_map(|(id, issue)| {
+                let dissue = DIssue::from_issue_with_id(issue, page, id);
+
+                let display_issue = dissue.display_issue();
+                if display_issue.suggestion.is_some()
+                    && display_issue.fixable.unwrap_or_default()
+                    && display_issue.column.is_some()
+                    && display_issue.line.is_some()
+                {
+                    Some(dissue)
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>()
+    };
+    issues.sort_by(|a, b| {
+        if a.display_issue().line == b.display_issue().line {
+            a.display_issue().column.cmp(&b.display_issue().column)
+        } else {
+            a.display_issue().line.cmp(&b.display_issue().line)
+        }
+    });
+
+    let raw = page.raw_content();
+    let fixed = fix_issues(raw, &issues)?;
+    let is_fixed = fixed != raw;
+    if is_fixed {
+        tracing::info!("updating {}", page.full_path().display());
+        let file = File::create(page.full_path()).unwrap();
+        let mut buffed = BufWriter::new(file);
+        buffed.write_all(fixed.as_bytes())?;
+    }
+    Ok(is_fixed)
+}
+
+pub fn fix_issues(raw: &str, issues: &[DIssue]) -> Result<String, ToolError> {
+    let (olc, mut fixed) =
+        issues
+            .iter()
+            .fold((OLCMapper::default(), vec![]), |(olc, mut acc), dissue| {
+                let olc = fix_issue(&mut acc, dissue, raw, olc);
+                (olc, acc)
+            });
+    fixed.push(&raw[olc.offset..]);
+    Ok(fixed.join(""))
+}
+
+fn calc_offset(input: &str, olc: OLCMapper, new_line: usize, new_column: usize) -> Option<usize> {
+    let OLCMapper {
+        offset,
+        line,
+        column,
+    } = olc;
+    let lines = new_line - line;
+
+    let offset = if new_line > line {
+        let begin_of_line = input[offset..]
+            .lines()
+            .take(lines)
+            .map(|line| line.len() + 1)
+            .sum::<usize>();
+        let new_column_offset = new_column;
+        Some(offset + begin_of_line + new_column_offset)
+    } else if new_line == line && new_column > column {
+        Some(offset + (new_column - column))
+    } else {
+        tracing::warn!("skipping issues");
+        None
+    };
+    if let Some(offset) = offset {
+        let mut index = offset;
+        while !input.is_char_boundary(index) {
+            index -= 1;
+        }
+    }
+    offset
+}
+
+fn fix_issue<'a>(
+    acc: &mut Vec<&'a str>,
+    dissue: &'a DIssue,
+    raw: &'a str,
+    olc: OLCMapper,
+) -> OLCMapper {
+    let new_line = dissue.display_issue().line.unwrap_or_default() as usize - 1;
+    let new_column = dissue.display_issue().column.unwrap_or_default() as usize - 1;
+    if let Some(offset) = calc_offset(raw, olc, new_line, new_column) {
+        #[allow(clippy::single_match)]
+        match dissue {
+            DIssue::BrokenLink {
+                display_issue,
+                href: Some(href),
+            } => {
+                if let Some(start) = raw[offset..].find(href) {
+                    let href_offset = offset + start;
+
+                    if href_offset > olc.offset {
+                        acc.push(&raw[olc.offset..href_offset]);
+                    }
+                    let fix = display_issue.suggestion.as_deref().unwrap_or_default();
+                    let new_offset = href_offset + href.len();
+                    acc.push(fix);
+                    return OLCMapper {
+                        offset: new_offset,
+                        line: new_line,
+                        column: new_column + start + href.len(),
+                    };
+                }
+            }
+            _ => {}
+        }
+    }
+    olc
+}

--- a/crates/rari-tools/src/fix/mod.rs
+++ b/crates/rari-tools/src/fix/mod.rs
@@ -1,0 +1,2 @@
+pub mod fixer;
+pub mod issues;

--- a/crates/rari-tools/src/lib.rs
+++ b/crates/rari-tools/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod add_redirect;
 pub mod error;
+pub mod fix;
 pub mod git;
 pub mod history;
 pub mod inventory;


### PR DESCRIPTION
### Description

Adds cli support for `content fix-flaws`.
By default it fixed all (broken_links) issues for all available locales.
Support `-l <LOCALE>` to restrict it to a single locale.

Experimental support for the API used by the flaws box in the front-end (depending on a yari PR).