### PR TITLE
fix(rari-npm): handle exit with signal

### DIFF
--- a/rari-npm/lib/cli.js
+++ b/rari-npm/lib/cli.js
@@ -13,8 +13,8 @@ spawn(rariBin, input, { stdio: "inherit" }).on("exit", (code, signal) => {
     } catch {
       // Reflect signal code in exit code.
       // See: https://nodejs.org/api/os.html#os-constants
-      const signalCode = os.constants?.signals?.[signal];
-      process.exit(signalCode ? 128 + signalCode : 1);
+      const signalCode = os.constants?.signals?.[signal] ?? 0;
+      process.exit(128 + signalCode);
     }
   }
   process.exit(code ?? 0);

--- a/rari-npm/lib/cli.js
+++ b/rari-npm/lib/cli.js
@@ -6,4 +6,16 @@ import { rariBin } from "./index.js";
 
 const input = process.argv.slice(2);
 
-spawn(rariBin, input, { stdio: "inherit" }).on("exit", process.exit);
+spawn(rariBin, input, { stdio: "inherit" }).on("exit", (code, signal) => {
+  if (signal) {
+    try {
+      process.kill(process.pid, signal);
+    } catch {
+      // Reflect signal code in exit code.
+      // See: https://nodejs.org/api/os.html#os-constants
+      const signalCode = os.constants?.signals?.[signal];
+      process.exit(signalCode ? 128 + signalCode : 1);
+    }
+  }
+  process.exit(code ?? 0);
+});


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Updates `rari-npm/lib/cli.js` to handle an exit with signal (i.e. without exit code).

### Motivation

If rari panicks, it terminates with the "SIGABRT" signal, not a with a exit code. This was not handled properly, so the CLI wrapper around rari was always exiting with code 0 (success).

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Fixes #306.