### PR TITLE
chore: add rustfmt and clippy to linter action toolchain

### DIFF
--- a/.github/workflows/lint-test-clippy.yaml
+++ b/.github/workflows/lint-test-clippy.yaml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@4305c38b25d97ef35a8ad1f985ccf2d2242004f2 # stable
+        with:
+          components: rustfmt, clippy
       - name: sccache-cache
         uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
 

--- a/crates/rari-lsp/src/lsp.rs
+++ b/crates/rari-lsp/src/lsp.rs
@@ -294,7 +294,7 @@ impl LanguageServer for Backend {
                 let (locale, link) = link
                     .trim_start_matches('/')
                     .split_once('/')
-                    .and_then(|(l, link)| (Locale::from_str(l).ok().map(|l| (l, link))))
+                    .and_then(|(l, link)| Locale::from_str(l).ok().map(|l| (l, link)))
                     .unwrap_or((Locale::EnUs, &link));
                 let items = doc_pages_from_slugish(link, locale)
                     .unwrap()


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Adds rustfmt and clippy components to the toolchain used for the linting action

### Motivation

The action failed because these were missing

