### PR TITLE
enhance(sidebar): wrap unlinked summary text in span

### DIFF
--- a/crates/rari-doc/src/helpers/subpages.rs
+++ b/crates/rari-doc/src/helpers/subpages.rs
@@ -268,9 +268,9 @@ pub fn list_sub_pages_flattened_grouped_internal(
     for (prefix, group) in grouped {
         let keep_group = group.len() > 2;
         if keep_group {
-            out.push_str("<li class=\"toggle\"><details><summary>");
+            out.push_str("<li class=\"toggle\"><details><summary><span>");
             out.push_str(&html_escape::encode_safe(prefix));
-            out.push_str("-*</summary><ol>");
+            out.push_str("-*</span></summary><ol>");
         }
         for sub_page in group {
             write_li_with_badges(out, sub_page, locale, code, true)?;

--- a/crates/rari-doc/src/html/sidebar.rs
+++ b/crates/rari-doc/src/html/sidebar.rs
@@ -638,18 +638,15 @@ impl SidebarMetaEntry {
                 )?;
             }
             SidebarMetaEntryContent::Link { link: None, title } => {
-                let title = title.as_ref().map(|t| l10n.lookup(t.as_str(), locale));
-                if self.code {
-                    out.push_str("<code>");
-                } else {
-                    out.push_str("<span>");
-                }
-                out.push_str(title.unwrap_or_default());
-                if self.code {
-                    out.push_str("</code>");
-                } else {
-                    out.push_str("</span>");
-                }
+                let title = title
+                    .as_ref()
+                    .map(|t| l10n.lookup(t.as_str(), locale))
+                    .unwrap_or_default();
+                out.extend([
+                    if self.code { "<code>" } else { "<span>" },
+                    title,
+                    if self.code { "</code>" } else { "</span>" },
+                ]);
             }
             SidebarMetaEntryContent::Page(page) => {
                 render_link_from_page(

--- a/crates/rari-doc/src/html/sidebar.rs
+++ b/crates/rari-doc/src/html/sidebar.rs
@@ -644,10 +644,14 @@ impl SidebarMetaEntry {
                 let title = title.as_ref().map(|t| l10n.lookup(t.as_str(), locale));
                 if self.code {
                     out.push_str("<code>");
+                } else {
+                    out.push_str("<span>");
                 }
                 out.push_str(title.unwrap_or_default());
                 if self.code {
                     out.push_str("</code>");
+                } else {
+                    out.push_str("</span>");
                 }
             }
             SidebarMetaEntryContent::Page(page) => {


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Wraps unlinked `<summary>` content in a `<span>` (unless it is already wrapped in a `<code>`).

### Motivation

Allows us to have consistent padding.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
