### PR TITLE
chore(htmlxref): update HTML Element url pattern

### DIFF
--- a/crates/rari-doc/src/templ/templs/links/htmlxref.rs
+++ b/crates/rari-doc/src/templ/templs/links/htmlxref.rs
@@ -18,7 +18,7 @@ pub fn htmlxref(
         format!("&lt;{element_name}&gt;")
     });
     let mut url = format!(
-        "/{}/docs/Web/HTML/Element/{}",
+        "/{}/docs/Web/HTML/Reference/Elements/{}",
         env.locale.as_url_str(),
         element_name,
     );


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

We've reorganized HTML docs in https://github.com/mdn/content/pull/39055 (merged on Apr 10).
Found only one instance where the path went deeper than `Web/HTML`.

### Motivation

To prevent unnecessary redirects

---

**UPDATE**: To have this change be included in the release please:

BEGIN_COMMIT_OVERRIDE
feat: update HTML Element url pattern
END_COMMIT_OVERRIDE

