### PR TITLE
chore(rari-deps): handle GitHub API error

### DIFF
--- a/crates/rari-deps/src/error.rs
+++ b/crates/rari-deps/src/error.rs
@@ -22,6 +22,6 @@ pub enum DepsError {
     VersionNotFound,
     #[error("Invalid url: {0}")]
     UrlError(#[from] url::ParseError),
-    #[error("upstream error: {0}")]
-    UpstreamError(String),
+    #[error("GitHub error: {0}")]
+    GithubError(String),
 }

--- a/crates/rari-deps/src/github_release.rs
+++ b/crates/rari-deps/src/github_release.rs
@@ -30,8 +30,8 @@ fn get_version(repo: &str, version_req: &VersionReq) -> Result<(Version, String)
         let status = resp.status();
         let err: Result<GithubError, _> = resp.json();
         return Err(match err {
-            Ok(e) => DepsError::UpstreamError(format!("GitHub error: {} ({url})", e.message)),
-            Err(_) => DepsError::UpstreamError(format!("GitHub HTTP {status} ({url})")),
+            Ok(e) => DepsError::GithubError(format!("{} ({url})", e.message)),
+            Err(_) => DepsError::GithubError(format!("HTTP {status} ({url})")),
         });
     }
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Handle GitHub API error, and use error message.

### Motivation

Avoids the following error message:

```
Error: invalid type: map, expected a sequence
```

Instead, it will show an error message like this:

```
Updating @webref/css to 6.23.8
Error: GitHub error: API rate limit exceeded for ***.***.**.**. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.) (https://api.github.com/repos/web-platform-dx/web-features/releases?per_page=10)
```

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Fixes https://github.com/mdn/rari/issues/279.