### PR TITLE
feat(client): add GitHub token support for API requests

### DIFF
--- a/crates/rari-deps/src/client.rs
+++ b/crates/rari-deps/src/client.rs
@@ -1,9 +1,38 @@
 use reqwest::blocking::Response;
+use url::{Url, Host};
 
 pub fn get(url: impl AsRef<str>) -> reqwest::Result<Response> {
-    reqwest::blocking::ClientBuilder::new()
-        .user_agent("mdn/rari")
-        .build()?
+    let mut client = reqwest::blocking::ClientBuilder::new().user_agent("mdn/rari");
+
+    // check if the URL's host is api.github.com
+    if is_github_url(url.as_ref()) {
+        // get the GitHub token from the environment
+        if let Ok(token) = std::env::var("GITHUB_TOKEN") {
+            client = client
+                .default_headers(
+                    reqwest::header::HeaderMap::from_iter(vec![(
+                        reqwest::header::AUTHORIZATION,
+                        format!("Bearer {}", token).parse().unwrap(),
+                    )]),
+                );
+        }
+    }
+
+    client.build()?
         .get(url.as_ref())
         .send()
+}
+
+fn is_github_url(url: impl AsRef<str>) -> bool {
+    let url = Url::parse(url.as_ref());
+    if let Ok(url) = url {
+        match url.host() {
+            Some(Host::Domain(host)) => {
+                host == "api.github.com"
+            }
+            _ => false,
+        }
+    } else {
+        false
+    }
 }

--- a/crates/rari-deps/src/client.rs
+++ b/crates/rari-deps/src/client.rs
@@ -1,5 +1,5 @@
 use reqwest::blocking::Response;
-use url::{Url, Host};
+use url::{Host, Url};
 
 pub fn get(url: impl AsRef<str>) -> reqwest::Result<Response> {
     let mut client = reqwest::blocking::ClientBuilder::new().user_agent("mdn/rari");
@@ -8,28 +8,21 @@ pub fn get(url: impl AsRef<str>) -> reqwest::Result<Response> {
     if is_github_url(url.as_ref()) {
         // get the GitHub token from the environment
         if let Ok(token) = std::env::var("GITHUB_TOKEN") {
-            client = client
-                .default_headers(
-                    reqwest::header::HeaderMap::from_iter(vec![(
-                        reqwest::header::AUTHORIZATION,
-                        format!("Bearer {}", token).parse().unwrap(),
-                    )]),
-                );
+            client = client.default_headers(reqwest::header::HeaderMap::from_iter(vec![(
+                reqwest::header::AUTHORIZATION,
+                format!("Bearer {}", token).parse().unwrap(),
+            )]));
         }
     }
 
-    client.build()?
-        .get(url.as_ref())
-        .send()
+    client.build()?.get(url.as_ref()).send()
 }
 
 fn is_github_url(url: impl AsRef<str>) -> bool {
     let url = Url::parse(url.as_ref());
     if let Ok(url) = url {
         match url.host() {
-            Some(Host::Domain(host)) => {
-                host == "api.github.com"
-            }
+            Some(Host::Domain(host)) => host == "api.github.com",
             _ => false,
         }
     } else {

--- a/crates/rari-deps/src/client.rs
+++ b/crates/rari-deps/src/client.rs
@@ -1,31 +1,22 @@
 use reqwest::blocking::Response;
-use url::{Host, Url};
+use url::Url;
 
-pub fn get(url: impl AsRef<str>) -> reqwest::Result<Response> {
-    let mut client = reqwest::blocking::ClientBuilder::new().user_agent("mdn/rari");
+use crate::error::DepsError;
+
+pub fn get(url: impl AsRef<str>) -> Result<Response, DepsError> {
+    let url = Url::parse(url.as_ref())?;
+    let mut req_builder = reqwest::blocking::ClientBuilder::new()
+        .user_agent("mdn/rari")
+        .build()?
+        .get(url.as_ref());
 
     // check if the URL's host is api.github.com
-    if is_github_url(url.as_ref()) {
+    if url.host_str() == Some("api.github.com") {
         // get the GitHub token from the environment
         if let Ok(token) = std::env::var("GITHUB_TOKEN") {
-            client = client.default_headers(reqwest::header::HeaderMap::from_iter(vec![(
-                reqwest::header::AUTHORIZATION,
-                format!("Bearer {}", token).parse().unwrap(),
-            )]));
+            req_builder = req_builder.bearer_auth(token);
         }
     }
 
-    client.build()?.get(url.as_ref()).send()
-}
-
-fn is_github_url(url: impl AsRef<str>) -> bool {
-    let url = Url::parse(url.as_ref());
-    if let Ok(url) = url {
-        match url.host() {
-            Some(Host::Domain(host)) => host == "api.github.com",
-            _ => false,
-        }
-    } else {
-        false
-    }
+    Ok(req_builder.send()?)
 }

--- a/crates/rari-deps/src/error.rs
+++ b/crates/rari-deps/src/error.rs
@@ -20,4 +20,6 @@ pub enum DepsError {
     InvalidGitHubVersion,
     #[error("Invalid github version")]
     VersionNotFound,
+    #[error("Invalid url: {0}")]
+    UrlError(#[from] url::ParseError),
 }


### PR DESCRIPTION
### Description

Add GitHub token support for API requests, this is a part of fix to resolve the problem described on discord (Got `Error: invalid type: map, expected a sequence` when running [yarn build in GitHub workflows](https://github.com/mdn/content/blob/main/.github/workflows/pr-test.yml#L109)):

![image](https://github.com/user-attachments/assets/f7e1f662-0b0a-4ce7-a91d-18e593b1df04)

I finally figure out what is going on: The error was not caused by "updating xyz To va.b.c", but by rari encountering a rate limiting problem when trying to [get the release info list on GitHub using GitHub API](https://github.com/mdn/rari/blob/82b80b07c462d047648c2c36a242caa8163d5ba5/crates/rari-deps/src/github_release.rs#L21-L26).

To verify this, you can remove the cached version check info, set the wrong **GITHUB_TOKEN** in the environment variable, and you will get output similar to the following:

![image](https://github.com/user-attachments/assets/84d07d3f-6ab7-46cc-adb0-457371294eeb)

> Note: I am not sure whether we need to do similar authorization for requests to "github.com". Currently, github's documentation does not describe a rate limit policy for github.com.

### Motivation

Our CI for building preview documents occasionally fails to build documents in the same way as above.
