### PR TITLE
feat(updates): allow skip updates from env

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,7 +136,7 @@ self_update = { version = "0.42", default-features = false, features = [
   "compression-flate2",
   "compression-zip-deflate",
 ] }
-clap = { version = "4.5.1", features = ["derive"] }
+clap = { version = "4.5.1", features = ["derive", "env"] }
 clap-verbosity-flag = { version = "3", features = ["tracing"] }
 tabwriter = "1"
 axum = "0.8"

--- a/crates/rari-cli/main.rs
+++ b/crates/rari-cli/main.rs
@@ -57,7 +57,7 @@ mod serve;
 #[command(propagate_version = true)]
 struct Cli {
     /// Skip updating dependencies (bcd, webref, ...)
-    #[arg(short, long)]
+    #[arg(short, long, env = "RARI_SKIP_UPDATES")]
     skip_updates: bool,
     #[command(flatten)]
     verbose: Verbosity,


### PR DESCRIPTION
### Description

Use `RARI_SKIP_UPDATES=true` to enable skip updates via env. If your dependencies are not in place or to outdated this is unsupported and will crash rari.

### Motivation

Easy the use of rari w/o internet.