### PR TITLE
enhance(sidebars): add guides/tutorials to APIRef

### DIFF
--- a/crates/rari-doc/src/sidebars/apiref.rs
+++ b/crates/rari-doc/src/sidebars/apiref.rs
@@ -28,6 +28,8 @@ pub fn sidebar(slug: &str, group: Option<&str>, locale: Locale) -> Result<MetaSi
         Cow::Borrowed(l10n_json_data("Common", "Related_pages_wo_group", locale)?)
     };
     let events_label = l10n_json_data("Common", "Events", locale)?;
+    let guides_label = l10n_json_data("Common", "Guides", locale)?;
+    let tutorial_label = l10n_json_data("Common", "Tutorial", locale)?;
 
     let main_if = slug
         .strip_prefix("Web/API/")
@@ -118,6 +120,21 @@ pub fn sidebar(slug: &str, group: Option<&str>, locale: Locale) -> Result<MetaSi
 
     build_interface_list(&mut entries, &inherited, inheritance_label);
     build_interface_list(&mut entries, &related, &related_label);
+
+    if let Some(groups) = web_api_groups {
+        let guides: Vec<Page> = groups
+            .guides
+            .iter()
+            .map(|slug| Doc::page_from_slug(slug.replace("/docs/", "").as_str(), locale, true))
+            .collect::<Result<_, _>>()?;
+        let tutorial: Vec<Page> = groups
+            .tutorial
+            .iter()
+            .map(|slug| Doc::page_from_slug(slug.replace("/docs/", "").as_str(), locale, true))
+            .collect::<Result<_, _>>()?;
+        build_sublist(&mut entries, &guides, guides_label);
+        build_sublist(&mut entries, &tutorial, tutorial_label);
+    }
 
     Ok(MetaSidebar {
         entries,

--- a/crates/rari-doc/src/sidebars/apiref.rs
+++ b/crates/rari-doc/src/sidebars/apiref.rs
@@ -125,13 +125,15 @@ pub fn sidebar(slug: &str, group: Option<&str>, locale: Locale) -> Result<MetaSi
         let guides: Vec<Page> = groups
             .guides
             .iter()
-            .map(|slug| Doc::page_from_slug(slug.replace("/docs/", "").as_str(), locale, true))
-            .collect::<Result<_, _>>()?;
+            .filter_map(|slug| slug.strip_prefix("/docs/"))
+            .filter_map(|slug| Doc::page_from_slug(slug, locale, true).ok())
+            .collect();
         let tutorial: Vec<Page> = groups
             .tutorial
             .iter()
-            .map(|slug| Doc::page_from_slug(slug.replace("/docs/", "").as_str(), locale, true))
-            .collect::<Result<_, _>>()?;
+            .filter_map(|slug| slug.strip_prefix("/docs/"))
+            .filter_map(|slug| Doc::page_from_slug(slug, locale, true).ok())
+            .collect();
         build_sublist(&mut entries, &guides, guides_label);
         build_sublist(&mut entries, &tutorial, tutorial_label);
     }


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Adds "Guides" and "Tutorials" sections in the `APIRef` section, similar to `DefaultAPIRef`.

### Motivation

This makes the `APIRef` sidebar slightly more consistent with `DefaultAPIRef`, and improves discoverability of API guides and tutorials.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Fixes https://github.com/mdn/rari/issues/223.
