### PR TITLE
fix(serve): avoid fallback for json

### DIFF
--- a/crates/rari-cli/serve.rs
+++ b/crates/rari-cli/serve.rs
@@ -142,7 +142,7 @@ async fn get_json_handler(req: Request) -> Result<Response, AppError> {
     let span = span!(Level::ERROR, "url", "{}", url);
     let _enter1 = span.enter();
     let url = url.strip_suffix("/index.json").unwrap_or(url);
-    match Page::from_url_with_fallback(url) {
+    match Page::from_url(url) {
         Ok(page) => {
             let file = page.full_path().to_string_lossy();
             let span = span!(


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Avoids en-US fallback when serving pages and `index.json`.

### Motivation

Ensures that an untranslated page yields HTTP 404, instead of an HTTP 200 with the English content.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Fixes https://github.com/mdn/rari/issues/250.