### PR TITLE
chore(page-types): add `firefox-release-notes-active` page type

### DIFF
--- a/crates/rari-types/src/fm_types.rs
+++ b/crates/rari-types/src/fm_types.rs
@@ -109,6 +109,7 @@ pub enum PageType {
     XsltAxis,
     XsltFunction,
     FirefoxReleaseNotes,
+    FirefoxReleaseNotesActive,
 
     // Synthetic
     BlogPost,


### PR DESCRIPTION
### Description

Allowing a `firefox-release-notes-active` page type variant.

Renaming the page type will require an update in content after this PR has landed.

### Motivation

We're using some filtering logic in content to show pages in current active Firefox release cycle.

### Related issues and pull requests

- [x] https://github.com/mdn/content/pull/39761

Fixes #221 