### PR TITLE
feat(sidebars): allow webgl-extension-method to show up in ApiRef sidebar

### DIFF
--- a/crates/rari-doc/src/sidebars/apiref.rs
+++ b/crates/rari-doc/src/sidebars/apiref.rs
@@ -73,7 +73,7 @@ pub fn sidebar(slug: &str, group: Option<&str>, locale: Locale) -> Result<MetaSi
             PageType::WebApiInstanceMethod => &mut instance_methods,
             PageType::WebApiConstructor => &mut constructors,
             PageType::WebApiEvent => &mut events,
-            PageType::WebglExtensionMethod => &mut instance_properties,
+            PageType::WebglExtensionMethod => &mut instance_methods,
             _ => continue,
         };
         v.push(page);

--- a/crates/rari-doc/src/sidebars/apiref.rs
+++ b/crates/rari-doc/src/sidebars/apiref.rs
@@ -73,6 +73,7 @@ pub fn sidebar(slug: &str, group: Option<&str>, locale: Locale) -> Result<MetaSi
             PageType::WebApiInstanceMethod => &mut instance_methods,
             PageType::WebApiConstructor => &mut constructors,
             PageType::WebApiEvent => &mut events,
+            PageType::WebglExtensionMethod => &mut instance_properties,
             _ => continue,
         };
         v.push(page);


### PR DESCRIPTION
Currently, the extension methods are not available in the sidebar:

<img width="1155" alt="image" src="https://github.com/user-attachments/assets/ca5fd913-e975-4898-8be2-253e58516779" />

By treating `webgl-extension-method` the same as `web-api-instance-method`, this page can now be included in the sidebar.