### PR TITLE
fix(npm): generate types matching serialized objects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2982,9 +2982,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.9.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
 dependencies = [
  "chrono",
  "dyn-clone",
@@ -2997,9 +2997,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.9.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5016d94c77c6d32f0b8e08b781f7dc8a90c2007d4e77472cc2807bc10a8438fe"
+checksum = "33d020396d1d138dc19f1165df7545479dcd58d93810dc5d646a16e55abefa80"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ console = "0.15"
 sha2 = "0.10"
 dashmap = { version = "6", features = ["serde"] }
 serde_yaml_ng = "0.10"
-schemars = { version = "0.9", features = ["chrono04", "url2"] }
+schemars = { version = "1", features = ["chrono04", "url2"] }
 pretty_yaml = "0.5"
 yaml_parser = "0.2"
 const_format = "0.2"

--- a/crates/rari-cli/main.rs
+++ b/crates/rari-cli/main.rs
@@ -41,7 +41,6 @@ use rari_types::globals::{build_out_root, content_root, content_translated_root,
 use rari_types::locale::Locale;
 use rari_types::settings::Settings;
 use rari_utils::io::read_to_string;
-use schemars::schema_for;
 use self_update::cargo_crate_version;
 use tabwriter::TabWriter;
 use tracing::level_filters::LevelFilter;
@@ -558,7 +557,10 @@ fn export_schema(args: ExportSchemaArgs) -> Result<(), Error> {
     let out_path = args
         .output_file
         .unwrap_or_else(|| PathBuf::from("schema.json"));
-    let schema = schema_for!(BuiltPage);
+    let schema = schemars::generate::SchemaSettings::default()
+        .for_serialize()
+        .into_generator()
+        .into_root_schema_for::<BuiltPage>();
     fs::write(out_path, serde_json::to_string_pretty(&schema)?)?;
     Ok(())
 }


### PR DESCRIPTION
Opening as draft because this'll need to be released in tandem with: https://github.com/mdn/fred/pull/781

Updates schemars and changes the settings to generate types for *serialized* objects (rather than types for objects to be *deserialized*, the default): https://graham.cool/schemars/generating/#serialize-vs-deserialize-contract

This means that fields in structs that have `skip_serializing` aren't included, and which have `skip_serializing_if` are made optional - both important changes to ensure our types are correct in fred.

currently we can have a struct like:
```rs
pub struct Example {
  #[serde(skip_serializing)]
  pub foo: Vec<String>
  #[serde(skip_serializing_if = "Vec::is_empty")]
  pub bar: Vec<String>
}
```
which will end up generating types like:
```ts
interface Example {
  foo: string[];
  bar: string[];
}
```
but actually serialize to an object like:
```js
{}
```

This change means the types generated would be like:
```ts
interface Example {
  bar?: string[];
}
```