### PR TITLE
fix(contributors): add short_title to spotlight pages

### DIFF
--- a/crates/rari-doc/src/pages/build.rs
+++ b/crates/rari-doc/src/pages/build.rs
@@ -468,6 +468,7 @@ fn build_contributor_spotlight(cs: &ContributorSpotlight) -> Result<BuiltPage, D
     Ok(BuiltPage::ContributorSpotlight(Box::new(
         JsonContributorSpotlightPage {
             url: cs.meta.url.clone(),
+            short_title: cs.meta.short_title.clone(),
             page_title: cs.meta.title.clone(),
             hy_data: contributor_spotlight_data,
             common: CommonJsonData {

--- a/crates/rari-doc/src/pages/json.rs
+++ b/crates/rari-doc/src/pages/json.rs
@@ -611,6 +611,7 @@ pub struct ContributorSpotlightHyData {
 #[schemars(rename = "ContributorSpotlightPage")]
 pub struct JsonContributorSpotlightPage {
     pub url: String,
+    pub short_title: String,
     #[serde(rename = "pageTitle")]
     pub page_title: String,
     #[serde(rename = "hyData")]

--- a/crates/rari-doc/src/pages/types/contributors.rs
+++ b/crates/rari-doc/src/pages/types/contributors.rs
@@ -51,6 +51,7 @@ pub struct ContributorMeta {
 pub struct ContributorBuildMeta {
     pub locale: Locale,
     pub slug: String,
+    pub short_title: String,
     pub title: String,
     pub url: String,
     pub contributor_name: String,
@@ -120,6 +121,7 @@ impl ContributorBuildMeta {
         Ok(Self {
             url: concat_strs!("/", locale.as_url_str(), "/community/", slug.as_str()),
             locale,
+            short_title: concat_strs!("Contributor Spotlight: ", contributor_name.as_str()),
             title: concat_strs!(
                 "Contributor, Spotlight - ",
                 contributor_name.as_str(),
@@ -186,7 +188,7 @@ impl PageLike for ContributorSpotlight {
     }
 
     fn short_title(&self) -> Option<&str> {
-        None
+        Some(&self.meta.short_title)
     }
 
     fn locale(&self) -> Locale {

--- a/crates/rari-doc/src/pages/types/contributors.rs
+++ b/crates/rari-doc/src/pages/types/contributors.rs
@@ -122,11 +122,7 @@ impl ContributorBuildMeta {
             url: concat_strs!("/", locale.as_url_str(), "/community/", slug.as_str()),
             locale,
             short_title: concat_strs!("Contributor Spotlight: ", contributor_name.as_str()),
-            title: concat_strs!(
-                "Contributor, Spotlight - ",
-                contributor_name.as_str(),
-                " | MDN"
-            ),
+            title: concat_strs!(contributor_name.as_str(), " - Contributor Spotlight | MDN"),
             slug,
             contributor_name,
             folder_name,

--- a/crates/rari-doc/src/pages/types/contributors.rs
+++ b/crates/rari-doc/src/pages/types/contributors.rs
@@ -121,7 +121,7 @@ impl ContributorBuildMeta {
         Ok(Self {
             url: concat_strs!("/", locale.as_url_str(), "/community/", slug.as_str()),
             locale,
-            short_title: concat_strs!("Contributor Spotlight: ", contributor_name.as_str()),
+            short_title: concat_strs!("Spotlight: ", contributor_name.as_str()),
             title: concat_strs!(contributor_name.as_str(), " - Contributor Spotlight | MDN"),
             slug,
             contributor_name,


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

1. Adds `short_title` to Contributor Spotlight pages.
2. Improves the `pageTitle` of Contributor Spotlight pages.

### Motivation

1. Prevents the full `pageTitle` from showing up in the breadcrumbs.
2. Makes the `pageTitle` consistent with other pages (`<current page> - <section> - MDN`).

### Additional details

#### Before

1. <img width="572" height="113" alt="image" src="https://github.com/user-attachments/assets/963050bb-a499-4a26-b1b2-83445019fab6" />
2. <img width="364" height="71" alt="image" src="https://github.com/user-attachments/assets/83de96f6-96dd-4e22-866d-b0bb09ff3227" />

#### After

1. <img width="572" height="113" alt="image" src="https://github.com/user-attachments/assets/ab06322d-ae86-44d1-a068-c190c06210bb" />
3. <img width="364" height="71" alt="image" src="https://github.com/user-attachments/assets/3dfa7899-3a64-4c74-8277-4956508e12d5" />

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
