### PR TITLE
chore(sidebar): remove unused toggle class

### DIFF
--- a/crates/rari-doc/src/helpers/subpages.rs
+++ b/crates/rari-doc/src/helpers/subpages.rs
@@ -268,7 +268,7 @@ pub fn list_sub_pages_flattened_grouped_internal(
     for (prefix, group) in grouped {
         let keep_group = group.len() > 2;
         if keep_group {
-            out.push_str("<li class=\"toggle\"><details><summary>");
+            out.push_str("<li><details><summary>");
             out.push_str(&html_escape::encode_safe(prefix));
             out.push_str("-*</summary><ol>");
         }

--- a/crates/rari-doc/src/html/sidebar.rs
+++ b/crates/rari-doc/src/html/sidebar.rs
@@ -593,9 +593,6 @@ impl SidebarMetaEntry {
         if self.section {
             out.push_str(" class=\"section\"");
         }
-        if self.details.is_set() || !matches!(self.children, MetaChildren::None) {
-            out.push_str(" class=\"toggle\"");
-        }
         if self.details.is_set() {
             out.push_str("><details");
             if self.details.is_open() {


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Removes the unused toggle class from sidebar `li`s.

### Motivation

Cleanup.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
