### PR TITLE
fix(webref_css): pin @webref/css to v6 using package.json

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,3 +3,4 @@ TESTING_CONTENT_ROOT = { value = "tests/data/content/files", relative = true }
 TESTING_CONTENT_TRANSLATED_ROOT = { value = "tests/data/translated_content/files", relative = true }
 TESTING_CACHE_CONTENT = "0"
 TESTING_READER_IGNORES_GITIGNORE = "1"
+DEPS_PACKAGE_JSON = { value = "package.json", relative = true }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@webref/css": ">=6.0.0, <7.0.0"
+  }
+}


### PR DESCRIPTION
Alternative to https://github.com/mdn/rari/pull/305

Tested locally with (the paths are a little different on linux):

```
rm -r ~/.local/share/rari/@webref/css/
CONTENT_ROOT=../content/files cargo run serve
```

Resulting in:

```
Update for @webref/css available 6.23.10 -> 7.0.11
Updating @webref/css to 6.23.10
```