### PR TITLE
ci(workflows): disable `actions/checkout` credential persistance

### DIFF
--- a/.github/workflows/publish-npm-manual.yml
+++ b/.github/workflows/publish-npm-manual.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Setup
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Checkout
         uses: actions/setup-node@v5

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Setup
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Checkout
         uses: actions/setup-node@v5


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description
  
Adds `persist-credentials: false` to all `actions/checkout` workflow steps.

## Motivation

Applies security best practices. It prevents persistance of the `GITHUB_TOKEN` in the local git config.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/883.
