### PR TITLE
fix(csssyntax): update renamed CSS slug

### DIFF
--- a/crates/rari-doc/src/templ/templs/csssyntax.rs
+++ b/crates/rari-doc/src/templ/templs/csssyntax.rs
@@ -62,7 +62,7 @@ pub fn csssyntax(name: Option<String>) -> Result<String, DocError> {
         typ,
         env.locale.as_url_str(),
         &format!(
-            "/{}/docs/Web/CSS/CSS_Values_and_Units/Value_definition_syntax",
+            "/{}/docs/Web/CSS/CSS_values_and_units/Value_definition_syntax",
             env.locale.as_url_str()
         ),
         &TOOLTIPS,
@@ -77,7 +77,7 @@ pub fn csssyntaxraw(syntax: String) -> Result<String, DocError> {
         syntax,
         env.locale.as_url_str(),
         &format!(
-            "/{}/docs/Web/CSS/CSS_Values_and_Units/Value_definition_syntax",
+            "/{}/docs/Web/CSS/CSS_values_and_units/Value_definition_syntax",
             env.locale.as_url_str()
         ),
         &TOOLTIPS,


### PR DESCRIPTION
Updating the slug on /content/ as it's the only slug that is title case. All others are sentence case. See https://github.com/mdn/content/pull/41438