### PR TITLE
fix(translations): include current locale when doing build

### DIFF
--- a/crates/rari-doc/src/translations.rs
+++ b/crates/rari-doc/src/translations.rs
@@ -76,13 +76,7 @@ fn get_other_translations_for<T: PageLike>(doc: &T) -> Vec<(Locale, String)> {
                 by_slug.get(slug).map(|translations| {
                     translations
                         .iter()
-                        .filter_map(|(t_locale, title)| {
-                            if *t_locale != locale {
-                                Some((*t_locale, title.to_string()))
-                            } else {
-                                None
-                            }
-                        })
+                        .map(|(t_locale, title)| (*t_locale, title.to_string()))
                         .collect()
                 })
             })


### PR DESCRIPTION
Relates to: https://github.com/mdn/fred/issues/480
Follow up to: https://github.com/mdn/rari/pull/272

That PR changed the logic in the server to include the current locale in `other_locales` when building a doc, but didn't change the logic when doing a build proper. Fred relies on the former functionality, so this fixes the build to also include the current locale.