### PR TITLE
enhance(pages): default title-suffix to "MDN"

### DIFF
--- a/crates/rari-doc/src/pages/build.rs
+++ b/crates/rari-doc/src/pages/build.rs
@@ -383,11 +383,13 @@ fn build_generic_page(page: &Generic) -> Result<BuiltPage, DocError> {
             toc,
         },
         short_title: page.meta.short_title.clone(),
-        page_title: concat_strs!(
-            page.meta.title.as_str(),
-            " | ",
-            &page.meta.title_suffix.as_deref().unwrap_or("MDN")
-        ),
+        page_title: match page.meta.title_suffix.as_deref() {
+            Some(suffix) => concat_strs!(page.meta.title.as_str(), " | ", suffix),
+            None if !page.meta.title.contains("MDN") => {
+                concat_strs!(page.meta.title.as_str(), " | MDN")
+            }
+            _ => page.meta.title.clone(),
+        },
         url: page.meta.url.clone(),
         id: page.meta.page.clone(),
         common: CommonJsonData {


### PR DESCRIPTION
### Description

Adds a suffix "MDN" to all generic pages without a specific one.

### Motivation

We don't want to specify these explicitly for each page.

Currently, the About page's title is "About MDN", whereas the Community's page is "Contribute to MDN | Contribute to MDN".

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Part of https://github.com/mdn/rari/issues/273.
