### PR TITLE
fix(APIListAlpha): use current locale for links

### DIFF
--- a/crates/rari-doc/src/templ/templs/api_list_alpha.rs
+++ b/crates/rari-doc/src/templ/templs/api_list_alpha.rs
@@ -1,5 +1,6 @@
 use rari_templ_func::rari_f;
 use rari_types::fm_types::PageType;
+use rari_utils::concat_strs;
 
 use crate::error::DocError;
 use crate::helpers::subpages::{get_sub_pages, SubPagesSorter};
@@ -33,10 +34,13 @@ pub fn apilistalpha() -> Result<String, DocError> {
                 out.push_str("</h3><ul>");
             }
         }
+
+        let url = concat_strs!("/", env.locale.as_url_str(), "/docs/", page.slug());
+
         out.extend([
             "<li>",
             &RariApi::link(
-                page.url(),
+                &url,
                 env.locale,
                 None,
                 true,


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Updates the `APIListAlpha` macro to use the current locale for interface links.

### Motivation

In translated locales, all links currently point to en-US, even if the page is available in the current locale.

### Additional details

<img width="867" height="382" alt="image" src="https://github.com/user-attachments/assets/49e352b0-7266-450f-a73e-52c54934ec7a" />

### Related issues and pull requests

Fixes https://github.com/mdn/rari/issues/286.

Closes https://github.com/mdn/rari/pull/287.
