### PR TITLE
chore(npm): migrate to Trusted Publishing

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -25,6 +25,10 @@ jobs:
           node-version-file: "./rari-npm/package.json"
           package-manager-cache: false
 
+      # Ensure npm 11.5.1 or later for trusted publishing
+      - name: Install latest npm
+        run: npm install -g npm@latest
+
       - name: Generate Schema
         working-directory: ./rari-npm
         run: npm install && npm run export-schema && npm run generate-types

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -5,8 +5,8 @@ on:
     workflows: [build-and-upload-binaries]
     types: [completed]
 
-# No GITHUB_TOKEN permissions, as we only use it to increase API limit.
-permissions: {}
+permissions:
+  id-token: write # OIDC for npm Trusted Publishing
 
 jobs:
   on-success:
@@ -37,6 +37,4 @@ jobs:
 
       - name: Publish
         working-directory: ./rari-npm
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public --provenance


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Migrates the `publish-npm` workflow from token-based to [Trusted publishing](https://docs.npmjs.com/trusted-publishers).

Note: Trusted publishing has already been configured on npmjs.com.

### Motivation

> Trusted publishing eliminates long-lived tokens entirely by using temporary, job-specific credentials from your CI/CD provider.

### Additional details

See: https://github.blog/changelog/2025-09-29-strengthening-npm-security-important-changes-to-authentication-and-token-management/#looking-ahead-trusted-publishers

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1018.
