### PR TITLE
feat(sidebar): support args in fm sidebar

### DIFF
--- a/crates/rari-doc/src/error.rs
+++ b/crates/rari-doc/src/error.rs
@@ -116,6 +116,8 @@ pub enum DocError {
     SlugFolderMismatch(String, String, String),
     #[error("Fatal error reading docs")]
     DocsReadError,
+    #[error("No RariEnv for Page")]
+    NoRariEnv,
 }
 
 /// Represents various errors that can occur while processing URLs.

--- a/crates/rari-doc/src/pages/build.rs
+++ b/crates/rari-doc/src/pages/build.rs
@@ -38,6 +38,7 @@ use crate::pages::types::curriculum::{
 };
 use crate::pages::types::doc::Doc;
 use crate::pages::types::spa::SPA;
+use crate::pages::types::utils::FmTempl;
 use crate::specs::extract_specifications;
 use crate::templ::render::{decode_ref, render, Rendered};
 use crate::translations::get_other_translations_for;
@@ -292,7 +293,11 @@ fn build_doc(doc: &Doc) -> Result<BuiltPage, DocError> {
             summary,
             popularity,
             no_indexing,
-            sidebar_macro: doc.meta.sidebar.first().cloned(),
+            sidebar_macro: doc
+                .meta
+                .sidebar
+                .first()
+                .map(|s| FmTempl::name(s).to_string()),
             source: Source {
                 folder,
                 filename,

--- a/crates/rari-doc/src/pages/types/doc.rs
+++ b/crates/rari-doc/src/pages/types/doc.rs
@@ -19,6 +19,7 @@ use validator::Validate;
 use crate::cached_readers::{doc_page_from_static_files, CACHED_DOC_PAGE_FILES};
 use crate::error::DocError;
 use crate::pages::page::{Page, PageCategory, PageLike, PageReader, PageWriter};
+use crate::pages::types::utils::FmTempl;
 use crate::resolve::{build_url, url_to_folder_path};
 use crate::utils::{
     locale_and_typ_from_path, root_for_locale, serialize_t_or_vec, split_fm, t_or_vec,
@@ -79,7 +80,7 @@ pub struct FrontMatter {
         default,
         skip_serializing_if = "Vec::is_empty"
     )]
-    pub sidebar: Vec<String>,
+    pub sidebar: Vec<FmTempl>,
     #[serde(flatten)]
     pub other: HashMap<String, Value>,
 }
@@ -95,7 +96,7 @@ pub struct Meta {
     pub browser_compat: Vec<String>,
     pub spec_urls: Vec<String>,
     pub original_slug: Option<String>,
-    pub sidebar: Vec<String>,
+    pub sidebar: Vec<FmTempl>,
     pub locale: Locale,
     pub full_path: PathBuf,
     pub path: PathBuf,

--- a/crates/rari-doc/src/pages/types/mod.rs
+++ b/crates/rari-doc/src/pages/types/mod.rs
@@ -5,3 +5,4 @@ pub mod doc;
 pub mod generic;
 pub mod spa;
 pub mod spa_homepage;
+pub mod utils;

--- a/crates/rari-doc/src/pages/types/utils.rs
+++ b/crates/rari-doc/src/pages/types/utils.rs
@@ -1,0 +1,117 @@
+use std::fmt;
+
+use serde::de::{self, MapAccess, SeqAccess, Visitor};
+use serde::ser::SerializeMap;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum FmTempl {
+    NoArgs(String),
+    WithArgs { name: String, args: Vec<String> },
+}
+
+impl FmTempl {
+    pub fn name(&self) -> &str {
+        match self {
+            FmTempl::NoArgs(name) => name,
+            FmTempl::WithArgs { name, .. } => name,
+        }
+        .as_str()
+    }
+}
+
+impl<'de> Deserialize<'de> for FmTempl {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct EntryVisitor;
+
+        impl<'de> Visitor<'de> for EntryVisitor {
+            type Value = FmTempl;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("either a string or a single-key map to a list of strings")
+            }
+
+            fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(FmTempl::NoArgs(s.to_owned()))
+            }
+
+            fn visit_string<E>(self, s: String) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(FmTempl::NoArgs(s))
+            }
+
+            fn visit_seq<A>(self, mut _seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                Err(de::Error::custom(
+                    "unexpected sequence; expected a map or string",
+                ))
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                if let Some((key, val)) = map.next_entry::<String, Vec<String>>()? {
+                    if map.next_entry::<String, Vec<String>>()?.is_some() {
+                        return Err(de::Error::custom("map has more than one key"));
+                    }
+                    Ok(FmTempl::WithArgs {
+                        name: key,
+                        args: val,
+                    })
+                } else {
+                    Err(de::Error::custom("empty map is not allowed"))
+                }
+            }
+        }
+
+        deserializer.deserialize_any(EntryVisitor)
+    }
+}
+
+impl Serialize for FmTempl {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            FmTempl::NoArgs(s) => serializer.serialize_str(s),
+            FmTempl::WithArgs { name, args } => {
+                let mut map = serializer.serialize_map(Some(1))?;
+                map.serialize_entry(name, &args)?;
+                map.end()
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_sidebar_fm() {
+        let s = r#"["foobar", { "foo": ["bar", "2000"]}]"#;
+        let j: Vec<FmTempl> = serde_json::from_str(s).unwrap();
+        let sb = vec![
+            FmTempl::NoArgs("foobar".to_string()),
+            FmTempl::WithArgs {
+                name: "foo".to_string(),
+                args: vec!["bar".to_string(), "2000".to_string()],
+            },
+        ];
+        assert_eq!(j, sb);
+        let j = serde_yaml_ng::to_string(&sb).unwrap();
+        assert_eq!(j, "- foobar\n- foo:\n  - bar\n  - '2000'\n");
+    }
+}

--- a/crates/rari-doc/src/templ/templs/mod.rs
+++ b/crates/rari-doc/src/templ/templs/mod.rs
@@ -58,6 +58,10 @@ pub static TEMPL_MAP: LazyLock<Vec<&'static Templ>> =
 pub static TEMPL_MAPPING: LazyLock<HashMap<&'static str, &'static Templ>> =
     LazyLock::new(|| inventory::iter::<Templ>().map(|t| (t.name, t)).collect());
 
+pub fn exists(name: &str) -> bool {
+    TEMPL_MAPPING.contains_key(name)
+}
+
 pub fn invoke(
     env: &RariEnv,
     name: &str,


### PR DESCRIPTION
### Description

Support sidebars that need arguments in the frontmatter.
Syntax is:

```
sidebar:
  - defaultapisidebar: ["Audio Output Devices API"]
```
