### PR TITLE
chore: correct the environment name of `content_translated_root`

### DIFF
--- a/crates/rari-types/src/error.rs
+++ b/crates/rari-types/src/error.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 pub enum EnvError {
     #[error("CONTENT_ROOT must be set")]
     NoContent,
-    #[error("TRANSLATED_CONTENT_ROOT must be set")]
+    #[error("CONTENT_TRANSLATED_ROOT must be set")]
     NoTranslatedContent,
     #[error("BUILD_OUT_ROOT must be set")]
     NoBuildOut,


### PR DESCRIPTION
### Description

Correct the environment name of `content_translated_root`.

### Motivation

When working with translated-content, the environment name `CONTENT_TRANSLATED_ROOT` should be set, instead of `TRANSLATED_CONTENT_ROOT`. I believe the error message here is a typo.

See the following code/doc for more information:

- https://github.com/mdn/rari/blob/72ee2423fc0ee6e48032a3eb06eee0b26c702acf/crates/rari-types/src/settings.rs#L59
- https://github.com/mdn/rari/blob/72ee2423fc0ee6e48032a3eb06eee0b26c702acf/crates/rari-types/src/settings.rs#L105-L108
- https://github.com/mdn/yari/blob/ad04254426fe69b5c619918bd83a5d845bba9f4a/libs/env/index.js#L83-L85
- https://github.com/mdn/translated-content/blob/main/CONTRIBUTING.md#link-translated-content
