### PR TITLE
chore(clippy): update rust toolchain, added elided lifetime specifiers

### DIFF
--- a/.github/workflows/lint-test-clippy.yaml
+++ b/.github/workflows/lint-test-clippy.yaml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@38b70195107dddab2c7bbd522bcf763bac00963b # stable
+      - uses: dtolnay/rust-toolchain@4305c38b25d97ef35a8ad1f985ccf2d2242004f2 # stable
       - name: sccache-cache
         uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
 

--- a/crates/rari-data/src/baseline.rs
+++ b/crates/rari-data/src/baseline.rs
@@ -115,7 +115,7 @@ impl WebFeatures {
 
     // Compute status according to:
     // https://github.com/mdn/yari/issues/11546#issuecomment-2531611136
-    pub fn baseline_by_bcd_key(&self, bcd_key: &str) -> Option<Baseline> {
+    pub fn baseline_by_bcd_key(&self, bcd_key: &str) -> Option<Baseline<'_>> {
         let bcd_key_spaced = &spaced(bcd_key);
         if let Some(feature) = self.feature_data_by_key(bcd_key_spaced) {
             if let Some(status) = feature.status.as_ref() {

--- a/crates/rari-doc/src/html/sections.rs
+++ b/crates/rari-doc/src/html/sections.rs
@@ -28,7 +28,7 @@ pub struct Split<'a> {
     pub sidebar: Option<String>,
 }
 
-pub fn split_sections(html: &Html) -> Result<Split, DocError> {
+pub fn split_sections(html: &Html) -> Result<Split<'_>, DocError> {
     let root_children = html.root_element().children();
     let raw_sections = root_children;
     let summary_selector = Selector::parse("html > p").unwrap();

--- a/crates/rari-lsp/src/lsp.rs
+++ b/crates/rari-lsp/src/lsp.rs
@@ -82,11 +82,11 @@ impl Documents {
         self.documents.insert(uri, doc);
     }
 
-    pub fn get_mut(&self, uri: &Uri) -> Option<RefMut<Uri, Document>> {
+    pub fn get_mut(&self, uri: &Uri) -> Option<RefMut<'_, Uri, Document>> {
         self.documents.get_mut(uri)
     }
 
-    pub fn get(&self, uri: &Uri) -> Option<Ref<Uri, Document>> {
+    pub fn get(&self, uri: &Uri) -> Option<Ref<'_, Uri, Document>> {
         self.documents.get(uri)
     }
 }


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Update toolchain to get the latest clippy updates

### Motivation

Linter was failing in ci, but not locally.

### Additional details

See this [CI run](https://github.com/mdn/rari/actions/runs/16880147078/job/47813767251)

