### PR TITLE
enhance(rari-doc): use root short-title in pageTitle

### DIFF
--- a/crates/rari-doc/src/helpers/title.rs
+++ b/crates/rari-doc/src/helpers/title.rs
@@ -27,7 +27,7 @@ pub fn page_title(doc: &impl PageLike, with_suffix: bool) -> Result<String, DocE
         if root_url != doc.url() {
             let root_doc = Page::from_url_with_fallback(root_url)?;
             out.push_str(" - ");
-            out.push_str(root_doc.title());
+            out.push_str(root_doc.short_title().unwrap_or(root_doc.title()));
         }
     }
     if with_suffix {


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Updates the `pageTitle` to use the root's `short-title` instead of `title`.

### Motivation

Makes the titles more concise, e.g.:

```patch
-display - CSS: Cascading Style Sheets | MDN
+display - CSS | MDN

-<a>: The Anchor element - HTML: HyperText Markup Language | MDN
+<a>: The Anchor element - HTML | MDN
```

Note that this does **not** affect the title of the landing pages themselves:

```patch
-CSS: Cascading Style Sheets | MDN
+CSS: Cascading Style Sheets | MDN

-HTML: HyperText Markup Language | MDN
+HTML: HyperText Markup Language | MDN
````

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Related:

- https://github.com/mdn/content/pull/39650