### PR TITLE
enhance(pages): support short-title for generic

### DIFF
--- a/crates/rari-doc/src/pages/build.rs
+++ b/crates/rari-doc/src/pages/build.rs
@@ -379,6 +379,7 @@ fn build_generic_page(page: &Generic) -> Result<BuiltPage, DocError> {
             title: page.meta.title.clone(),
             toc,
         },
+        short_title: page.meta.short_title.clone(),
         page_title: if let Some(suffix) = &page.meta.title_suffix {
             concat_strs!(page.meta.title.as_str(), " | ", suffix)
         } else {

--- a/crates/rari-doc/src/pages/json.rs
+++ b/crates/rari-doc/src/pages/json.rs
@@ -951,6 +951,7 @@ pub struct JsonGenericHyData {
 #[schemars(rename = "GenericPage")]
 pub struct JsonGenericPage {
     pub hy_data: JsonGenericHyData,
+    pub short_title: Option<String>,
     pub page_title: String,
     pub url: String,
     pub id: String,

--- a/crates/rari-doc/src/pages/types/generic.rs
+++ b/crates/rari-doc/src/pages/types/generic.rs
@@ -25,6 +25,8 @@ pub enum Template {
 #[derive(Debug, Clone, Deserialize)]
 pub struct GenericFrontmatter {
     pub title: String,
+    #[serde(rename = "short-title", skip_serializing_if = "Option::is_none")]
+    pub short_title: Option<String>,
     pub template: Option<Template>,
     pub description: Option<String>,
 }
@@ -32,6 +34,7 @@ pub struct GenericFrontmatter {
 #[derive(Debug, Clone)]
 pub struct GenericMeta {
     pub title: String,
+    pub short_title: Option<String>,
     pub locale: Locale,
     pub slug: String,
     pub url: String,
@@ -63,6 +66,7 @@ impl GenericMeta {
         );
         Ok(GenericMeta {
             title: fm.title,
+            short_title: fm.short_title,
             locale,
             slug,
             url,
@@ -159,7 +163,7 @@ impl PageLike for Generic {
     }
 
     fn short_title(&self) -> Option<&str> {
-        None
+        self.meta.short_title.as_deref()
     }
 
     fn locale(&self) -> Locale {


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Allows setting `short-title` for generic pages (to control the breadcrumb entry).

### Motivation

We sometimes want a different title in the breadcrumbs than in the `<title>`, e.g. "MDN Community" for the community page.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Part of https://github.com/mdn/rari/issues/273.
