### PR TITLE
fix: Added advertising page and the plus landing page to PSA pages.

### DIFF
--- a/crates/rari-doc/src/pages/types/spa.rs
+++ b/crates/rari-doc/src/pages/types/spa.rs
@@ -412,6 +412,24 @@ static BASIC_SPAS: LazyLock<HashMap<String, BuildSPA>> = LazyLock::new(|| {
                     },
                 ),
                 (
+                    "advertising",
+                    BuildSPA {
+                        slug: Cow::Borrowed("advertising"),
+                        page_title: Cow::Borrowed("Advertise with us"),
+                        template: SpaBuildTemplate::SpaAdvertise,
+                        ..Default::default()
+                    },
+                ),
+                (
+                    "plus",
+                    BuildSPA {
+                        slug: Cow::Borrowed("plus"),
+                        page_title: Cow::Borrowed(MDN_PLUS_TITLE),
+                        template: SpaBuildTemplate::SpaPlusLanding,
+                        ..Default::default()
+                    },
+                ),
+                (
                     "plus/ai-help",
                     BuildSPA {
                         slug: Cow::Borrowed("plus/ai-help"),


### PR DESCRIPTION
### Description

Some spa pages were missing from rari. This adds the /advertise and /plus slugs to return the correct data.
