### PR TITLE
feat(json): update schemars and inline renderer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2737,6 +2737,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.103",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2966,12 +2986,13 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.22"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
 dependencies = [
  "chrono",
  "dyn-clone",
+ "ref-cast",
  "schemars_derive",
  "serde",
  "serde_json",
@@ -2980,9 +3001,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.22"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+checksum = "5016d94c77c6d32f0b8e08b781f7dc8a90c2007d4e77472cc2807bc10a8438fe"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ console = "0.15"
 sha2 = "0.10"
 dashmap = { version = "6", features = ["serde"] }
 serde_yaml_ng = "0.10"
-schemars = { version = "0.8", features = ["chrono", "url"] }
+schemars = { version = "0.9", features = ["chrono04", "url2"] }
 pretty_yaml = "0.5"
 yaml_parser = "0.2"
 const_format = "0.2"

--- a/crates/rari-cli/serve.rs
+++ b/crates/rari-cli/serve.rs
@@ -1,6 +1,5 @@
 use std::cmp::Ordering;
 use std::collections::HashMap;
-use std::ops::{Deref, DerefMut};
 use std::str::FromStr;
 use std::sync::atomic::{AtomicI64, AtomicU64};
 
@@ -16,7 +15,6 @@ use rari_doc::error::{DocError, UrlError};
 use rari_doc::issues::{to_display_issues, IN_MEMORY, ISSUE_COUNTER_F};
 use rari_doc::pages::json::BuiltPage;
 use rari_doc::pages::page::{Page, PageBuilder, PageCategory, PageLike};
-use rari_doc::pages::templates::DocPage;
 use rari_doc::pages::types::doc::Doc;
 use rari_doc::reader::read_docs_parallel;
 use rari_doc::resolve::{url_meta_from, UrlMeta};
@@ -156,7 +154,6 @@ async fn get_json_handler(req: Request) -> Result<Response, AppError> {
             let mut json = page.build()?;
             tracing::info!("{url}");
             if let BuiltPage::Doc(json_doc) = &mut json {
-                let DocPage::Doc(json_doc) = json_doc.deref_mut();
                 let m = IN_MEMORY.get_events();
                 let (_, req_issues) = m
                     .remove(page.full_path().to_string_lossy().as_ref())
@@ -200,7 +197,6 @@ fn get_contributors(url: &str) -> Result<String, AppError> {
     let page = Page::from_url_with_fallback(url)?;
     let json = page.build()?;
     let github_file_url = if let BuiltPage::Doc(ref doc) = json {
-        let DocPage::Doc(doc) = doc.deref();
         &doc.doc.source.github_url
     } else {
         ""

--- a/crates/rari-data/src/baseline.rs
+++ b/crates/rari-data/src/baseline.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 use indexmap::IndexMap;
 use rari_utils::concat_strs;
 use rari_utils::io::read_to_string;
-use schemars::schema::Schema;
+use schemars::Schema;
 use schemars::{JsonSchema, SchemaGenerator};
 use serde::de::{self, value, SeqAccess, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -282,7 +282,7 @@ pub enum BaselineHighLow {
 
 // Deriving JsonSchema fails to type the false case. So we do it manually.
 impl JsonSchema for BaselineHighLow {
-    fn schema_name() -> String {
+    fn schema_name() -> Cow<'static, str> {
         "BaselineHighLow".into()
     }
 

--- a/crates/rari-doc/src/build.rs
+++ b/crates/rari-doc/src/build.rs
@@ -8,7 +8,6 @@ use std::collections::HashMap;
 use std::fs::{self, File};
 use std::io::{BufWriter, Write};
 use std::iter::once;
-use std::ops::DerefMut;
 use std::path::PathBuf;
 
 use chrono::{NaiveDateTime, Utc};
@@ -32,7 +31,6 @@ use crate::issues::{to_display_issues, IN_MEMORY};
 use crate::pages::build::copy_additional_files;
 use crate::pages::json::{BuiltPage, JsonDocMetadata};
 use crate::pages::page::{Page, PageBuilder, PageLike};
-use crate::pages::templates::DocPage;
 use crate::pages::types::spa::SPA;
 use crate::resolve::url_to_folder_path;
 use crate::rss::create_rss;
@@ -73,8 +71,7 @@ pub fn build_single_page(page: &Page) -> Result<(BuiltPage, String), DocError> {
     let _enter = span.enter();
     let mut built_page = page.build()?;
     if settings().json_issues {
-        if let BuiltPage::Doc(inner) = &mut built_page {
-            let DocPage::Doc(json_doc) = inner.deref_mut();
+        if let BuiltPage::Doc(json_doc) = &mut built_page {
             let flaws = if let Some(issues) = IN_MEMORY
                 .get_events()
                 .get(page.full_path().to_string_lossy().as_ref())
@@ -105,7 +102,6 @@ pub fn build_single_page(page: &Page) -> Result<(BuiltPage, String), DocError> {
 pub fn build_single_doc(page: &Page) -> Result<JsonDocMetadata, DocError> {
     let (built_doc, hash) = build_single_page(page)?;
     if let BuiltPage::Doc(json) = built_doc {
-        let DocPage::Doc(json) = *json;
         let meta = JsonDocMetadata::from_json_doc(json.doc, hash);
 
         let out_path = build_out_root()

--- a/crates/rari-doc/src/pages/json.rs
+++ b/crates/rari-doc/src/pages/json.rs
@@ -13,14 +13,15 @@ use rari_types::locale::{Locale, Native};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use super::templates::{
-    BlogPage, ContributorSpotlightPage, CurriculumPage, DocPage, GenericPage, HomePage, SpaPage,
-};
 use super::types::contributors::Usernames;
 use super::types::curriculum::{CurriculumIndexEntry, CurriculumSidebarEntry, Template, Topic};
 use crate::cached_readers::PaginationData;
 use crate::html::code::Code;
 use crate::issues::DisplayIssues;
+use crate::pages::templates::{
+    BlogRenderer, ContributorSpotlightRenderer, CurriculumRenderer, DocPageRenderer,
+    GenericRenderer, HomeRenderer, SpaRenderer,
+};
 use crate::pages::types::blog::BlogMeta;
 use crate::specs::Specification;
 use crate::utils::modified_dt;
@@ -379,6 +380,7 @@ pub struct JsonDocMetadata {
 pub struct JsonDocPage {
     pub doc: JsonDoc,
     pub url: String,
+    pub renderer: DocPageRenderer,
 }
 
 /// Represents an index of blog posts in the documentation system.
@@ -471,6 +473,7 @@ pub struct JsonCurriculumPage {
     #[serde(rename = "pageTitle")]
     pub page_title: String,
     pub locale: Locale,
+    pub renderer: CurriculumRenderer,
 }
 
 /// Represents a blog post in the system.
@@ -553,6 +556,7 @@ pub struct JsonBlogPostPage {
     pub hy_data: Option<BlogIndex>,
     #[serde(flatten)]
     pub common: CommonJsonData,
+    pub renderer: BlogRenderer,
 }
 
 /// Represents a contributor spotlight page in the documentation system.
@@ -610,6 +614,7 @@ pub struct JsonContributorSpotlightPage {
     pub hy_data: ContributorSpotlightHyData,
     #[serde(flatten)]
     pub common: CommonJsonData,
+    pub renderer: ContributorSpotlightRenderer,
 }
 
 /// Represents the different JSON artifacts of built pages.
@@ -621,19 +626,19 @@ pub struct JsonContributorSpotlightPage {
 #[serde(untagged)]
 pub enum BuiltPage {
     /// Represents a standard documentation page, backed by a Markdown source.
-    Doc(Box<DocPage>),
+    Doc(Box<JsonDocPage>),
     /// Represents a curriculum page, backed by a Markdown source
-    Curriculum(Box<CurriculumPage>),
+    Curriculum(Box<JsonCurriculumPage>),
     /// Represents a blog post, backed by a Markdown source
-    BlogPost(Box<BlogPage>),
+    BlogPost(Box<JsonBlogPostPage>),
     /// Represents a contributor spotlight page, backed by a Markdown source.
-    ContributorSpotlight(Box<ContributorSpotlightPage>),
+    ContributorSpotlight(Box<JsonContributorSpotlightPage>),
     /// Represents a generic page, i.e Observatory FAQ, About pages, etc.
-    GenericPage(Box<GenericPage>),
+    GenericPage(Box<JsonGenericPage>),
     /// Represents a basic single-page application. i.e. AI Help, Observatory, etc.
-    SPA(Box<SpaPage>),
+    SPA(Box<JsonSpaPage>),
     /// Represents the home page.
-    Home(Box<HomePage>),
+    Home(Box<JsonHomePage>),
 }
 
 /// Represents the previous and next navigation links by slug.
@@ -734,6 +739,7 @@ pub struct JsonSpaPage {
     pub url: String,
     #[serde(flatten)]
     pub common: CommonJsonData,
+    pub renderer: SpaRenderer,
 }
 
 /// Represents a featured article (usually a blog post or documentation page) on the home page.
@@ -898,6 +904,7 @@ pub struct JsonHomePage {
     pub url: String,
     #[serde(flatten)]
     pub common: CommonJsonData,
+    pub renderer: HomeRenderer,
 }
 
 /// Represents the data for a generic page in the system. Generic pages are used for various purposes,
@@ -946,6 +953,7 @@ pub struct JsonGenericPage {
     pub id: String,
     #[serde(flatten)]
     pub common: CommonJsonData,
+    pub renderer: GenericRenderer,
 }
 
 #[derive(Debug, Clone, Default, Serialize, JsonSchema)]

--- a/crates/rari-doc/src/pages/templates.rs
+++ b/crates/rari-doc/src/pages/templates.rs
@@ -1,12 +1,6 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use super::json::{
-    JsonBlogPostPage, JsonContributorSpotlightPage, JsonCurriculumPage, JsonDocPage,
-    JsonGenericPage, JsonHomePage, JsonSpaPage,
-};
-use super::types::{curriculum, generic};
-
 #[derive(Debug, Clone, Copy, Serialize, Default, Deserialize)]
 pub enum SpaBuildTemplate {
     #[default]
@@ -26,110 +20,63 @@ pub enum SpaBuildTemplate {
     SpaSearch,
 }
 
-#[derive(Debug, Clone, Serialize, JsonSchema)]
-#[serde(tag = "renderer")]
-pub enum SpaPage {
-    SpaUnknown(JsonSpaPage),
-    SpaNotFound(JsonSpaPage),
-    SpaObservatoryLanding(JsonSpaPage),
-    SpaObservatoryAnalyze(JsonSpaPage),
-    SpaAdvertise(JsonSpaPage),
-    SpaPlusLanding(JsonSpaPage),
-    SpaPlusCollections(JsonSpaPage),
-    SpaPlusCollectionsFrequentlyViewed(JsonSpaPage),
-    SpaPlusUpdates(JsonSpaPage),
-    SpaPlusSettings(JsonSpaPage),
-    SpaPlusAiHelp(JsonSpaPage),
-    SpaPlay(JsonSpaPage),
-    SpaSearch(JsonSpaPage),
+#[derive(Debug, Clone, Default, Serialize, JsonSchema)]
+pub enum DocPageRenderer {
+    #[default]
+    Doc,
 }
 
-impl SpaPage {
-    pub fn from_page_and_template(page: JsonSpaPage, template: SpaBuildTemplate) -> Self {
-        match template {
-            SpaBuildTemplate::SpaUnknown | SpaBuildTemplate::SpaHomepage => Self::SpaUnknown(page),
-            SpaBuildTemplate::SpaNotFound => Self::SpaNotFound(page),
-            SpaBuildTemplate::SpaObservatoryLanding => Self::SpaObservatoryLanding(page),
-            SpaBuildTemplate::SpaObservatoryAnalyze => Self::SpaObservatoryAnalyze(page),
-            SpaBuildTemplate::SpaAdvertise => Self::SpaAdvertise(page),
-            SpaBuildTemplate::SpaPlusLanding => Self::SpaPlusLanding(page),
-            SpaBuildTemplate::SpaPlusCollections => Self::SpaPlusCollections(page),
-            SpaBuildTemplate::SpaPlusCollectionsFrequentlyViewed => {
-                Self::SpaPlusCollectionsFrequentlyViewed(page)
-            }
-            SpaBuildTemplate::SpaPlusUpdates => Self::SpaPlusUpdates(page),
-            SpaBuildTemplate::SpaPlusSettings => Self::SpaPlusSettings(page),
-            SpaBuildTemplate::SpaPlusAiHelp => Self::SpaPlusAiHelp(page),
-            SpaBuildTemplate::SpaPlay => Self::SpaPlay(page),
-            SpaBuildTemplate::SpaSearch => Self::SpaSearch(page),
-        }
-    }
+#[derive(Debug, Clone, Default, Serialize, JsonSchema)]
+pub enum BlogRenderer {
+    #[default]
+    BlogPost,
+    BlogIndex,
 }
 
-#[derive(Debug, Clone, Serialize, JsonSchema)]
-#[serde(tag = "renderer")]
-pub enum GenericPage {
-    GenericDoc(JsonGenericPage),
-    GenericAbout(JsonGenericPage),
-    GenericCommunity(JsonGenericPage),
+#[derive(Debug, Clone, Default, Serialize, JsonSchema)]
+pub enum ContributorSpotlightRenderer {
+    #[default]
+    ContributorSpotlight,
 }
 
-#[derive(Debug, Clone, Serialize, JsonSchema)]
-#[serde(tag = "renderer")]
-pub enum DocPage {
-    Doc(JsonDocPage),
+#[derive(Debug, Clone, Default, Serialize, JsonSchema)]
+pub enum GenericRenderer {
+    #[default]
+    GenericDoc,
+    GenericAbout,
+    GenericCommunity,
 }
 
-#[derive(Debug, Clone, Serialize, JsonSchema)]
-#[serde(tag = "renderer")]
-pub enum BlogPage {
-    BlogPost(JsonBlogPostPage),
-    BlogIndex(JsonBlogPostPage),
+#[derive(Debug, Clone, Default, Serialize, JsonSchema)]
+pub enum SpaRenderer {
+    #[default]
+    SpaUnknown,
+    SpaNotFound,
+    SpaObservatoryLanding,
+    SpaObservatoryAnalyze,
+    SpaAdvertise,
+    SpaPlusLanding,
+    SpaPlusCollections,
+    SpaPlusCollectionsFrequentlyViewed,
+    SpaPlusUpdates,
+    SpaPlusSettings,
+    SpaPlusAiHelp,
+    SpaPlay,
+    SpaSearch,
 }
 
-impl GenericPage {
-    pub fn from_page_and_template(page: JsonGenericPage, template: generic::Template) -> Self {
-        match template {
-            generic::Template::GenericDoc => Self::GenericDoc(page),
-            generic::Template::GenericAbout => Self::GenericAbout(page),
-            generic::Template::GenericCommunity => Self::GenericCommunity(page),
-        }
-    }
+#[derive(Debug, Clone, Default, Serialize, JsonSchema)]
+pub enum HomeRenderer {
+    #[default]
+    Homepage,
 }
 
-#[derive(Debug, Clone, Serialize, JsonSchema)]
-#[serde(tag = "renderer")]
-pub enum ContributorSpotlightPage {
-    ContributorSpotlight(JsonContributorSpotlightPage),
-}
-
-#[derive(Debug, Clone, Serialize, JsonSchema)]
-#[serde(tag = "renderer")]
-pub enum HomePage {
-    Homepage(JsonHomePage),
-}
-
-#[derive(Debug, Clone, Serialize, JsonSchema)]
-#[serde(tag = "renderer")]
-pub enum CurriculumPage {
-    CurriculumDefault(JsonCurriculumPage),
-    CurriculumModule(JsonCurriculumPage),
-    CurriculumOverview(JsonCurriculumPage),
-    CurriculumLanding(JsonCurriculumPage),
-    CurriculumAbout(JsonCurriculumPage),
-}
-
-impl CurriculumPage {
-    pub fn from_page_and_template(
-        page: JsonCurriculumPage,
-        template: curriculum::Template,
-    ) -> Self {
-        match template {
-            curriculum::Template::Module => Self::CurriculumModule(page),
-            curriculum::Template::Overview => Self::CurriculumOverview(page),
-            curriculum::Template::Landing => Self::CurriculumLanding(page),
-            curriculum::Template::About => Self::CurriculumAbout(page),
-            curriculum::Template::Default => Self::CurriculumDefault(page),
-        }
-    }
+#[derive(Debug, Clone, Serialize, Default, JsonSchema)]
+pub enum CurriculumRenderer {
+    #[default]
+    CurriculumDefault,
+    CurriculumModule,
+    CurriculumOverview,
+    CurriculumLanding,
+    CurriculumAbout,
 }

--- a/rari-npm/lib/generate-types.js
+++ b/rari-npm/lib/generate-types.js
@@ -1,13 +1,12 @@
-import { compileFromFile } from 'json-schema-to-typescript'
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-import fs from 'node:fs';
+import { compileFromFile } from "json-schema-to-typescript";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import fs from "node:fs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const schemaPath = join(__dirname, '..', 'schema.json');
-const typesPath = join(__dirname, 'rari-types.d.ts');
+const schemaPath = join(__dirname, "..", "schema.json");
+const typesPath = join(__dirname, "rari-types.d.ts");
 
 compileFromFile(schemaPath, {
   additionalProperties: false,
-}).then(ts => fs.writeFileSync(typesPath, ts))
-
+}).then((ts) => fs.writeFileSync(typesPath, ts));

--- a/rari-npm/lib/generate-types.js
+++ b/rari-npm/lib/generate-types.js
@@ -1,12 +1,13 @@
-import { compileFromFile } from "json-schema-to-typescript";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
-import fs from "node:fs";
+import { compileFromFile } from 'json-schema-to-typescript'
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import fs from 'node:fs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const schemaPath = join(__dirname, "..", "schema.json");
-const typesPath = join(__dirname, "rari-types.d.ts");
+const schemaPath = join(__dirname, '..', 'schema.json');
+const typesPath = join(__dirname, 'rari-types.d.ts');
 
 compileFromFile(schemaPath, {
   additionalProperties: false,
-}).then((ts) => fs.writeFileSync(typesPath, ts));
+}).then(ts => fs.writeFileSync(typesPath, ts))
+


### PR DESCRIPTION
### Description

The updated version of schemars allows/foced us to inline the renderer. This is slightly more intuitive.

### Additional details

To test:

run:

```
cargo run -- export-schema
cd rari-npm && npm run generate-types

cp lib/rari-types.d.ts $FRED_DIR/node_modules/@mdn/rari/lib/rari-types.d.ts
cd $FRED_DIR && npx eslint .
```
### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
