### PR TITLE
enhance(page): add other_translations to non-Doc pages

### DIFF
--- a/crates/rari-doc/src/pages/build.rs
+++ b/crates/rari-doc/src/pages/build.rs
@@ -376,7 +376,6 @@ fn build_blog_post(post: &BlogPost) -> Result<BuiltPage, DocError> {
 fn build_generic_page(page: &Generic) -> Result<BuiltPage, DocError> {
     let built = build_content(page);
     let parents: Vec<super::json::Parent> = parents(page);
-    let other_translations = other_translations(page);
     let PageContent { body, toc, .. } = built?;
     Ok(BuiltPage::GenericPage(Box::new(JsonGenericPage {
         hy_data: JsonGenericHyData {
@@ -394,7 +393,7 @@ fn build_generic_page(page: &Generic) -> Result<BuiltPage, DocError> {
         common: CommonJsonData {
             description: page.meta.description.clone(),
             parents,
-            other_translations,
+            other_translations: other_translations(page),
         },
         renderer: match page.meta.template {
             super::types::generic::Template::GenericDoc => GenericRenderer::GenericDoc,
@@ -468,7 +467,6 @@ fn build_contributor_spotlight(cs: &ContributorSpotlight) -> Result<BuiltPage, D
         quote: cs.meta.quote.clone(),
     };
     let parents = parents(cs);
-    let other_translations = other_translations(cs);
     Ok(BuiltPage::ContributorSpotlight(Box::new(
         JsonContributorSpotlightPage {
             url: cs.meta.url.clone(),
@@ -477,7 +475,7 @@ fn build_contributor_spotlight(cs: &ContributorSpotlight) -> Result<BuiltPage, D
             common: CommonJsonData {
                 description: cs.meta.description.clone(),
                 parents,
-                other_translations,
+                other_translations: other_translations(cs),
             },
             renderer: ContributorSpotlightRenderer::ContributorSpotlight,
         },

--- a/crates/rari-doc/src/pages/build.rs
+++ b/crates/rari-doc/src/pages/build.rs
@@ -12,7 +12,7 @@ use scraper::Html;
 use super::json::{
     BuiltPage, Compat, ContributorSpotlightHyData, JsonBlogPostDoc, JsonBlogPostPage,
     JsonCurriculumPage, JsonDoc, JsonDocPage, JsonGenericHyData, JsonGenericPage, Prose, Section,
-    Source, SpecificationSection, TocEntry, Translation,
+    Source, SpecificationSection, TocEntry,
 };
 use super::page::{Page, PageBuilder, PageLike};
 use super::types::contributors::ContributorSpotlight;
@@ -45,7 +45,7 @@ use crate::pages::types::spa::SPA;
 use crate::pages::types::utils::FmTempl;
 use crate::specs::extract_specifications;
 use crate::templ::render::{decode_ref, render, Rendered};
-use crate::translations::get_other_translations_for;
+use crate::translations::other_translations;
 
 impl From<BuildSection<'_>> for Section {
     fn from(value: BuildSection) -> Self {
@@ -270,14 +270,7 @@ fn build_doc(doc: &Doc) -> Result<BuiltPage, DocError> {
         history.map(|entry| entry.hash.as_str()).unwrap_or_default()
     );
     let popularity = popularities().popularities.get(doc.url()).cloned();
-    let other_translations = get_other_translations_for(doc.slug(), doc.locale())
-        .into_iter()
-        .map(|(locale, title)| Translation {
-            native: locale.into(),
-            locale,
-            title,
-        })
-        .collect();
+    let other_translations = other_translations(doc);
 
     let no_indexing =
         doc.meta.slug == "MDN/Kitchensink" || doc.is_orphaned() || doc.is_conflicting();

--- a/crates/rari-doc/src/pages/build.rs
+++ b/crates/rari-doc/src/pages/build.rs
@@ -270,14 +270,20 @@ fn build_doc(doc: &Doc) -> Result<BuiltPage, DocError> {
         history.map(|entry| entry.hash.as_str()).unwrap_or_default()
     );
     let popularity = popularities().popularities.get(doc.url()).cloned();
-    let other_translations = other_translations(doc);
-
     let no_indexing =
         doc.meta.slug == "MDN/Kitchensink" || doc.is_orphaned() || doc.is_conflicting();
-    let parents = if !doc.is_conflicting() && !doc.is_orphaned() {
-        parents(doc)
+
+    let (parents, other_translations) = if !doc.is_conflicting() && !doc.is_orphaned() {
+        (parents(doc), other_translations(doc))
     } else {
-        Default::default()
+        (
+            Default::default(),
+            vec![Translation {
+                native: doc.locale().into(),
+                locale: doc.locale(),
+                title: doc.title().to_string(),
+            }],
+        )
     };
 
     Ok(BuiltPage::Doc(Box::new(JsonDocPage {

--- a/crates/rari-doc/src/pages/build.rs
+++ b/crates/rari-doc/src/pages/build.rs
@@ -375,7 +375,6 @@ fn build_blog_post(post: &BlogPost) -> Result<BuiltPage, DocError> {
 
 fn build_generic_page(page: &Generic) -> Result<BuiltPage, DocError> {
     let built = build_content(page);
-    let parents: Vec<super::json::Parent> = parents(page);
     let PageContent { body, toc, .. } = built?;
     Ok(BuiltPage::GenericPage(Box::new(JsonGenericPage {
         hy_data: JsonGenericHyData {
@@ -392,7 +391,7 @@ fn build_generic_page(page: &Generic) -> Result<BuiltPage, DocError> {
         id: page.meta.page.clone(),
         common: CommonJsonData {
             description: page.meta.description.clone(),
-            parents,
+            parents: parents(page),
             other_translations: other_translations(page),
         },
         renderer: match page.meta.template {
@@ -410,8 +409,7 @@ fn build_spa(spa: &SPA) -> Result<BuiltPage, DocError> {
 fn build_curriculum(curriculum: &Curriculum) -> Result<BuiltPage, DocError> {
     let PageContent { body, toc, .. } = build_content(curriculum)?;
     let sidebar = build_sidebar().ok();
-    let parents = parents(curriculum);
-    let group = curriculum_group(&parents);
+    let group = curriculum_group(&parents(curriculum));
     let modules = match curriculum.meta.template {
         Template::Overview => build_overview_modules(curriculum.slug())?,
         Template::Landing => build_landing_modules()?,
@@ -428,7 +426,7 @@ fn build_curriculum(curriculum: &Curriculum) -> Result<BuiltPage, DocError> {
             locale: curriculum.locale(),
             native: curriculum.locale().into(),
             mdn_url: curriculum.meta.url.clone(),
-            parents,
+            parents: parents(curriculum),
             page_title: page_title(curriculum, true)?,
             summary: curriculum.meta.summary.clone(),
             body,
@@ -466,7 +464,6 @@ fn build_contributor_spotlight(cs: &ContributorSpotlight) -> Result<BuiltPage, D
         usernames: cs.meta.usernames.clone(),
         quote: cs.meta.quote.clone(),
     };
-    let parents = parents(cs);
     Ok(BuiltPage::ContributorSpotlight(Box::new(
         JsonContributorSpotlightPage {
             url: cs.meta.url.clone(),
@@ -474,7 +471,7 @@ fn build_contributor_spotlight(cs: &ContributorSpotlight) -> Result<BuiltPage, D
             hy_data: contributor_spotlight_data,
             common: CommonJsonData {
                 description: cs.meta.description.clone(),
-                parents,
+                parents: parents(cs),
                 other_translations: other_translations(cs),
             },
             renderer: ContributorSpotlightRenderer::ContributorSpotlight,

--- a/crates/rari-doc/src/pages/json.rs
+++ b/crates/rari-doc/src/pages/json.rs
@@ -960,10 +960,11 @@ pub struct JsonGenericPage {
 }
 
 #[derive(Debug, Clone, Default, Serialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
 #[schemars(rename = "GenericPage")]
 pub struct CommonJsonData {
     pub description: Option<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub parents: Vec<Parent>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub other_translations: Vec<Translation>,
 }

--- a/crates/rari-doc/src/pages/page.rs
+++ b/crates/rari-doc/src/pages/page.rs
@@ -114,34 +114,27 @@ impl Page {
                 .ok_or(DocError::PageNotFound(url.to_string(), PageCategory::SPA)),
             PageCategory::Doc => Doc::page_from_slug_path(&folder_path, locale, fallback)
                 .map_err(|_| DocError::PageNotFound(url.to_string(), PageCategory::Doc)),
-            PageCategory::BlogPost => {
-                if locale != Locale::EnUs {
-                    // Blog is en-US only.
-                    Err(DocError::PageNotFound(
-                        url.to_string(),
-                        PageCategory::BlogPost,
-                    ))
-                } else {
-                    BlogPost::page_from_url(url).ok_or(DocError::PageNotFound(
-                        url.to_string(),
-                        PageCategory::BlogPost,
-                    ))
-                }
+            PageCategory::BlogPost if locale != Locale::EnUs => {
+                // Blog is en-US only.
+                Err(DocError::PageNotFound(
+                    url.to_string(),
+                    PageCategory::BlogPost,
+                ))
             }
-            PageCategory::Curriculum => {
-                if locale != Locale::EnUs {
-                    // Curriculum is en-US only.
-                    Err(DocError::PageNotFound(
-                        url.to_string(),
-                        PageCategory::Curriculum,
-                    ))
-                } else {
-                    Curriculum::page_from_url(url).ok_or(DocError::PageNotFound(
-                        url.to_string(),
-                        PageCategory::Curriculum,
-                    ))
-                }
+            PageCategory::BlogPost => BlogPost::page_from_url(url).ok_or(DocError::PageNotFound(
+                url.to_string(),
+                PageCategory::BlogPost,
+            )),
+            PageCategory::Curriculum if locale != Locale::EnUs => {
+                // Curriculum is en-US only.
+                Err(DocError::PageNotFound(
+                    url.to_string(),
+                    PageCategory::Curriculum,
+                ))
             }
+            PageCategory::Curriculum => Curriculum::page_from_url(url).ok_or(
+                DocError::PageNotFound(url.to_string(), PageCategory::Curriculum),
+            ),
             PageCategory::ContributorSpotlight => contributor_spotlight_from_url(url, locale)
                 .ok_or(DocError::PageNotFound(
                     url.to_string(),

--- a/crates/rari-doc/src/pages/page.rs
+++ b/crates/rari-doc/src/pages/page.rs
@@ -110,15 +110,8 @@ impl Page {
         } = url_meta_from(url)?;
         let locale = locale.unwrap_or(locale_from_url);
         match page_category {
-            PageCategory::SPA => {
-                if locale != Locale::EnUs && slug.starts_with("blog") {
-                    // Blog is en-US only.
-                    Err(DocError::PageNotFound(url.to_string(), PageCategory::SPA))
-                } else {
-                    SPA::from_slug(slug, locale)
-                        .ok_or(DocError::PageNotFound(url.to_string(), PageCategory::SPA))
-                }
-            }
+            PageCategory::SPA => SPA::from_slug(slug, locale)
+                .ok_or(DocError::PageNotFound(url.to_string(), PageCategory::SPA)),
             PageCategory::Doc => Doc::page_from_slug_path(&folder_path, locale, fallback)
                 .map_err(|_| DocError::PageNotFound(url.to_string(), PageCategory::Doc)),
             PageCategory::BlogPost => {

--- a/crates/rari-doc/src/pages/page.rs
+++ b/crates/rari-doc/src/pages/page.rs
@@ -110,17 +110,42 @@ impl Page {
         } = url_meta_from(url)?;
         let locale = locale.unwrap_or(locale_from_url);
         match page_category {
-            PageCategory::SPA => SPA::from_slug(slug, locale)
-                .ok_or(DocError::PageNotFound(url.to_string(), PageCategory::SPA)),
+            PageCategory::SPA => {
+                if !(locale != Locale::EnUs && slug.starts_with("blog")) {
+                    SPA::from_slug(slug, locale)
+                        .ok_or(DocError::PageNotFound(url.to_string(), PageCategory::SPA))
+                } else {
+                    Err(DocError::PageNotFound(url.to_string(), PageCategory::SPA))
+                }
+            }
             PageCategory::Doc => Doc::page_from_slug_path(&folder_path, locale, fallback)
                 .map_err(|_| DocError::PageNotFound(url.to_string(), PageCategory::Doc)),
-            PageCategory::BlogPost => BlogPost::page_from_url(url).ok_or(DocError::PageNotFound(
-                url.to_string(),
-                PageCategory::BlogPost,
-            )),
-            PageCategory::Curriculum => Curriculum::page_from_url(url).ok_or(
-                DocError::PageNotFound(url.to_string(), PageCategory::Curriculum),
-            ),
+            PageCategory::BlogPost => {
+                if locale == Locale::EnUs {
+                    BlogPost::page_from_url(url).ok_or(DocError::PageNotFound(
+                        url.to_string(),
+                        PageCategory::BlogPost,
+                    ))
+                } else {
+                    Err(DocError::PageNotFound(
+                        url.to_string(),
+                        PageCategory::BlogPost,
+                    ))
+                }
+            }
+            PageCategory::Curriculum => {
+                if locale == Locale::EnUs {
+                    Curriculum::page_from_url(url).ok_or(DocError::PageNotFound(
+                        url.to_string(),
+                        PageCategory::Curriculum,
+                    ))
+                } else {
+                    Err(DocError::PageNotFound(
+                        url.to_string(),
+                        PageCategory::Curriculum,
+                    ))
+                }
+            }
             PageCategory::ContributorSpotlight => contributor_spotlight_from_url(url, locale)
                 .ok_or(DocError::PageNotFound(
                     url.to_string(),

--- a/crates/rari-doc/src/pages/page.rs
+++ b/crates/rari-doc/src/pages/page.rs
@@ -111,36 +111,39 @@ impl Page {
         let locale = locale.unwrap_or(locale_from_url);
         match page_category {
             PageCategory::SPA => {
-                if !(locale != Locale::EnUs && slug.starts_with("blog")) {
+                if locale != Locale::EnUs && slug.starts_with("blog") {
+                    // Blog is en-US only.
+                    Err(DocError::PageNotFound(url.to_string(), PageCategory::SPA))
+                } else {
                     SPA::from_slug(slug, locale)
                         .ok_or(DocError::PageNotFound(url.to_string(), PageCategory::SPA))
-                } else {
-                    Err(DocError::PageNotFound(url.to_string(), PageCategory::SPA))
                 }
             }
             PageCategory::Doc => Doc::page_from_slug_path(&folder_path, locale, fallback)
                 .map_err(|_| DocError::PageNotFound(url.to_string(), PageCategory::Doc)),
             PageCategory::BlogPost => {
-                if locale == Locale::EnUs {
-                    BlogPost::page_from_url(url).ok_or(DocError::PageNotFound(
+                if locale != Locale::EnUs {
+                    // Blog is en-US only.
+                    Err(DocError::PageNotFound(
                         url.to_string(),
                         PageCategory::BlogPost,
                     ))
                 } else {
-                    Err(DocError::PageNotFound(
+                    BlogPost::page_from_url(url).ok_or(DocError::PageNotFound(
                         url.to_string(),
                         PageCategory::BlogPost,
                     ))
                 }
             }
             PageCategory::Curriculum => {
-                if locale == Locale::EnUs {
-                    Curriculum::page_from_url(url).ok_or(DocError::PageNotFound(
+                if locale != Locale::EnUs {
+                    // Curriculum is en-US only.
+                    Err(DocError::PageNotFound(
                         url.to_string(),
                         PageCategory::Curriculum,
                     ))
                 } else {
-                    Err(DocError::PageNotFound(
+                    Curriculum::page_from_url(url).ok_or(DocError::PageNotFound(
                         url.to_string(),
                         PageCategory::Curriculum,
                     ))

--- a/crates/rari-doc/src/pages/types/spa.rs
+++ b/crates/rari-doc/src/pages/types/spa.rs
@@ -22,12 +22,13 @@ use crate::helpers::parents::parents;
 use crate::helpers::title::page_title;
 use crate::pages::json::{
     BlogIndex, BuiltPage, CommonJsonData, ItemContainer, JsonBlogPostDoc, JsonBlogPostPage,
-    JsonHomePage, JsonHomePageSPAHyData, JsonSpaPage, Parent,
+    JsonHomePage, JsonHomePageSPAHyData, JsonSpaPage, Parent, Translation,
 };
 use crate::pages::page::{Page, PageLike, PageReader};
 use crate::pages::templates::{BlogRenderer, HomeRenderer, SpaBuildTemplate, SpaRenderer};
 use crate::pages::types::blog::BlogMeta;
 use crate::pages::types::utils::FmTempl;
+use crate::translations::other_translations;
 
 #[derive(Debug, Clone)]
 pub struct SPA {
@@ -144,6 +145,11 @@ impl SPA {
                         uri: "/en-US/blog/".to_string(),
                         title: self.title().to_owned(),
                     }],
+                    other_translations: vec![Translation {
+                        native: self.locale().into(),
+                        locale: self.locale(),
+                        title: self.title().to_string(),
+                    }],
                     ..Default::default()
                 },
                 image: None,
@@ -159,6 +165,7 @@ impl SPA {
                 url: concat_strs!(self.base_slug.as_ref(), self.slug),
                 common: CommonJsonData {
                     parents: parents(self),
+                    other_translations: other_translations(self),
                     ..Default::default()
                 },
                 renderer: match self.template {
@@ -189,6 +196,7 @@ impl SPA {
                 url: concat_strs!(self.base_slug.as_ref(), self.slug),
                 common: CommonJsonData {
                     parents: parents(self),
+                    other_translations: other_translations(self),
                     ..Default::default()
                 },
                 renderer: SpaRenderer::SpaNotFound,
@@ -212,6 +220,7 @@ impl SPA {
                 },
                 common: CommonJsonData {
                     parents: parents(self),
+                    other_translations: other_translations(self),
                     ..Default::default()
                 },
                 renderer: HomeRenderer::Homepage,

--- a/crates/rari-doc/src/translations.rs
+++ b/crates/rari-doc/src/translations.rs
@@ -13,6 +13,7 @@ use crate::cached_readers::{STATIC_DOC_PAGE_FILES, STATIC_DOC_PAGE_TRANSLATED_FI
 use crate::pages::json::Translation;
 use crate::pages::page::PageLike;
 use crate::pages::types::doc::Doc;
+use crate::pages::types::spa::SPA;
 
 pub type TranslationsOf<'a> = BTreeMap<Locale, &'a str>;
 
@@ -61,7 +62,7 @@ pub(crate) fn init_translations_from_static_docs() {
 /// * `Vec<(Locale, String)>` - Returns a vector of tuples, where each tuple contains a `Locale` and a `String`
 ///   representing the title of the translation. If no translations are found, an empty vector is returned.
 pub(crate) fn get_other_translations_for(slug: &str, locale: Locale) -> Vec<(Locale, String)> {
-    if cache_content() {
+    if cache_content() && slug.contains("/docs/") {
         TRANSLATIONS_BY_SLUG
             .get()
             .and_then(|by_slug| {
@@ -83,9 +84,12 @@ pub(crate) fn get_other_translations_for(slug: &str, locale: Locale) -> Vec<(Loc
         Locale::for_generic_and_spas()
             .iter()
             .filter_map(|l| {
-                Doc::page_from_slug(slug, *l, false)
-                    .ok()
-                    .map(|d| (*l, d.title().to_string()))
+                if slug.contains("/docs/") {
+                    Doc::page_from_slug(slug, *l, false).ok()
+                } else {
+                    SPA::from_slug(slug, *l)
+                }
+                .map(|d| (*l, d.title().to_string()))
             })
             .collect()
     }

--- a/crates/rari-doc/src/translations.rs
+++ b/crates/rari-doc/src/translations.rs
@@ -66,7 +66,7 @@ pub(crate) fn other_translations<T: PageLike>(doc: &T) -> Vec<Translation> {
         .collect()
 }
 
-pub(crate) fn get_other_translations_for(slug: &str, locale: Locale) -> Vec<(Locale, String)> {
+fn get_other_translations_for(slug: &str, locale: Locale) -> Vec<(Locale, String)> {
     if cache_content() && slug.contains("/docs/") {
         TRANSLATIONS_BY_SLUG
             .get()

--- a/crates/rari-doc/src/translations.rs
+++ b/crates/rari-doc/src/translations.rs
@@ -12,7 +12,6 @@ use rari_types::locale::Locale;
 use crate::cached_readers::{STATIC_DOC_PAGE_FILES, STATIC_DOC_PAGE_TRANSLATED_FILES};
 use crate::pages::json::Translation;
 use crate::pages::page::{Page, PageLike};
-use crate::resolve::strip_locale_from_url;
 
 pub type TranslationsOf<'a> = BTreeMap<Locale, &'a str>;
 
@@ -68,9 +67,9 @@ pub(crate) fn other_translations<T: PageLike>(doc: &T) -> Vec<Translation> {
 fn get_other_translations_for<T: PageLike>(doc: &T) -> Vec<(Locale, String)> {
     let slug = doc.slug();
     let locale = doc.locale();
-    let (_, url_without_locale) = strip_locale_from_url(doc.url());
+    let url = doc.url();
 
-    if cache_content() && url_without_locale.starts_with("/docs/") {
+    if cache_content() && url.contains("/docs/") {
         TRANSLATIONS_BY_SLUG
             .get()
             .and_then(|by_slug| {
@@ -95,8 +94,7 @@ fn get_other_translations_for<T: PageLike>(doc: &T) -> Vec<(Locale, String)> {
                 if *l == locale {
                     Some((*l, doc.title().to_string()))
                 } else {
-                    let other_url = &format!("/{}{}", *l, url_without_locale);
-                    Page::from_url(other_url)
+                    Page::internal_from_url(url, Some(*l), false)
                         .ok()
                         .map(|d| (*l, d.title().to_string()))
                 }

--- a/crates/rari-doc/src/translations.rs
+++ b/crates/rari-doc/src/translations.rs
@@ -46,21 +46,26 @@ pub(crate) fn init_translations_from_static_docs() {
     TRANSLATIONS_BY_SLUG.set(all).unwrap();
 }
 
-/// Retrieves translations for a specific slug, _excluding_ the specified locale.
-///
-/// This function looks up translations for the given slug in the global `TRANSLATIONS_BY_SLUG` cache.
-/// It filters out the translation for the specified locale and returns a vector of tuples containing
-/// the locale and the corresponding title for each translation.
+/// Determines all available translations for a specific page.
 ///
 /// # Arguments
 ///
-/// * `slug` - A string slice that holds the slug of the documentation page.
-/// * `locale` - A `Locale` that specifies the locale to be excluded from the results.
+/// * `doc` - The page for which the translations should be determined.
 ///
 /// # Returns
 ///
-/// * `Vec<(Locale, String)>` - Returns a vector of tuples, where each tuple contains a `Locale` and a `String`
-///   representing the title of the translation. If no translations are found, an empty vector is returned.
+/// * `Vec<Translation>` - The vector of translations (including the current locale).
+pub(crate) fn other_translations<T: PageLike>(doc: &T) -> Vec<Translation> {
+    get_other_translations_for(doc.slug(), doc.locale())
+        .into_iter()
+        .map(|(locale, title)| Translation {
+            native: locale.into(),
+            locale,
+            title,
+        })
+        .collect()
+}
+
 pub(crate) fn get_other_translations_for(slug: &str, locale: Locale) -> Vec<(Locale, String)> {
     if cache_content() && slug.contains("/docs/") {
         TRANSLATIONS_BY_SLUG
@@ -93,15 +98,4 @@ pub(crate) fn get_other_translations_for(slug: &str, locale: Locale) -> Vec<(Loc
             })
             .collect()
     }
-}
-
-pub(crate) fn other_translations<T: PageLike>(doc: &T) -> Vec<Translation> {
-    get_other_translations_for(doc.slug(), doc.locale())
-        .into_iter()
-        .map(|(locale, title)| Translation {
-            native: locale.into(),
-            locale,
-            title,
-        })
-        .collect()
 }

--- a/crates/rari-doc/src/translations.rs
+++ b/crates/rari-doc/src/translations.rs
@@ -56,7 +56,7 @@ pub(crate) fn init_translations_from_static_docs() {
 ///
 /// * `Vec<Translation>` - The vector of translations (including the current locale).
 pub(crate) fn other_translations<T: PageLike>(doc: &T) -> Vec<Translation> {
-    get_other_translations_for(doc.slug(), doc.locale())
+    get_other_translations_for(doc)
         .into_iter()
         .map(|(locale, title)| Translation {
             native: locale.into(),
@@ -66,7 +66,10 @@ pub(crate) fn other_translations<T: PageLike>(doc: &T) -> Vec<Translation> {
         .collect()
 }
 
-fn get_other_translations_for(slug: &str, locale: Locale) -> Vec<(Locale, String)> {
+fn get_other_translations_for<T: PageLike>(doc: &T) -> Vec<(Locale, String)> {
+    let slug = doc.slug();
+    let locale = doc.locale();
+
     if cache_content() && slug.contains("/docs/") {
         TRANSLATIONS_BY_SLUG
             .get()

--- a/crates/rari-doc/src/translations.rs
+++ b/crates/rari-doc/src/translations.rs
@@ -10,6 +10,7 @@ use rari_types::globals::cache_content;
 use rari_types::locale::Locale;
 
 use crate::cached_readers::{STATIC_DOC_PAGE_FILES, STATIC_DOC_PAGE_TRANSLATED_FILES};
+use crate::pages::json::Translation;
 use crate::pages::page::PageLike;
 use crate::pages::types::doc::Doc;
 
@@ -88,4 +89,15 @@ pub(crate) fn get_other_translations_for(slug: &str, locale: Locale) -> Vec<(Loc
             })
             .collect()
     }
+}
+
+pub(crate) fn other_translations<T: PageLike>(doc: &T) -> Vec<Translation> {
+    get_other_translations_for(doc.slug(), doc.locale())
+        .into_iter()
+        .map(|(locale, title)| Translation {
+            native: locale.into(),
+            locale,
+            title,
+        })
+        .collect()
 }

--- a/crates/rari-doc/src/translations.rs
+++ b/crates/rari-doc/src/translations.rs
@@ -92,9 +92,14 @@ fn get_other_translations_for<T: PageLike>(doc: &T) -> Vec<(Locale, String)> {
         Locale::for_generic_and_spas()
             .iter()
             .filter_map(|l| {
-                Page::from_url(&format!("/{}{}", *l, url))
-                    .ok()
-                    .map(|d| (*l, d.title().to_string()))
+                if *l == locale {
+                    Some((*l, doc.title().to_string()))
+                } else {
+                    let other_url = &format!("/{}{}", *l, url);
+                    Page::from_url(other_url)
+                        .ok()
+                        .map(|d| (*l, d.title().to_string()))
+                }
             })
             .collect()
     }

--- a/crates/rari-doc/src/translations.rs
+++ b/crates/rari-doc/src/translations.rs
@@ -68,8 +68,9 @@ pub(crate) fn other_translations<T: PageLike>(doc: &T) -> Vec<Translation> {
 fn get_other_translations_for<T: PageLike>(doc: &T) -> Vec<(Locale, String)> {
     let slug = doc.slug();
     let locale = doc.locale();
+    let (_, url_without_locale) = strip_locale_from_url(doc.url());
 
-    if cache_content() && slug.contains("/docs/") {
+    if cache_content() && url_without_locale.starts_with("/docs/") {
         TRANSLATIONS_BY_SLUG
             .get()
             .and_then(|by_slug| {
@@ -88,14 +89,13 @@ fn get_other_translations_for<T: PageLike>(doc: &T) -> Vec<(Locale, String)> {
             })
             .unwrap_or_default()
     } else {
-        let (_, url) = strip_locale_from_url(doc.url());
         Locale::for_generic_and_spas()
             .iter()
             .filter_map(|l| {
                 if *l == locale {
                     Some((*l, doc.title().to_string()))
                 } else {
-                    let other_url = &format!("/{}{}", *l, url);
+                    let other_url = &format!("/{}{}", *l, url_without_locale);
                     Page::from_url(other_url)
                         .ok()
                         .map(|d| (*l, d.title().to_string()))


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Adds `other_translations` to non-`Doc` pages (Curriculum, SPA incl. Blog Index, Blog posts, Generic content).

### Motivation

Consistency: The language selector is currently only shown on doc pages.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Downstream:

- https://github.com/mdn/fred/pull/345
