### PR TITLE
feat(homepage): use data from generic content

### DIFF
--- a/crates/rari-doc/src/cached_readers.rs
+++ b/crates/rari-doc/src/cached_readers.rs
@@ -761,11 +761,18 @@ pub struct PaginationData {
     pub num_pages: usize,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct HomePageData {
+    pub featured_articles: Vec<String>,
+    pub latest_news: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum SPAData {
     BlogIndex(PaginationData),
-    HomePage,
+    HomePage(HomePageData),
     NotFound,
     #[serde(untagged)]
     BasicSPA(BasicSPA),

--- a/crates/rari-doc/src/pages/json.rs
+++ b/crates/rari-doc/src/pages/json.rs
@@ -798,6 +798,7 @@ pub struct HomePageLatestNewsItem {
     pub author: Option<String>,
     pub source: NameUrl,
     pub published_at: NaiveDate,
+    pub summary: String,
 }
 
 /// Represents a recent contribution item on the home page.

--- a/crates/rari-doc/src/pages/types/spa.rs
+++ b/crates/rari-doc/src/pages/types/spa.rs
@@ -36,7 +36,7 @@ pub struct SPA {
     pub url: String,
     pub locale: Locale,
     pub page_type: PageType,
-    pub data: SPAData,
+    pub data: &'static SPAData,
     pub base_slug: Cow<'static, str>,
     pub page_description: Option<&'static str>,
     pub template: SpaBuildTemplate,
@@ -70,7 +70,7 @@ impl SPA {
                     ),
                     locale,
                     page_type: PageType::SPA,
-                    data: build_spa.data,
+                    data: &build_spa.data,
                     base_slug: Cow::Owned(concat_strs!("/", locale.as_url_str(), "/")),
                     page_description: build_spa.page_description.as_deref(),
                     template: build_spa.template,
@@ -162,29 +162,19 @@ impl SPA {
                 },
                 self.template,
             )))),
-            SPAData::HomePage => Ok(BuiltPage::Home(Box::new(HomePage::Homepage(
+            SPAData::HomePage(home_page_data) => Ok(BuiltPage::Home(Box::new(HomePage::Homepage(
                 JsonHomePage {
                     url: concat_strs!("/", self.locale().as_url_str(), "/", self.slug),
                     page_title: self.page_title,
                     hy_data: JsonHomePageSPAHyData {
                         page_description: self.page_description,
                         featured_articles: featured_articles(
-                            &[
-                                "/en-US/blog/javascript-temporal-is-coming/",
-                                "/en-US/docs/Web/CSS/CSS_anchor_positioning",
-                                "/en-US/docs/Web/API/View_Transition_API/Using",
-                                "/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal",
-                            ],
+                            &home_page_data.featured_articles,
                             self.locale,
                         )?,
                         featured_contributor: featured_contributor(self.locale)?,
                         latest_news: ItemContainer {
-                            items: latest_news(&[
-                                "/en-US/blog/mdn-2024-content-projects/",
-                                "/en-US/blog/curriculum-learn-web-development/",
-                                "/en-US/blog/new-community-page/",
-                                "/en-US/blog/javascript-intl-segmenter-i18n/",
-                            ])?,
+                            items: latest_news(&home_page_data.latest_news)?,
                         },
                         recent_contributions: ItemContainer {
                             items: recent_contributions()?,
@@ -337,17 +327,6 @@ static BASIC_SPAS: LazyLock<HashMap<String, BuildSPA>> = LazyLock::new(|| {
         .chain(blog_indices())
         .chain(
             [
-                (
-                    "",
-                    BuildSPA {
-                        slug: Cow::Borrowed(""),
-                        page_title: Cow::Borrowed("MDN Web Docs"),
-                        trailing_slash: true,
-                        data: SPAData::HomePage,
-                        template: SpaBuildTemplate::SpaHomepage,
-                        ..Default::default()
-                    },
-                ),
                 (
                     "404",
                     BuildSPA {

--- a/crates/rari-doc/src/pages/types/spa_homepage.rs
+++ b/crates/rari-doc/src/pages/types/spa_homepage.rs
@@ -18,7 +18,7 @@ use crate::pages::json::{
 };
 use crate::pages::page::{Page, PageLike};
 
-pub fn latest_news(urls: &[&str]) -> Result<Vec<HomePageLatestNewsItem>, DocError> {
+pub fn latest_news(urls: &[String]) -> Result<Vec<HomePageLatestNewsItem>, DocError> {
     urls.iter()
         .filter_map(|url| match Page::from_url_with_fallback(url) {
             Ok(Page::BlogPost(post)) => Some(Ok(HomePageLatestNewsItem {
@@ -30,6 +30,7 @@ pub fn latest_news(urls: &[&str]) -> Result<Vec<HomePageLatestNewsItem>, DocErro
                     url: concat_strs!("/", Locale::default().as_url_str(), "/blog/"),
                 },
                 published_at: post.meta.date,
+                summary: post.meta.description.clone(),
             })),
             Err(DocError::PageNotFound(url, category)) => {
                 tracing::warn!("page not found {url} ({category:?})");
@@ -45,7 +46,7 @@ pub fn latest_news(urls: &[&str]) -> Result<Vec<HomePageLatestNewsItem>, DocErro
 }
 
 pub fn featured_articles(
-    urls: &[&str],
+    urls: &[String],
     locale: Locale,
 ) -> Result<Vec<HomePageFeaturedArticle>, DocError> {
     urls.iter()


### PR DESCRIPTION
### Description

Use [mdn/generic-content ](https://github.com/mdn/generic-content) to build homepage.
