### PR TITLE
feat(livesamples): tag live sample code blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2682,6 +2682,7 @@ dependencies = [
  "constcat",
  "crossbeam-channel",
  "css-syntax",
+ "cssparser 0.34.0",
  "dashmap",
  "ego-tree",
  "enum_dispatch",

--- a/crates/rari-cli/main.rs
+++ b/crates/rari-cli/main.rs
@@ -217,6 +217,11 @@ struct BuildArgs {
     #[arg(long, help = "Add flaws field to index.json for docs")]
     json_issues: bool,
     #[arg(
+        long,
+        help = "Add live_samples field to index.json docs docs and blog posts"
+    )]
+    json_live_samples: bool,
+    #[arg(
         short,
         long,
         help = "Noop flag to legacy compatibility (has no effect on build)"
@@ -293,6 +298,7 @@ fn main() -> Result<(), Error> {
             settings.cache_content = !args.no_cache;
             settings.data_issues = args.data_issues;
             settings.json_issues = args.json_issues;
+            settings.json_live_samples = args.json_live_samples;
             let _ = SETTINGS.set(settings);
 
             let mut arg_files = args
@@ -467,6 +473,7 @@ fn main() -> Result<(), Error> {
             settings.cache_content = args.cache;
             settings.data_issues = true;
             settings.blog_unpublished = true;
+            settings.json_live_samples = true;
             let _ = SETTINGS.set(settings);
             serve::serve()?
         }

--- a/crates/rari-doc/Cargo.toml
+++ b/crates/rari-doc/Cargo.toml
@@ -43,6 +43,7 @@ html-escape = "0.2"
 html5ever = "0.29"
 ego-tree = "0.10"
 rss = { version = "2", features = [], default-features = false }
+cssparser = "0.34"
 
 ignore = "0.4"
 crossbeam-channel = "0.5"

--- a/crates/rari-doc/src/html/code.rs
+++ b/crates/rari-doc/src/html/code.rs
@@ -1,0 +1,245 @@
+use std::borrow::Cow;
+use std::collections::HashSet;
+
+use ego_tree::NodeId;
+use html5ever::{namespace_url, ns, QualName};
+use rari_types::globals::settings;
+use rari_utils::concat_strs;
+use schemars::JsonSchema;
+use scraper::{Element, ElementRef, Html, Node, Selector};
+use serde::Serialize;
+
+use super::ids::uniquify_id;
+use super::modifier::insert_attribute;
+
+#[derive(Debug, Default, Clone)]
+pub struct CodeInternal {
+    pub css: String,
+    pub html: String,
+    pub js: String,
+    pub src: Option<String>,
+    pub node_ids: Vec<NodeId>,
+    pub id: String,
+}
+
+#[derive(Debug, Default, Clone, Serialize, JsonSchema)]
+pub struct Code {
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub css: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub html: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub js: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub src: Option<String>,
+    pub id: String,
+}
+
+impl From<CodeInternal> for Code {
+    fn from(
+        CodeInternal {
+            css,
+            html,
+            js,
+            src,
+            id,
+            ..
+        }: CodeInternal,
+    ) -> Self {
+        Self {
+            css,
+            html,
+            js,
+            src,
+            id,
+        }
+    }
+}
+
+pub fn code_blocks(html: &mut Html) -> Option<Vec<Code>> {
+    let mut ids = HashSet::new();
+    let mut update_data_live_id = Vec::new();
+    let mut examples = vec![];
+    let selector = Selector::parse("iframe[data-live-id]").ok()?;
+    for iframe in html.select(&selector) {
+        if let Some(id) = iframe.attr("data-live-id") {
+            let src = iframe.attr("data-live-path").map(String::from);
+            if let Some(mut code) = code_by_query(
+                &html.root_element(),
+                &concat_strs!("pre.live-sample___", id),
+                None,
+            ) {
+                code.src = src;
+                code.id = id.to_string();
+                examples.push(code);
+            } else {
+                let id_ = uniquify_id(&mut ids, Cow::Borrowed(id));
+                if id != id_ {
+                    update_data_live_id.push((iframe.id(), id_.clone().to_string()));
+                }
+                let id = id_;
+
+                let mut css_id = String::with_capacity(id.len() + 1);
+                css_id.push('#');
+                cssparser::serialize_identifier(&id, &mut css_id).unwrap();
+                let selector = Selector::parse(&css_id);
+                if let Ok(selector) = selector {
+                    let mut next = html
+                        .select(&selector)
+                        .next()
+                        .or_else(|| closest_heading(iframe));
+                    {
+                        while let Some(heading) = next {
+                            if let Some(mut code) = gather_code(heading) {
+                                code.src = src;
+                                code.id = id.to_string();
+                                examples.push(code);
+                                break;
+                            } else {
+                                next = closest_parent_heading(heading)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    for (el_id, id) in update_data_live_id {
+        insert_attribute(html, el_id, "data-live-id", &id);
+    }
+
+    let mut result = Vec::with_capacity(examples.len());
+    for code in examples {
+        for node_id in &code.node_ids {
+            if let Some(mut node) = html.tree.get_mut(*node_id) {
+                if let Node::Element(ref mut el) = node.value() {
+                    let class = el.attr("class").unwrap_or_default();
+                    let claas = concat_strs!(
+                        class,
+                        if class.is_empty() { "" } else { " " },
+                        "live-sample---",
+                        code.id.as_str()
+                    );
+                    el.attrs.insert(
+                        QualName {
+                            prefix: None,
+                            ns: ns!(),
+                            local: "class".into(),
+                        },
+                        claas.into(),
+                    );
+                }
+            }
+        }
+        result.push(code.into())
+    }
+
+    if settings().json_live_samples {
+        Some(result)
+    } else {
+        None
+    }
+}
+
+fn gather_code(ref_element: ElementRef) -> Option<CodeInternal> {
+    let h = ref_element.value().name();
+
+    let block_mode = !is_heading(&ref_element);
+
+    let mut code = None;
+    if block_mode {
+        code = code_by_query(&ref_element, "pre", code);
+        return code;
+    }
+
+    let mut next = ref_element;
+    while let Some(element) = next.next_sibling_element() {
+        if is_heading(&element) && element.value().name() <= h {
+            break;
+        }
+        code = code_by_query(&element, "pre", code);
+        next = element;
+    }
+
+    code
+}
+
+fn code_by_query(
+    root: &ElementRef,
+    query: &str,
+    code: Option<CodeInternal>,
+) -> Option<CodeInternal> {
+    let selector = Selector::parse(query).ok()?;
+    root.select(&selector).fold(code, |acc, pre| {
+        let mut acc = acc.unwrap_or_default();
+        if pre.value().classes().any(|cls| match cls {
+            "css" => {
+                if !acc.css.is_empty() {
+                    acc.css.push('\n');
+                }
+                acc.css.extend(pre.text());
+                true
+            }
+            "js" => {
+                if !acc.js.is_empty() {
+                    acc.js.push('\n');
+                }
+                acc.js.extend(pre.text());
+                true
+            }
+            "html" => {
+                if !acc.html.is_empty() {
+                    acc.html.push('\n');
+                }
+                acc.html.extend(pre.text());
+                true
+            }
+            _ => false,
+        }) {
+            acc.node_ids.push(pre.id())
+        };
+        Some(acc)
+    })
+}
+
+fn closest_parent_heading(heading: ElementRef) -> Option<ElementRef> {
+    let h = heading.value().name();
+    let mut next = heading;
+    while let Some(element) = next
+        .prev_sibling_element()
+        .or_else(|| next.parent_element())
+    {
+        if is_major_heading(&element) && element.value().name() < h {
+            return Some(element);
+        } else {
+            next = element;
+        }
+    }
+    None
+}
+
+fn closest_heading(element: ElementRef) -> Option<ElementRef> {
+    let mut next = element;
+    while let Some(element) = next
+        .prev_sibling_element()
+        .or_else(|| next.parent_element())
+    {
+        if is_major_heading(&element) {
+            return Some(element);
+        } else {
+            next = element;
+        }
+    }
+    None
+}
+
+fn is_heading(element: &ElementRef) -> bool {
+    matches!(
+        element.value().name(),
+        "h1" | "h2" | "h3" | "h4" | "h5" | "h6"
+    )
+}
+
+fn is_major_heading(element: &ElementRef) -> bool {
+    matches!(element.value().name(), "h1" | "h2" | "h3")
+}

--- a/crates/rari-doc/src/html/ids.rs
+++ b/crates/rari-doc/src/html/ids.rs
@@ -1,0 +1,27 @@
+use std::borrow::Cow;
+use std::collections::HashSet;
+
+pub fn uniquify_id<'a>(ids: &mut HashSet<Cow<'_, str>>, id: Cow<'a, str>) -> Cow<'a, str> {
+    if ids.contains(id.as_ref()) {
+        let (prefix, mut count) = if let Some((prefix, counter)) = id.rsplit_once('_') {
+            if counter.chars().all(|c| c.is_ascii_digit()) {
+                let count = counter.parse::<i64>().unwrap_or_default() + 1;
+                (prefix, count)
+            } else {
+                (id.as_ref(), 2)
+            }
+        } else {
+            (id.as_ref(), 2)
+        };
+        let mut new_id = format!("{prefix}_{count}");
+        while ids.contains(new_id.as_str()) && count < 666 {
+            count += 1;
+            new_id = format!("{prefix}_{count}");
+        }
+        ids.insert(Cow::Owned(new_id.clone()));
+        return Cow::Owned(new_id);
+    }
+    let id_ = id.clone().to_string();
+    ids.insert(Cow::Owned(id_));
+    id
+}

--- a/crates/rari-doc/src/html/mod.rs
+++ b/crates/rari-doc/src/html/mod.rs
@@ -1,6 +1,8 @@
 pub mod bubble_up;
+pub mod code;
 mod fix_img;
 mod fix_link;
+pub mod ids;
 pub mod links;
 pub mod modifier;
 pub mod rewriter;

--- a/crates/rari-doc/src/pages/json.rs
+++ b/crates/rari-doc/src/pages/json.rs
@@ -18,6 +18,7 @@ use super::templates::{
 };
 use super::types::contributors::Usernames;
 use super::types::curriculum::{CurriculumIndexEntry, CurriculumSidebarEntry, Template, Topic};
+use crate::html::code::Code;
 use crate::issues::DisplayIssues;
 use crate::pages::types::blog::BlogMeta;
 use crate::specs::Specification;
@@ -275,6 +276,8 @@ pub struct JsonDoc {
     pub page_type: PageType,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub flaws: Option<DisplayIssues>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub live_samples: Option<Vec<Code>>,
 }
 
 impl JsonDocMetadata {
@@ -510,6 +513,8 @@ pub struct JsonBlogPostDoc {
     pub title: String,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub toc: Vec<TocEntry>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub live_samples: Option<Vec<Code>>,
 }
 
 /// Represents the outermost structure of the serialized JSON for a blog post. This struct

--- a/crates/rari-types/src/settings.rs
+++ b/crates/rari-types/src/settings.rs
@@ -72,6 +72,7 @@ pub struct Settings {
     pub reader_ignores_gitignore: bool,
     pub data_issues: bool,
     pub json_issues: bool,
+    pub json_live_samples: bool,
     pub blog_unpublished: bool,
     pub deps: Deps,
 }


### PR DESCRIPTION
### Description

This adds `live-sample---<ID>` to the code blocks of a live samples. Yari supports `live-sample___<ID>` but we'll add support for `live-sample---<ID>` and then change rari to use `live-sample___<ID>` once it's fully rolled out.

This also adds support for exposing `live_samples` in the `index.json`. This is enabled in the dev server and behind the `--json-live-samples` flag for `rari build`.