### PR TITLE
fix(npm): export types in an esm-compatible way

### DIFF
--- a/rari-npm/lib/index.d.ts
+++ b/rari-npm/lib/index.d.ts
@@ -1,2 +1,2 @@
 export declare const rariBin: string;
-export * from "./rari-types.d";
+export * from "./rari-types.js";


### PR DESCRIPTION
not using a `.js` extension is breaking things in my fred rspack migration