### PR TITLE
fix(sidebar): avoid empty span

### DIFF
--- a/crates/rari-doc/src/html/sidebar.rs
+++ b/crates/rari-doc/src/html/sidebar.rs
@@ -677,20 +677,21 @@ impl SidebarMetaEntry {
                     },
                 )?;
             }
-            SidebarMetaEntryContent::Link { link: None, title } => {
-                let title = title
-                    .as_ref()
-                    .map(|t| l10n.lookup(t.as_str(), locale))
-                    .unwrap_or_default();
-
-                if !title.is_empty() {
-                    out.extend([
-                        if self.code { "<code>" } else { "<span>" },
-                        title,
-                        if self.code { "</code>" } else { "</span>" },
-                    ]);
-                }
+            SidebarMetaEntryContent::Link {
+                link: None,
+                title: Some(title),
+            } => {
+                let title = l10n.lookup(title.as_str(), locale);
+                out.extend([
+                    if self.code { "<code>" } else { "<span>" },
+                    title,
+                    if self.code { "</code>" } else { "</span>" },
+                ]);
             }
+            SidebarMetaEntryContent::Link {
+                link: None,
+                title: None,
+            } => {}
             SidebarMetaEntryContent::Page(page) => {
                 render_link_from_page(
                     out,

--- a/crates/rari-doc/src/html/sidebar.rs
+++ b/crates/rari-doc/src/html/sidebar.rs
@@ -682,11 +682,14 @@ impl SidebarMetaEntry {
                     .as_ref()
                     .map(|t| l10n.lookup(t.as_str(), locale))
                     .unwrap_or_default();
-                out.extend([
-                    if self.code { "<code>" } else { "<span>" },
-                    title,
-                    if self.code { "</code>" } else { "</span>" },
-                ]);
+
+                if !title.is_empty() {
+                    out.extend([
+                        if self.code { "<code>" } else { "<span>" },
+                        title,
+                        if self.code { "</code>" } else { "</span>" },
+                    ]);
+                }
             }
             SidebarMetaEntryContent::Page(page) => {
                 render_link_from_page(


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Avoids empty spans in the sidebar.

### Motivation

Noticed empty `<span></span>` on https://developer.mozilla.org/en-US/docs/Web/CSS/Layout_cookbook (in the `<li>` following the `Layout cookbook` link in the sidebar), after adding padding in https://github.com/mdn/fred/commit/6befb4f15be2b2f2144817f9753ea4a2e6dd7e3e.

### Additional details

Visually noticable here: https://fred.review.mdn.allizom.net/en-US/docs/Web/CSS/Layout_cookbook

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
