### PR TITLE
fix(macro): update redirected URLs in the CSSInfo macro

### DIFF
--- a/crates/rari-doc/src/helpers/css_info.rs
+++ b/crates/rari-doc/src/helpers/css_info.rs
@@ -305,7 +305,7 @@ pub fn get_for_locale(locale: Locale, lookup: &Value) -> &Value {
 pub fn css_computed(locale: Locale) -> Result<String, DocError> {
     let copy = l10n_json_data("Template", "xref_csscomputed", locale)?;
     RariApi::link(
-        "/Web/CSS/CSS_cascade/computed_value",
+        "/Web/CSS/CSS_cascade/Value_processing#computed_value",
         locale,
         Some(copy),
         false,
@@ -329,7 +329,7 @@ pub fn css_inherited(locale: Locale) -> Result<String, DocError> {
 pub fn css_initial(locale: Locale) -> Result<String, DocError> {
     let copy = l10n_json_data("Template", "xref_cssinitial", locale)?;
     RariApi::link(
-        "/Web/CSS/CSS_cascade/initial_value",
+        "Web/CSS/CSS_cascade/Value_processing#initial_value",
         locale,
         Some(copy),
         false,


### PR DESCRIPTION
### Description

The hardcoded URLs in the macro are being redirected to the new locations.

### Motivation

Fix flaws.

### Related issues and pull requests

- addresses https://github.com/mdn/content/pull/39451#issuecomment-2861950429