### PR TITLE
chore(css-syntax): update to webref 8

### DIFF
--- a/crates/rari-types/src/settings.rs
+++ b/crates/rari-types/src/settings.rs
@@ -52,7 +52,7 @@ impl Deps {
         let mut deps: Self = s.try_deserialize::<Self>()?;
         // Make sure we are in the correct version range for webref-css, unless overridden.
         if deps.webref_css.is_none() {
-            deps.webref_css = VersionReq::parse(">=7.0.0, <8.0.0").ok();
+            deps.webref_css = VersionReq::parse(">=7.0.0, <9.0.0").ok();
         }
         Ok(deps)
     }


### PR DESCRIPTION


### Description

This follows the upstream update of webref-css to version 8. 

### Additional details

Ran a diff on the output with webref 7x vs 8.x with no issues detected.

