### PR TITLE
fix(serve): return 404 for UrlError::InvalidUrl

### DIFF
--- a/crates/rari-cli/serve.rs
+++ b/crates/rari-cli/serve.rs
@@ -12,7 +12,7 @@ use axum::routing::{get, put};
 use axum::{Json, Router};
 use rari_doc::cached_readers::wiki_histories;
 use rari_doc::contributors::contributors_txt;
-use rari_doc::error::DocError;
+use rari_doc::error::{DocError, UrlError};
 use rari_doc::issues::{to_display_issues, IN_MEMORY, ISSUE_COUNTER_F};
 use rari_doc::pages::json::BuiltPage;
 use rari_doc::pages::page::{Page, PageBuilder, PageCategory, PageLike};
@@ -272,7 +272,10 @@ impl IntoResponse for AppError {
     fn into_response(self) -> Response<Body> {
         match self.0 {
             ToolError::DocError(
-                DocError::RariIoError(_) | DocError::IOError(_) | DocError::PageNotFound(..),
+                DocError::RariIoError(_)
+                | DocError::IOError(_)
+                | DocError::PageNotFound(..)
+                | DocError::UrlError(UrlError::InvalidUrl),
             ) => (StatusCode::NOT_FOUND, "").into_response(),
 
             _ => (StatusCode::INTERNAL_SERVER_ERROR, error!("🤷: {}", self.0)).into_response(),

--- a/crates/rari-doc/src/resolve.rs
+++ b/crates/rari-doc/src/resolve.rs
@@ -20,7 +20,7 @@ use std::str::FromStr;
 use rari_types::locale::Locale;
 use rari_utils::concat_strs;
 
-use crate::error::DocError;
+use crate::error::{DocError, UrlError};
 use crate::pages::page::{PageCategory, PageLike};
 use crate::pages::types::generic::Generic;
 use crate::pages::types::spa::SPA;
@@ -116,7 +116,7 @@ pub struct UrlMeta<'a> {
 /// This function will return an error if:
 /// - The URL does not contain a recognizable locale.
 /// - The URL does not match any known patterns for documentation pages, blog posts, curriculum pages, etc.
-pub fn url_meta_from(url: &str) -> Result<UrlMeta<'_>, DocError> {
+pub fn url_meta_from(url: &str) -> Result<UrlMeta<'_>, UrlError> {
     let mut split = url[..url.find('#').unwrap_or(url.len())]
         .splitn(4, '/')
         .skip(1);
@@ -153,10 +153,7 @@ pub fn url_meta_from(url: &str) -> Result<UrlMeta<'_>, DocError> {
             } else if Generic::is_generic(slug, locale) {
                 (PageCategory::GenericPage, slug)
             } else {
-                return Err(DocError::PageNotFound(
-                    url.to_string(),
-                    PageCategory::GenericPage,
-                ));
+                return Err(UrlError::InvalidUrl);
             }
         }
     };
@@ -288,7 +285,7 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_url_to_path() -> Result<(), DocError> {
+    fn test_url_to_path() -> Result<(), UrlError> {
         let url = "/en-US/docs/Web/HTML";
         let UrlMeta {
             folder_path,

--- a/crates/rari-doc/src/resolve.rs
+++ b/crates/rari-doc/src/resolve.rs
@@ -20,7 +20,7 @@ use std::str::FromStr;
 use rari_types::locale::Locale;
 use rari_utils::concat_strs;
 
-use crate::error::{DocError, UrlError};
+use crate::error::DocError;
 use crate::pages::page::{PageCategory, PageLike};
 use crate::pages::types::generic::Generic;
 use crate::pages::types::spa::SPA;
@@ -116,7 +116,7 @@ pub struct UrlMeta<'a> {
 /// This function will return an error if:
 /// - The URL does not contain a recognizable locale.
 /// - The URL does not match any known patterns for documentation pages, blog posts, curriculum pages, etc.
-pub fn url_meta_from(url: &str) -> Result<UrlMeta<'_>, UrlError> {
+pub fn url_meta_from(url: &str) -> Result<UrlMeta<'_>, DocError> {
     let mut split = url[..url.find('#').unwrap_or(url.len())]
         .splitn(4, '/')
         .skip(1);
@@ -153,7 +153,10 @@ pub fn url_meta_from(url: &str) -> Result<UrlMeta<'_>, UrlError> {
             } else if Generic::is_generic(slug, locale) {
                 (PageCategory::GenericPage, slug)
             } else {
-                return Err(UrlError::InvalidUrl);
+                return Err(DocError::PageNotFound(
+                    url.to_string(),
+                    PageCategory::GenericPage,
+                ));
             }
         }
     };
@@ -285,7 +288,7 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_url_to_path() -> Result<(), UrlError> {
+    fn test_url_to_path() -> Result<(), DocError> {
         let url = "/en-US/docs/Web/HTML";
         let UrlMeta {
             folder_path,


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Falls back to `DocError::PageNotFound()` for unknown URLs.

### Motivation

Avoids HTTP 500 for unknown pages.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Fixes https://github.com/mdn/rari/issues/248.