### PR TITLE
chore(api): apply locale passed to RariApi::link + make optional

### DIFF
--- a/crates/rari-doc/src/helpers/css_info.rs
+++ b/crates/rari-doc/src/helpers/css_info.rs
@@ -114,7 +114,7 @@ pub fn css_info_properties(
             "animationType",
             Cow::Owned(RariApi::link(
                 "/Web/CSS/CSS_animated_properties",
-                locale,
+                Some(locale),
                 Some(get_css_l10n_for_locale("animationType", locale)),
                 false,
                 None,
@@ -306,7 +306,7 @@ pub fn css_computed(locale: Locale) -> Result<String, DocError> {
     let copy = l10n_json_data("Template", "xref_csscomputed", locale)?;
     RariApi::link(
         "/Web/CSS/CSS_cascade/Value_processing#computed_value",
-        locale,
+        Some(locale),
         Some(copy),
         false,
         None,
@@ -318,7 +318,7 @@ pub fn css_inherited(locale: Locale) -> Result<String, DocError> {
     let copy = l10n_json_data("Template", "xref_cssinherited", locale)?;
     RariApi::link(
         "/Web/CSS/CSS_cascade/Inheritance",
-        locale,
+        Some(locale),
         Some(copy),
         false,
         None,
@@ -330,7 +330,7 @@ pub fn css_initial(locale: Locale) -> Result<String, DocError> {
     let copy = l10n_json_data("Template", "xref_cssinitial", locale)?;
     RariApi::link(
         "/Web/CSS/CSS_cascade/Value_processing#initial_value",
-        locale,
+        Some(locale),
         Some(copy),
         false,
         None,

--- a/crates/rari-doc/src/templ/api.rs
+++ b/crates/rari-doc/src/templ/api.rs
@@ -97,18 +97,35 @@ impl RariApi {
         &settings().interactive_examples_base_url
     }
 
+    /**
+     * Renders a link to a page. If a locale is provided, it will be used to generate the link.
+     * If no locale is provided, either the locale implicit in the link or the default locale will be used.
+     *
+     * @param link The URL of the page.
+     * @param locale The optional locale of the page.
+     * @param content The content of the link.
+     * @param code Whether the link is for code.
+     * @param title The title of the link.
+     * @param with_badges Whether to include badges.
+     * @return The rendered link.
+     */
     pub fn link(
         link: &str,
-        locale: Locale,
+        locale: Option<Locale>,
         content: Option<&str>,
         code: bool,
         title: Option<&str>,
         with_badges: bool,
     ) -> Result<String, DocError> {
         let mut out = String::new();
+        let (url, locale) = if let Some(locale) = locale {
+            (link.strip_prefix("/en-US/docs").unwrap_or(link), locale)
+        } else {
+            (link, Locale::default())
+        };
         render_link_via_page(
             &mut out,
-            link,
+            url,
             locale,
             content,
             title,

--- a/crates/rari-doc/src/templ/templs/api_list_alpha.rs
+++ b/crates/rari-doc/src/templ/templs/api_list_alpha.rs
@@ -37,7 +37,7 @@ pub fn apilistalpha() -> Result<String, DocError> {
             "<li>",
             &RariApi::link(
                 page.url(),
-                env.locale,
+                Some(env.locale),
                 None,
                 true,
                 Some(page.short_title().unwrap_or(page.title())),

--- a/crates/rari-doc/src/templ/templs/css_ref.rs
+++ b/crates/rari-doc/src/templ/templs/css_ref.rs
@@ -230,7 +230,7 @@ pub fn css_ref() -> Result<String, DocError> {
                 "<li>",
                 &RariApi::link(
                     &concat_strs!("/Web/CSS/", url.as_ref()),
-                    env.locale,
+                    Some(env.locale),
                     Some(&html_escape::encode_text(&label)),
                     true,
                     None,

--- a/crates/rari-doc/src/templ/templs/css_ref_list.rs
+++ b/crates/rari-doc/src/templ/templs/css_ref_list.rs
@@ -56,7 +56,7 @@ pub fn css_ref_list() -> Result<String, DocError> {
                 "<li>",
                 &RariApi::link(
                     &concat_strs!("/", url),
-                    env.locale,
+                    Some(env.locale),
                     Some(&html_escape::encode_text(&label)),
                     true,
                     None,

--- a/crates/rari-doc/src/templ/templs/glossary.rs
+++ b/crates/rari-doc/src/templ/templs/glossary.rs
@@ -12,7 +12,7 @@ pub fn glossary(term_name: String, display_name: Option<String>) -> Result<Strin
     );
     RariApi::link(
         &url,
-        env.locale,
+        Some(env.locale),
         Some(&display_name.unwrap_or(term_name)),
         false,
         None,

--- a/crates/rari-doc/src/templ/templs/links/csp.rs
+++ b/crates/rari-doc/src/templ/templs/links/csp.rs
@@ -32,7 +32,7 @@ pub fn csp(directive: String) -> Result<String, DocError> {
     );
     RariApi::link(
         &url,
-        env.locale,
+        Some(env.locale),
         Some(directive.as_ref()),
         true,
         None,

--- a/crates/rari-doc/src/templ/templs/links/cssxref.rs
+++ b/crates/rari-doc/src/templ/templs/links/cssxref.rs
@@ -91,5 +91,5 @@ pub fn cssxref_internal(
     } else {
         encoded_maybe_display_name.to_string()
     };
-    RariApi::link(&url, locale, Some(&display_name), true, None, false)
+    RariApi::link(&url, Some(locale), Some(&display_name), true, None, false)
 }

--- a/crates/rari-doc/src/templ/templs/links/domxref.rs
+++ b/crates/rari-doc/src/templ/templs/links/domxref.rs
@@ -71,7 +71,7 @@ pub fn domxref(
     let code = !no_code.map(|nc| nc.as_bool()).unwrap_or_default();
     RariApi::link(
         &url,
-        env.locale,
+        Some(env.locale),
         Some(&display_with_fallback),
         code,
         display,

--- a/crates/rari-doc/src/templ/templs/links/htmlxref.rs
+++ b/crates/rari-doc/src/templ/templs/links/htmlxref.rs
@@ -50,5 +50,12 @@ pub fn htmlelement(
         url.push_str(&anchor);
     }
 
-    RariApi::link(&url, env.locale, Some(display.as_ref()), code, None, false)
+    RariApi::link(
+        &url,
+        Some(env.locale),
+        Some(display.as_ref()),
+        code,
+        None,
+        false,
+    )
 }

--- a/crates/rari-doc/src/templ/templs/links/http.rs
+++ b/crates/rari-doc/src/templ/templs/links/http.rs
@@ -129,5 +129,12 @@ fn http(
         display.push_str(&anchor);
     }
     let code = !no_code.map(|nc| nc.as_bool()).unwrap_or_default();
-    RariApi::link(&url, locale, Some(display.as_ref()), code, None, false)
+    RariApi::link(
+        &url,
+        Some(locale),
+        Some(display.as_ref()),
+        code,
+        None,
+        false,
+    )
 }

--- a/crates/rari-doc/src/templ/templs/links/jsxref.rs
+++ b/crates/rari-doc/src/templ/templs/links/jsxref.rs
@@ -72,5 +72,5 @@ pub fn jsxref(
     }
 
     let code = !no_code.map(|nc| nc.as_bool()).unwrap_or_default();
-    RariApi::link(&url, env.locale, Some(display), code, None, false)
+    RariApi::link(&url, Some(env.locale), Some(display), code, None, false)
 }

--- a/crates/rari-doc/src/templ/templs/links/mathmlxref.rs
+++ b/crates/rari-doc/src/templ/templs/links/mathmlxref.rs
@@ -14,7 +14,7 @@ use crate::templ::api::RariApi;
 /// # Arguments
 /// * `element_name` - The MathML element name (will be converted to lowercase)
 ///
-/// # Examples  
+/// # Examples
 /// * `{{MathMLElement("math")}}` -> links to `<math>` element with code formatting
 /// * `{{MathMLElement("mrow")}}` -> links to `<mrow>` element
 /// * `{{MathMLElement("mi")}}` -> links to `<mi>` element for identifiers
@@ -38,5 +38,12 @@ pub fn mathmlelement(element_name: String) -> Result<String, DocError> {
         element_name.as_str()
     );
 
-    RariApi::link(&url, env.locale, Some(&display), true, Some(&title), false)
+    RariApi::link(
+        &url,
+        Some(env.locale),
+        Some(&display),
+        true,
+        Some(&title),
+        false,
+    )
 }

--- a/crates/rari-doc/src/templ/templs/links/svgattr.rs
+++ b/crates/rari-doc/src/templ/templs/links/svgattr.rs
@@ -12,7 +12,7 @@ use crate::templ::api::RariApi;
 /// # Arguments
 /// * `name` - The SVG attribute name (e.g., "fill", "stroke", "viewBox")
 ///
-/// # Examples  
+/// # Examples
 /// * `{{SVGAttr("fill")}}` -> links to fill attribute with code formatting
 /// * `{{SVGAttr("stroke-width")}}` -> links to stroke-width attribute
 /// * `{{SVGAttr("viewBox")}}` -> links to viewBox attribute
@@ -29,5 +29,5 @@ pub fn svgattr(name: String) -> Result<String, DocError> {
         name,
     );
 
-    RariApi::link(&url, env.locale, Some(&name), true, None, false)
+    RariApi::link(&url, Some(env.locale), Some(&name), true, None, false)
 }

--- a/crates/rari-doc/src/templ/templs/links/svgxref.rs
+++ b/crates/rari-doc/src/templ/templs/links/svgxref.rs
@@ -37,5 +37,12 @@ pub fn svgxref_internal(element_name: &str, locale: Locale) -> Result<String, Do
         element_name,
     );
 
-    RariApi::link(&url, locale, Some(display.as_ref()), true, None, false)
+    RariApi::link(
+        &url,
+        Some(locale),
+        Some(display.as_ref()),
+        true,
+        None,
+        false,
+    )
 }

--- a/crates/rari-doc/src/templ/templs/links/webextapixref.rs
+++ b/crates/rari-doc/src/templ/templs/links/webextapixref.rs
@@ -56,7 +56,7 @@ pub fn webextapiref(
 
     RariApi::link(
         &url,
-        env.locale,
+        Some(env.locale),
         Some(display.as_ref()),
         !no_code.map(|nc| nc.as_bool()).unwrap_or_default(),
         None,

--- a/crates/rari-doc/src/templ/templs/svginfo.rs
+++ b/crates/rari-doc/src/templ/templs/svginfo.rs
@@ -45,7 +45,8 @@ pub fn svginfo() -> Result<String, DocError> {
                     let anchor = to_snake_case(element);
                     let url = format!("/{}/docs/Web/SVG/Element#{anchor}", env.locale.as_url_str());
                     let display = l10n_json_data("SVG", element, env.locale).unwrap_or(element);
-                    let link = RariApi::link(&url, env.locale, Some(display), false, None, false)?;
+                    let link =
+                        RariApi::link(&url, Some(env.locale), Some(display), false, None, false)?;
                     element_groups.push(link);
                 }
                 Ok::<_, DocError>((element_groups, elements))

--- a/crates/rari-doc/src/templ/templs/webext_all_examples.rs
+++ b/crates/rari-doc/src/templ/templs/webext_all_examples.rs
@@ -31,7 +31,7 @@ pub fn webextallexamples() -> Result<String, DocError> {
                 env.locale.as_url_str(),
                 &api.replace(' ', "_").replace("()", "").replace('.', "/"),
             );
-            let link = RariApi::link(&url, env.locale, None, true, None, false)?;
+            let link = RariApi::link(&url, Some(env.locale), None, true, None, false)?;
             out.push_str(&link);
             out.push_str("<br/>")
         }


### PR DESCRIPTION
### Description

The`{{APIListAlpha}}` macro was handling locale incorrectly (always returning en-US links, regardless of the presence of a translated page). 

### Motivation

Repairing a leftover regression after moving to rari, made explicit in [this Issue](https://github.com/mdn/rari/issues/286).

### Additional details

While fixing the logic, it was decided to make the function shape more in line with the rest of the internal API, by passing in an optional locale to `RariApi::link`. Concequently, all callers of the function had to be changed as well.

### Related issues and pull requests

fixes  #286 