### PR TITLE
feat(frontmatter): support banners

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2662,9 +2662,12 @@ version = "0.1.44"
 dependencies = [
  "chrono",
  "config",
+ "darling",
  "dirs",
  "indexmap",
  "normalize-path",
+ "proc-macro2",
+ "quote",
  "schemars",
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,8 @@ tokio = "1"
 inventory = "0.3"
 tree-sitter-mdn = "0.1"
 tree-sitter = "0.23"
+darling = "0.20"
+quote = "1"
 
 [features]
 default = []

--- a/crates/rari-doc/src/html/banner.rs
+++ b/crates/rari-doc/src/html/banner.rs
@@ -1,0 +1,39 @@
+use rari_types::{templ::TemplType, Arg, Quotes};
+use tracing::{span, Level};
+
+use crate::{
+    error::DocError,
+    pages::{page::PageLike, types::utils::FmTempl},
+    templ::templs::invoke,
+};
+
+pub fn build_banner<T: PageLike>(banner: &FmTempl, page: &T) -> Result<String, DocError> {
+    let rari_env = page.rari_env().ok_or(DocError::NoRariEnv)?;
+    let (name, args) = match banner {
+        FmTempl::NoArgs(name) => (name.as_str(), vec![]),
+        FmTempl::WithArgs { name, args } => (
+            name.as_str(),
+            args.iter()
+                .map(|s| Some(Arg::String(s.clone(), Quotes::Double)))
+                .collect(),
+        ),
+    };
+    let span = span!(Level::ERROR, "banner", banner = name,);
+    let _enter = span.enter();
+    let rendered_banner = match invoke(&rari_env, name, args) {
+        Ok((rendered_banner, TemplType::Banner)) => rendered_banner,
+        Ok((_, typ)) => {
+            let span = span!(Level::ERROR, "banner", banner = name,);
+            let _enter = span.enter();
+            tracing::warn!("{typ} macro in banner frontmatter");
+            Default::default()
+        }
+        Err(e) => {
+            let span = span!(Level::ERROR, "banner", banner = name,);
+            let _enter = span.enter();
+            tracing::warn!("{e}");
+            Default::default()
+        }
+    };
+    Ok(rendered_banner)
+}

--- a/crates/rari-doc/src/html/mod.rs
+++ b/crates/rari-doc/src/html/mod.rs
@@ -1,3 +1,4 @@
+pub mod banner;
 pub mod bubble_up;
 pub mod code;
 mod fix_img;

--- a/crates/rari-doc/src/pages/json.rs
+++ b/crates/rari-doc/src/pages/json.rs
@@ -23,6 +23,7 @@ use crate::pages::templates::{
     GenericRenderer, HomeRenderer, SpaRenderer,
 };
 use crate::pages::types::blog::BlogMeta;
+use crate::pages::types::utils::FmTempl;
 use crate::specs::Specification;
 use crate::utils::modified_dt;
 
@@ -280,6 +281,8 @@ pub struct JsonDoc {
     pub flaws: Option<DisplayIssues>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub live_samples: Option<Vec<Code>>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub banners: Vec<FmTempl>,
 }
 
 impl JsonDocMetadata {

--- a/crates/rari-doc/src/pages/page.rs
+++ b/crates/rari-doc/src/pages/page.rs
@@ -18,6 +18,7 @@ use crate::pages::types::contributors::ContributorSpotlight;
 use crate::pages::types::curriculum::Curriculum;
 use crate::pages::types::doc::Doc;
 use crate::pages::types::spa::SPA;
+use crate::pages::types::utils::FmTempl;
 use crate::resolve::{url_meta_from, UrlMeta};
 use crate::utils::locale_and_typ_from_path;
 
@@ -251,6 +252,7 @@ pub trait PageLike {
     fn trailing_slash(&self) -> bool;
     fn fm_offset(&self) -> usize;
     fn raw_content(&self) -> &str;
+    fn banners(&self) -> Option<&[FmTempl]>;
 }
 
 impl<T: PageLike> PageLike for Arc<T> {
@@ -320,6 +322,10 @@ impl<T: PageLike> PageLike for Arc<T> {
 
     fn raw_content(&self) -> &str {
         (**self).raw_content()
+    }
+
+    fn banners(&self) -> Option<&[FmTempl]> {
+        (**self).banners()
     }
 }
 

--- a/crates/rari-doc/src/pages/types/blog.rs
+++ b/crates/rari-doc/src/pages/types/blog.rs
@@ -15,6 +15,7 @@ use crate::cached_readers::{blog_author_by_name, blog_files};
 use crate::error::DocError;
 use crate::pages::json::{PrevNextBySlug, SlugNTitle};
 use crate::pages::page::{Page, PageCategory, PageLike, PageReader};
+use crate::pages::types::utils::FmTempl;
 use crate::resolve::build_url;
 use crate::utils::{calculate_read_time_minutes, locale_and_typ_from_path, modified_dt, split_fm};
 
@@ -298,6 +299,10 @@ impl PageLike for BlogPost {
 
     fn raw_content(&self) -> &str {
         &self.raw
+    }
+
+    fn banners(&self) -> Option<&[FmTempl]> {
+        None
     }
 }
 

--- a/crates/rari-doc/src/pages/types/contributors.rs
+++ b/crates/rari-doc/src/pages/types/contributors.rs
@@ -14,6 +14,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::DocError;
 use crate::pages::page::{Page, PageLike, PageReader};
+use crate::pages::types::utils::FmTempl;
 use crate::utils::split_fm;
 
 #[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
@@ -247,6 +248,10 @@ impl PageLike for ContributorSpotlight {
 
     fn raw_content(&self) -> &str {
         &self.raw
+    }
+
+    fn banners(&self) -> Option<&[FmTempl]> {
+        None
     }
 }
 

--- a/crates/rari-doc/src/pages/types/curriculum.rs
+++ b/crates/rari-doc/src/pages/types/curriculum.rs
@@ -16,6 +16,7 @@ use crate::cached_readers::curriculum_files;
 use crate::error::DocError;
 use crate::pages::json::{Parent, PrevNextBySlug, PrevNextByUrl, UrlNTitle};
 use crate::pages::page::{Page, PageCategory, PageLike, PageReader};
+use crate::pages::types::utils::FmTempl;
 use crate::utils::{as_null, split_fm};
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
@@ -262,6 +263,10 @@ impl PageLike for Curriculum {
 
     fn raw_content(&self) -> &str {
         &self.raw_content
+    }
+
+    fn banners(&self) -> Option<&[FmTempl]> {
+        None
     }
 }
 

--- a/crates/rari-doc/src/pages/types/doc.rs
+++ b/crates/rari-doc/src/pages/types/doc.rs
@@ -81,6 +81,13 @@ pub struct FrontMatter {
         skip_serializing_if = "Vec::is_empty"
     )]
     pub sidebar: Vec<FmTempl>,
+    #[serde(
+        deserialize_with = "t_or_vec",
+        serialize_with = "serialize_t_or_vec",
+        default,
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub banners: Vec<FmTempl>,
     #[serde(flatten)]
     pub other: HashMap<String, Value>,
 }
@@ -101,6 +108,7 @@ pub struct Meta {
     pub full_path: PathBuf,
     pub path: PathBuf,
     pub url: String,
+    pub banners: Vec<FmTempl>,
 }
 
 #[derive(Debug, Clone)]
@@ -288,6 +296,10 @@ impl PageLike for Doc {
     fn raw_content(&self) -> &str {
         &self.raw
     }
+
+    fn banners(&self) -> Option<&[FmTempl]> {
+        Some(&self.meta.banners)
+    }
 }
 
 pub fn doc_from_raw(raw: String, full_path: impl Into<PathBuf>) -> Result<Doc, DocError> {
@@ -306,6 +318,7 @@ pub fn doc_from_raw(raw: String, full_path: impl Into<PathBuf>) -> Result<Doc, D
         spec_urls,
         original_slug,
         sidebar,
+        banners,
         ..
     } = serde_yaml_ng::from_str(fm)?;
     let url = build_url(&slug, locale, PageCategory::Doc)?;
@@ -351,6 +364,7 @@ pub fn doc_from_raw(raw: String, full_path: impl Into<PathBuf>) -> Result<Doc, D
             full_path,
             path,
             url,
+            banners,
         },
         raw,
         content_start,

--- a/crates/rari-doc/src/pages/types/generic.rs
+++ b/crates/rari-doc/src/pages/types/generic.rs
@@ -12,6 +12,7 @@ use serde::Deserialize;
 use crate::cached_readers::{generic_content_config, generic_content_files, GenericPagesConfig};
 use crate::error::DocError;
 use crate::pages::page::{Page, PageLike, PageReader};
+use crate::pages::types::utils::FmTempl;
 use crate::utils::split_fm;
 
 #[derive(Debug, Clone, Copy, Deserialize, Default)]
@@ -217,6 +218,10 @@ impl PageLike for Generic {
 
     fn raw_content(&self) -> &str {
         &self.raw
+    }
+
+    fn banners(&self) -> Option<&[FmTempl]> {
+        None
     }
 }
 

--- a/crates/rari-doc/src/pages/types/spa.rs
+++ b/crates/rari-doc/src/pages/types/spa.rs
@@ -13,6 +13,7 @@ use rari_types::RariEnv;
 use rari_utils::concat_strs;
 
 use crate::pages::templates::{BlogRenderer, HomeRenderer, SpaRenderer};
+use crate::pages::types::utils::FmTempl;
 
 use super::spa_homepage::{
     featured_articles, featured_contributor, latest_news, recent_contributions,
@@ -288,6 +289,10 @@ impl PageLike for SPA {
 
     fn raw_content(&self) -> &str {
         ""
+    }
+
+    fn banners(&self) -> Option<&[FmTempl]> {
+        None
     }
 }
 

--- a/crates/rari-doc/src/pages/types/utils.rs
+++ b/crates/rari-doc/src/pages/types/utils.rs
@@ -1,10 +1,11 @@
 use std::fmt;
 
+use schemars::JsonSchema;
 use serde::de::{self, MapAccess, SeqAccess, Visitor};
 use serde::ser::SerializeMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub enum FmTempl {
     NoArgs(String),
     WithArgs { name: String, args: Vec<String> },
@@ -38,14 +39,14 @@ impl<'de> Deserialize<'de> for FmTempl {
             where
                 E: de::Error,
             {
-                Ok(FmTempl::NoArgs(s.to_owned()))
+                Ok(FmTempl::NoArgs(s.to_lowercase()))
             }
 
             fn visit_string<E>(self, s: String) -> Result<Self::Value, E>
             where
                 E: de::Error,
             {
-                Ok(FmTempl::NoArgs(s))
+                Ok(FmTempl::NoArgs(s.to_lowercase()))
             }
 
             fn visit_seq<A>(self, mut _seq: A) -> Result<Self::Value, A::Error>
@@ -66,7 +67,7 @@ impl<'de> Deserialize<'de> for FmTempl {
                         return Err(de::Error::custom("map has more than one key"));
                     }
                     Ok(FmTempl::WithArgs {
-                        name: key,
+                        name: key.to_lowercase(),
                         args: val,
                     })
                 } else {

--- a/crates/rari-doc/src/templ/templs/banners.rs
+++ b/crates/rari-doc/src/templ/templs/banners.rs
@@ -6,7 +6,7 @@ use tracing::warn;
 use crate::error::DocError;
 use crate::helpers::l10n::l10n_json_data;
 
-#[rari_f(register = "crate::Templ")]
+#[rari_f(register = "crate::Templ", typ = "TemplType::Banner")]
 pub fn deprecated_header(version: Option<AnyArg>) -> Result<String, DocError> {
     if version.is_some() {
         warn!("Do not use deprecated header with parameter!")
@@ -23,7 +23,7 @@ pub fn deprecated_header(version: Option<AnyArg>) -> Result<String, DocError> {
     ))
 }
 
-#[rari_f(register = "crate::Templ")]
+#[rari_f(register = "crate::Templ", typ = "TemplType::Banner")]
 pub fn availableinworkers(typ: Option<String>) -> Result<String, DocError> {
     let default_typ = "available_in_worker__default";
     let typ = typ
@@ -43,7 +43,7 @@ pub fn availableinworkers(typ: Option<String>) -> Result<String, DocError> {
     ))
 }
 
-#[rari_f(register = "crate::Templ")]
+#[rari_f(register = "crate::Templ", typ = "TemplType::Banner")]
 pub fn seecompattable() -> Result<String, DocError> {
     let title = l10n_json_data("Template", "experimental_badge_abbreviation", env.locale)?;
     let copy = l10n_json_data("Template", "see_compat_table_copy", env.locale)?;
@@ -57,7 +57,7 @@ pub fn seecompattable() -> Result<String, DocError> {
     ))
 }
 
-#[rari_f(register = "crate::Templ")]
+#[rari_f(register = "crate::Templ", typ = "TemplType::Banner")]
 pub fn securecontext_header() -> Result<String, DocError> {
     let title = l10n_json_data("Template", "secure_context_label", env.locale)?;
     let copy = l10n_json_data("Template", "secure_context_header_copy", env.locale)?;
@@ -71,7 +71,7 @@ pub fn securecontext_header() -> Result<String, DocError> {
     ))
 }
 
-#[rari_f(register = "crate::Templ")]
+#[rari_f(register = "crate::Templ", typ = "TemplType::Banner")]
 pub fn non_standard_header() -> Result<String, DocError> {
     let title = l10n_json_data("Template", "non_standard_badge_abbreviation", env.locale)?;
     let copy = l10n_json_data("Template", "non_standard_header_copy", env.locale)?;

--- a/crates/rari-doc/src/templ/templs/compat.rs
+++ b/crates/rari-doc/src/templ/templs/compat.rs
@@ -72,7 +72,7 @@ mod test {
         let Rendered {
             content, templs, ..
         } = render(&env, r#"{{ compat }}"#, 0)?;
-        let out = decode_ref(&content, &templs)?;
+        let out = decode_ref(&content, &templs, None)?;
         assert_eq!(out, r#""#);
         Ok(())
     }
@@ -89,7 +89,7 @@ If you're able to see this, something went wrong on this page.
         let Rendered {
             content, templs, ..
         } = render(&env, r#"{{ compat }}"#, 0)?;
-        let out = decode_ref(&content, &templs)?;
+        let out = decode_ref(&content, &templs, None)?;
         assert_eq!(out, exp);
         Ok(())
     }
@@ -112,7 +112,7 @@ If you're able to see this, something went wrong on this page.
         let Rendered {
             content, templs, ..
         } = render(&env, r#"{{ compat }}"#, 0)?;
-        let out = decode_ref(&content, &templs)?;
+        let out = decode_ref(&content, &templs, None)?;
         assert_eq!(out, exp);
         Ok(())
     }

--- a/crates/rari-doc/src/templ/templs/sidebars.rs
+++ b/crates/rari-doc/src/templ/templs/sidebars.rs
@@ -4,102 +4,102 @@ use crate::error::DocError;
 use crate::html::sidebar;
 use crate::sidebars::{apiref, default_api_sidebar, jsref};
 
-#[rari_f(register = "crate::Templ", sidebar)]
+#[rari_f(register = "crate::Templ", typ = "TemplType::Sidebar")]
 pub fn apiref(group: Option<String>) -> Result<String, DocError> {
     apiref::sidebar(env.slug, group.as_deref(), env.locale)?.render("apiref", env.locale)
 }
 
-#[rari_f(register = "crate::Templ", sidebar)]
+#[rari_f(register = "crate::Templ", typ = "TemplType::Sidebar")]
 pub fn defaultapisidebar(group: String) -> Result<String, DocError> {
     default_api_sidebar::sidebar(&group, env.locale)?.render("default_api", env.locale)
 }
 
-#[rari_f(register = "crate::Templ", sidebar)]
+#[rari_f(register = "crate::Templ", typ = "TemplType::Sidebar")]
 pub fn jsref() -> Result<String, DocError> {
     jsref::sidebar(env.slug, env.locale)?.render("jsref", env.locale)
 }
 
-#[rari_f(register = "crate::Templ", sidebar)]
+#[rari_f(register = "crate::Templ", typ = "TemplType::Sidebar")]
 pub fn cssref() -> Result<String, DocError> {
     sidebar::render_sidebar("cssref", env.slug, env.locale)
 }
 
-#[rari_f(register = "crate::Templ", sidebar)]
+#[rari_f(register = "crate::Templ", typ = "TemplType::Sidebar")]
 pub fn glossarysidebar() -> Result<String, DocError> {
     sidebar::render_sidebar("glossarysidebar", env.slug, env.locale)
 }
 
-#[rari_f(register = "crate::Templ", sidebar)]
+#[rari_f(register = "crate::Templ", typ = "TemplType::Sidebar")]
 pub fn addonsidebar() -> Result<String, DocError> {
     sidebar::render_sidebar("addonsidebar", env.slug, env.locale)
 }
 
-#[rari_f(register = "crate::Templ", sidebar)]
+#[rari_f(register = "crate::Templ", typ = "TemplType::Sidebar")]
 pub fn learnsidebar() -> Result<String, DocError> {
     sidebar::render_sidebar("learnsidebar", env.slug, env.locale)
 }
 
-#[rari_f(register = "crate::Templ", sidebar)]
+#[rari_f(register = "crate::Templ", typ = "TemplType::Sidebar")]
 pub fn svgref() -> Result<String, DocError> {
     sidebar::render_sidebar("svgref", env.slug, env.locale)
 }
 
-#[rari_f(register = "crate::Templ", sidebar)]
+#[rari_f(register = "crate::Templ", typ = "TemplType::Sidebar")]
 pub fn httpsidebar() -> Result<String, DocError> {
     sidebar::render_sidebar("httpsidebar", env.slug, env.locale)
 }
 
-#[rari_f(register = "crate::Templ", sidebar)]
+#[rari_f(register = "crate::Templ", typ = "TemplType::Sidebar")]
 pub fn jssidebar() -> Result<String, DocError> {
     sidebar::render_sidebar("jssidebar", env.slug, env.locale)
 }
 
-#[rari_f(register = "crate::Templ", sidebar)]
+#[rari_f(register = "crate::Templ", typ = "TemplType::Sidebar")]
 pub fn htmlsidebar() -> Result<String, DocError> {
     sidebar::render_sidebar("htmlsidebar", env.slug, env.locale)
 }
 
-#[rari_f(register = "crate::Templ", sidebar)]
+#[rari_f(register = "crate::Templ", typ = "TemplType::Sidebar")]
 pub fn accessibilitysidebar() -> Result<String, DocError> {
     sidebar::render_sidebar("accessibilitysidebar", env.slug, env.locale)
 }
 
-#[rari_f(register = "crate::Templ", sidebar)]
+#[rari_f(register = "crate::Templ", typ = "TemplType::Sidebar")]
 pub fn firefoxsidebar() -> Result<String, DocError> {
     sidebar::render_sidebar("firefoxsidebar", env.slug, env.locale)
 }
 
-#[rari_f(register = "crate::Templ", sidebar)]
+#[rari_f(register = "crate::Templ", typ = "TemplType::Sidebar")]
 pub fn webassemblysidebar() -> Result<String, DocError> {
     sidebar::render_sidebar("webassemblysidebar", env.slug, env.locale)
 }
 
-#[rari_f(register = "crate::Templ", sidebar)]
+#[rari_f(register = "crate::Templ", typ = "TemplType::Sidebar")]
 pub fn xsltsidebar() -> Result<String, DocError> {
     sidebar::render_sidebar("xsltsidebar", env.slug, env.locale)
 }
 
-#[rari_f(register = "crate::Templ", sidebar)]
+#[rari_f(register = "crate::Templ", typ = "TemplType::Sidebar")]
 pub fn mdnsidebar() -> Result<String, DocError> {
     sidebar::render_sidebar("mdnsidebar", env.slug, env.locale)
 }
 
-#[rari_f(register = "crate::Templ", sidebar)]
+#[rari_f(register = "crate::Templ", typ = "TemplType::Sidebar")]
 pub fn gamessidebar() -> Result<String, DocError> {
     sidebar::render_sidebar("gamessidebar", env.slug, env.locale)
 }
 
-#[rari_f(register = "crate::Templ", sidebar)]
+#[rari_f(register = "crate::Templ", typ = "TemplType::Sidebar")]
 pub fn mathmlref() -> Result<String, DocError> {
     sidebar::render_sidebar("mathmlref", env.slug, env.locale)
 }
 
-#[rari_f(register = "crate::Templ", sidebar)]
+#[rari_f(register = "crate::Templ", typ = "TemplType::Sidebar")]
 pub fn pwasidebar() -> Result<String, DocError> {
     sidebar::render_sidebar("pwasidebar", env.slug, env.locale)
 }
 
-#[rari_f(register = "crate::Templ", sidebar)]
+#[rari_f(register = "crate::Templ", typ = "TemplType::Sidebar")]
 pub fn addonsidebarmain() -> Result<String, DocError> {
     sidebar::render_sidebar("addonsidebarmain", env.slug, env.locale)
 }

--- a/crates/rari-templ-func/Cargo.toml
+++ b/crates/rari-templ-func/Cargo.toml
@@ -11,10 +11,10 @@ proc-macro = true
 
 [dependencies]
 rari-types.workspace = true
+darling.workspace = true
+quote.workspace = true
 
 syn = { version = "2", features = ["full"] }
-quote = "1"
-darling = "0.20"
 
 [dev-dependencies]
 anyhow.workspace = true

--- a/crates/rari-templ-func/src/lib.rs
+++ b/crates/rari-templ-func/src/lib.rs
@@ -69,7 +69,7 @@ struct RariFargs {
     #[darling(default)]
     register: Option<syn::TypePath>,
     #[darling(default)]
-    sidebar: bool,
+    typ: Option<syn::TypePath>,
 }
 
 /// Define rari templ functions.
@@ -186,24 +186,24 @@ pub fn rari_f(attr: TokenStream, input: TokenStream) -> TokenStream {
         .insert(0, parse_quote!(env: &::rari_types::RariEnv));
 
     let dup_ident = dup.sig.ident.clone();
-    let is_sidebar: Lit = if attr_args.sidebar {
-        parse_quote!(true)
-    } else {
-        parse_quote!(false)
-    };
+    let typ = attr_args
+        .typ
+        .map(|typ| quote! { #typ })
+        .unwrap_or(quote! { TemplType::None });
+
     let collect = if let Some(inventory_type) = attr_args.register {
         quote! {
-            inventory::submit! {
-                #inventory_type {
-                    name: #name,
-                    outline: #outline,
-                    outline_snippet: #outline_snippet,
-                    outline_plain: #outline_plain,
-                    doc: #doc_string,
-                    function: #dup_ident,
-                    is_sidebar: #is_sidebar,
+                inventory::submit! {
+                    #inventory_type {
+                        name: #name,
+                        outline: #outline,
+                        outline_snippet: #outline_snippet,
+                        outline_plain: #outline_plain,
+                        doc: #doc_string,
+                        function: #dup_ident,
+                        typ: rari_types::templ::#typ,
+                    }
                 }
-            }
         }
     } else {
         quote! {}

--- a/crates/rari-types/Cargo.toml
+++ b/crates/rari-types/Cargo.toml
@@ -20,8 +20,11 @@ schemars.workspace = true
 semver.workspace = true
 tracing.workspace = true
 strum.workspace = true
+darling.workspace = true
+quote.workspace = true
 
 serde_variant = "0.1"
 normalize-path = "0.2"
 dirs = "6"
 config = { version = "0.15", default-features = false, features = ["toml"] }
+proc-macro2 = "1"

--- a/crates/rari-types/src/templ.rs
+++ b/crates/rari-types/src/templ.rs
@@ -1,3 +1,28 @@
+use darling::FromMeta;
+use proc_macro2::TokenStream;
+use quote::{quote, ToTokens};
+
 use crate::{Arg, RariEnv};
 
 pub type RariFn<R> = fn(&RariEnv<'_>, Vec<Option<Arg>>) -> R;
+
+#[derive(Debug, Default, FromMeta, Clone, Copy, strum::Display)]
+pub enum TemplType {
+    #[default]
+    None,
+    Link,
+    Sidebar,
+    Banner,
+}
+
+impl ToTokens for TemplType {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let variant = match self {
+            TemplType::None => quote! { TemplType::None },
+            TemplType::Link => quote! { TemplType::Link },
+            TemplType::Sidebar => quote! { TemplType::Sidebar },
+            TemplType::Banner => quote! { TemplType::Banner },
+        };
+        tokens.extend(variant);
+    }
+}


### PR DESCRIPTION
### Description

Syntax is same as for sidebar:

```yaml
sidebar:
  - apiref: ["DOM"]
banners:
  - AvailableInWorkers: ["window_and_worker_except_service"]
  - deprecated_header
  - seecompattable
```

