### PR TITLE
fix(webref_css): pin @webref/css to v6

### DIFF
--- a/crates/rari-deps/src/webref_css.rs
+++ b/crates/rari-deps/src/webref_css.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 use css_syntax_types::Css;
 use rari_types::globals::deps;
 use rari_utils::io::read_to_string;
+use semver::VersionReq;
 use serde_json::Value;
 
 use crate::error::DepsError;
@@ -85,7 +86,14 @@ fn list_all(folder: &Path) -> Result<BTreeMap<String, Css>, DepsError> {
 }
 
 pub fn update_webref_css(base_path: &Path) -> Result<(), DepsError> {
-    if let Some(package_path) = get_package("@webref/css", &deps().webref_css, base_path)? {
+    if let Some(package_path) = get_package(
+        "@webref/css",
+        &deps()
+            .webref_css
+            .clone()
+            .or_else(|| Some(VersionReq::parse(">=6.0.0, <7.0.0").unwrap())),
+        base_path,
+    )? {
         let webref_css_dest_path = package_path.join("webref_css.json");
         let webref_css = list_all(&package_path)?;
         fs::write(webref_css_dest_path, serde_json::to_string(&webref_css)?)?;


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Pins `@webref/css` to v6 (manually for now).

### Motivation

The v7 release contains breaking changes that we have to adjust to, and this requires further work.

### Additional details

Tested locally by renaming `crates/css-syntax/{package => package-old}` and running `cargo run build`:

```
cargo run build       
(…)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.17s
     Running `target/debug/rari build`
Update for @webref/css available 6.23.10 -> 7.0.11
Updating @webref/css to 6.23.10
Building everything 🛠️
```

### Related issues and pull requests

Part of https://github.com/mdn/rari/issues/304.