### PR TITLE
chore(deps): bump rust from 1.86 to 1.90

### DIFF
--- a/.github/workflows/lint-test-clippy.yaml
+++ b/.github/workflows/lint-test-clippy.yaml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@4305c38b25d97ef35a8ad1f985ccf2d2242004f2 # stable
+      - uses: dtolnay/rust-toolchain@9a1d20035bdbcbc899baabe1e402e85bc33639bc # 1.90
         with:
           components: rustfmt, clippy
       - name: sccache-cache

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "rari"
 version = "0.2.0"
-edition = "2021"
+edition = "2024"
 license = "MPL-2.0"
 authors = ["MDN Engineering Team <mdn-dev@mozilla.com>"]
 homepage = "https://github.com/mdn/rari"
 repository = "https://github.com/mdn/rari"
-rust-version = "1.86"
+rust-version = "1.90"
 
 [[bin]]
 path = "crates/rari-cli/main.rs"
@@ -45,10 +45,10 @@ members = [
 ]
 
 [workspace.package]
-edition = "2021"
+edition = "2024"
 license = "MPL-2.0"
 authors = ["MDN Engineering Team <mdn-dev@mozilla.com>"]
-rust-version = "1.86"
+rust-version = "1.90"
 
 [workspace.dependencies]
 rari-doc = { path = "crates/rari-doc" }

--- a/crates/css-definition-syntax/src/parser.rs
+++ b/crates/css-definition-syntax/src/parser.rs
@@ -560,19 +560,20 @@ fn regroup_terms(
                     continue;
                 } else {
                     if let Some(subgroup_start) = subgroup_start
-                        && i - subgroup_start > 1 {
-                            let group = terms.splice(subgroup_start..i, empty()).collect();
-                            terms.insert(
-                                subgroup_start,
-                                Node::Group(Group {
-                                    terms: group,
-                                    combinator,
-                                    disallow_empty: false,
-                                    explicit: false,
-                                }),
-                            );
-                            i = subgroup_start + 1;
-                        }
+                        && i - subgroup_start > 1
+                    {
+                        let group = terms.splice(subgroup_start..i, empty()).collect();
+                        terms.insert(
+                            subgroup_start,
+                            Node::Group(Group {
+                                terms: group,
+                                combinator,
+                                disallow_empty: false,
+                                explicit: false,
+                            }),
+                        );
+                        i = subgroup_start + 1;
+                    }
                     subgroup_start = None;
                 }
             }
@@ -580,18 +581,19 @@ fn regroup_terms(
         }
 
         if let Some(subgroup_start) = subgroup_start
-            && !combinators.is_empty() {
-                let group = terms.splice(subgroup_start..i, empty()).collect();
-                terms.insert(
-                    subgroup_start,
-                    Node::Group(Group {
-                        terms: group,
-                        combinator,
-                        disallow_empty: false,
-                        explicit: false,
-                    }),
-                );
-            }
+            && !combinators.is_empty()
+        {
+            let group = terms.splice(subgroup_start..i, empty()).collect();
+            terms.insert(
+                subgroup_start,
+                Node::Group(Group {
+                    terms: group,
+                    combinator,
+                    disallow_empty: false,
+                    explicit: false,
+                }),
+            );
+        }
     }
     (terms, combinator)
 }
@@ -666,9 +668,10 @@ fn peek(
 ) -> Result<Option<Node>, SyntaxDefinitionError> {
     let code = tokenizer.char_code();
     if let Some(stop_char) = stop_char
-        && code == stop_char {
-            return Ok(None);
-        }
+        && code == stop_char
+    {
+        return Ok(None);
+    }
     if is_name_char(code) {
         return Ok(Some(read_keyword_or_function(tokenizer)?));
     }

--- a/crates/css-definition-syntax/src/parser.rs
+++ b/crates/css-definition-syntax/src/parser.rs
@@ -559,8 +559,8 @@ fn regroup_terms(
                     terms.remove(i);
                     continue;
                 } else {
-                    if let Some(subgroup_start) = subgroup_start {
-                        if i - subgroup_start > 1 {
+                    if let Some(subgroup_start) = subgroup_start
+                        && i - subgroup_start > 1 {
                             let group = terms.splice(subgroup_start..i, empty()).collect();
                             terms.insert(
                                 subgroup_start,
@@ -573,15 +573,14 @@ fn regroup_terms(
                             );
                             i = subgroup_start + 1;
                         }
-                    }
                     subgroup_start = None;
                 }
             }
             i += 1;
         }
 
-        if let Some(subgroup_start) = subgroup_start {
-            if !combinators.is_empty() {
+        if let Some(subgroup_start) = subgroup_start
+            && !combinators.is_empty() {
                 let group = terms.splice(subgroup_start..i, empty()).collect();
                 terms.insert(
                     subgroup_start,
@@ -593,7 +592,6 @@ fn regroup_terms(
                     }),
                 );
             }
-        }
     }
     (terms, combinator)
 }
@@ -667,11 +665,10 @@ fn peek(
     stop_char: Option<char>,
 ) -> Result<Option<Node>, SyntaxDefinitionError> {
     let code = tokenizer.char_code();
-    if let Some(stop_char) = stop_char {
-        if code == stop_char {
+    if let Some(stop_char) = stop_char
+        && code == stop_char {
             return Ok(None);
         }
-    }
     if is_name_char(code) {
         return Ok(Some(read_keyword_or_function(tokenizer)?));
     }

--- a/crates/css-syntax/src/syntax.rs
+++ b/crates/css-syntax/src/syntax.rs
@@ -106,14 +106,13 @@ pub fn get_at_rule_syntax(name: &str) -> Syntax {
 
 /// Get the formal syntax for an at-rule descriptor from the webref data.
 pub fn get_at_rule_descriptor_syntax(at_rule_descriptor_name: &str, at_rule_name: &str) -> Syntax {
-    if let Some(at_rule) = CSS_REF.atrules.get(at_rule_name) {
-        if let Some(at_rule_descriptor) = at_rule.descriptors.get(at_rule_descriptor_name) {
+    if let Some(at_rule) = CSS_REF.atrules.get(at_rule_name)
+        && let Some(at_rule_descriptor) = at_rule.descriptors.get(at_rule_descriptor_name) {
             return Syntax {
                 syntax: at_rule_descriptor.syntax.clone().unwrap_or_default(),
                 specs: at_rule_descriptor.spec_link.as_ref().map(|s| vec![s]),
             };
         }
-    }
     Syntax::default()
 }
 
@@ -179,15 +178,14 @@ fn get_syntax_internal(typ: CssType, top_level: bool) -> SyntaxLine {
         }
         CssType::Function(name) => {
             let name = format!("{name}()");
-            if let Some(t) = CSS_REF.functions.get(&name) {
-                if let Some(syntax) = &t.syntax {
+            if let Some(t) = CSS_REF.functions.get(&name)
+                && let Some(syntax) = &t.syntax {
                     return Syntax {
                         syntax: syntax.clone(),
                         specs: t.spec_link.as_ref().map(|s| vec![s]),
                     }
                     .to_syntax_line(format!("<{name}>"));
                 }
-            }
             Syntax::default().to_syntax_line(format!("<{name}>"))
         }
         CssType::AtRule(name) => get_at_rule_syntax(name).to_syntax_line(name),
@@ -531,14 +529,13 @@ impl SyntaxRenderer<'_> {
                         Some(get_syntax(CssType::AtRule(&at_keyword.name)))
                     }
                     _ => None,
-                } {
-                    if !constituent_entry.syntax.is_empty()
+                }
+                    && !constituent_entry.syntax.is_empty()
                         && !constituent_syntaxes.contains(&constituent_entry)
                     {
                         constituent.syntax_used = true;
                         constituent_syntaxes.push(constituent_entry)
                     }
-                }
             }
         }
         self.constituents
@@ -645,11 +642,10 @@ fn render_formal_syntax_internal(
     }
 
     let specs = constituents.iter_mut().fold(vec![], |mut acc, s| {
-        if let Some(spec) = s.specs.take() {
-            if !acc.contains(&spec) {
+        if let Some(spec) = s.specs.take()
+            && !acc.contains(&spec) {
                 acc.push(spec)
             }
-        }
         acc
     });
 

--- a/crates/diff-test/src/main.rs
+++ b/crates/diff-test/src/main.rs
@@ -6,17 +6,17 @@ use std::fs;
 use std::fs::File;
 use std::io::{BufWriter, Write as _};
 use std::path::Path;
+use std::sync::LazyLock;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering::Relaxed;
-use std::sync::LazyLock;
 
-use anyhow::{anyhow, Error};
+use anyhow::{Error, anyhow};
 use clap::{Args, Parser, Subcommand};
-use ignore::types::TypesBuilder;
 use ignore::WalkBuilder;
+use ignore::types::TypesBuilder;
 use itertools::Itertools;
 use jsonpath_lib::Compiled;
-use lol_html::{element, rewrite_str, ElementContentHandlers, RewriteStrSettings, Selector};
+use lol_html::{ElementContentHandlers, RewriteStrSettings, Selector, element, rewrite_str};
 use prettydiff::{diff_lines, diff_words};
 use rayon::prelude::*;
 use regex::Regex;
@@ -228,9 +228,10 @@ fn full_diff(
 ) {
     if path.len() == 1
         && let PathIndex::Object(s) = &path[0]
-            && s == "url" {
-                return;
-            }
+        && s == "url"
+    {
+        return;
+    }
     let key = make_key(path);
 
     if SKIP_GLOB_LIST.iter().any(|i| file.starts_with(i)) {

--- a/crates/diff-test/src/main.rs
+++ b/crates/diff-test/src/main.rs
@@ -226,13 +226,11 @@ fn full_diff(
     diff: &mut BTreeMap<String, String>,
     args: &BuildArgs,
 ) {
-    if path.len() == 1 {
-        if let PathIndex::Object(s) = &path[0] {
-            if s == "url" {
+    if path.len() == 1
+        && let PathIndex::Object(s) = &path[0]
+            && s == "url" {
                 return;
             }
-        }
-    }
     let key = make_key(path);
 
     if SKIP_GLOB_LIST.iter().any(|i| file.starts_with(i)) {

--- a/crates/rari-cli/main.rs
+++ b/crates/rari-cli/main.rs
@@ -5,21 +5,21 @@ use std::fs::{self, File};
 use std::io::{BufWriter, Write};
 use std::path::PathBuf;
 use std::str::FromStr;
-use std::sync::mpsc::channel;
 use std::sync::Arc;
+use std::sync::mpsc::channel;
 use std::thread::spawn;
 
-use anyhow::{anyhow, Error};
+use anyhow::{Error, anyhow};
 use clap::{Args, Parser, Subcommand};
 use clap_verbosity_flag::Verbosity;
 use dashmap::DashMap;
-use dialoguer::theme::ColorfulTheme;
 use dialoguer::Confirm;
+use dialoguer::theme::ColorfulTheme;
 use rari_doc::build::{
     build_blog_pages, build_contributor_spotlight_pages, build_curriculum_pages, build_docs,
     build_generic_pages, build_spas, build_top_level_meta,
 };
-use rari_doc::cached_readers::{read_and_cache_doc_pages, CACHED_DOC_PAGE_FILES};
+use rari_doc::cached_readers::{CACHED_DOC_PAGE_FILES, read_and_cache_doc_pages};
 use rari_doc::issues::IN_MEMORY;
 use rari_doc::pages::json::BuiltPage;
 use rari_doc::pages::page::Page;
@@ -37,17 +37,17 @@ use rari_tools::redirects::{fix_redirects, validate_redirects};
 use rari_tools::remove::remove;
 use rari_tools::sidebars::{fmt_sidebars, sync_sidebars};
 use rari_tools::sync_translated_content::sync_translated_content;
-use rari_types::globals::{build_out_root, content_root, content_translated_root, SETTINGS};
+use rari_types::globals::{SETTINGS, build_out_root, content_root, content_translated_root};
 use rari_types::locale::Locale;
 use rari_types::settings::Settings;
 use rari_utils::io::read_to_string;
 use self_update::cargo_crate_version;
 use tabwriter::TabWriter;
 use tracing::level_filters::LevelFilter;
-use tracing::{info, Level};
+use tracing::{Level, info};
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
-use tracing_subscriber::{filter, Layer};
+use tracing_subscriber::{Layer, filter};
 
 mod serve;
 

--- a/crates/rari-cli/serve.rs
+++ b/crates/rari-cli/serve.rs
@@ -102,14 +102,13 @@ async fn get_file_handler(req: Request) -> Result<Response, AppError> {
     } = url_meta_from(url)?;
 
     // Blog author avatars are special.
-    if matches!(page_category, PageCategory::BlogPost) && slug.starts_with("author/") {
-        if let Some(blog_root_parent) = blog_root() {
+    if matches!(page_category, PageCategory::BlogPost) && slug.starts_with("author/")
+        && let Some(blog_root_parent) = blog_root() {
             let path = blog_root_parent
                 .join("authors")
                 .join(slug.strip_prefix("author/").unwrap());
             return Ok(ServeFile::new(path).oneshot(req).await.into_response());
         }
-    }
 
     if let Some(last_slash) = url.rfind('/') {
         let doc_url = &url[..(if matches!(

--- a/crates/rari-cli/serve.rs
+++ b/crates/rari-cli/serve.rs
@@ -5,29 +5,29 @@ use std::sync::atomic::{AtomicI64, AtomicU64};
 
 use axum::body::Body;
 use axum::extract::{Path, Query, Request};
-use axum::http::{header, StatusCode};
+use axum::http::{StatusCode, header};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, put};
 use axum::{Json, Router};
 use rari_doc::cached_readers::wiki_histories;
 use rari_doc::contributors::contributors_txt;
 use rari_doc::error::{DocError, UrlError};
-use rari_doc::issues::{to_display_issues, IN_MEMORY, ISSUE_COUNTER_F};
+use rari_doc::issues::{IN_MEMORY, ISSUE_COUNTER_F, to_display_issues};
 use rari_doc::pages::json::BuiltPage;
 use rari_doc::pages::page::{Page, PageBuilder, PageCategory, PageLike};
 use rari_doc::pages::types::doc::Doc;
 use rari_doc::reader::read_docs_parallel;
-use rari_doc::resolve::{url_meta_from, UrlMeta};
+use rari_doc::resolve::{UrlMeta, url_meta_from};
 use rari_tools::error::ToolError;
 use rari_tools::fix::issues::fix_page;
+use rari_types::Popularities;
 use rari_types::globals::{self, blog_root, content_root, content_translated_root};
 use rari_types::locale::Locale;
-use rari_types::Popularities;
 use rari_utils::io::read_to_string;
 use serde::Serialize;
 use tower::ServiceExt;
 use tower_http::services::ServeFile;
-use tracing::{error, info, span, Level};
+use tracing::{Level, error, info, span};
 
 static REQ_COUNTER: AtomicU64 = AtomicU64::new(1);
 
@@ -102,13 +102,15 @@ async fn get_file_handler(req: Request) -> Result<Response, AppError> {
     } = url_meta_from(url)?;
 
     // Blog author avatars are special.
-    if matches!(page_category, PageCategory::BlogPost) && slug.starts_with("author/")
-        && let Some(blog_root_parent) = blog_root() {
-            let path = blog_root_parent
-                .join("authors")
-                .join(slug.strip_prefix("author/").unwrap());
-            return Ok(ServeFile::new(path).oneshot(req).await.into_response());
-        }
+    if matches!(page_category, PageCategory::BlogPost)
+        && slug.starts_with("author/")
+        && let Some(blog_root_parent) = blog_root()
+    {
+        let path = blog_root_parent
+            .join("authors")
+            .join(slug.strip_prefix("author/").unwrap());
+        return Ok(ServeFile::new(path).oneshot(req).await.into_response());
+    }
 
     if let Some(last_slash) = url.rfind('/') {
         let doc_url = &url[..(if matches!(

--- a/crates/rari-data/src/baseline.rs
+++ b/crates/rari-data/src/baseline.rs
@@ -102,12 +102,12 @@ impl WebFeatures {
             .bcd_keys
             .binary_search_by_key(&bcd_key_spaced, |ks| &ks.bcd_key_spaced)
             && start < self.bcd_keys.len()
-                && let Some(end) = self.bcd_keys[start + 1..]
-                    .iter()
-                    .position(|ks| !ks.bcd_key_spaced.starts_with(&suffix))
-                {
-                    return &self.bcd_keys[start + 1..start + 1 + end];
-                }
+            && let Some(end) = self.bcd_keys[start + 1..]
+                .iter()
+                .position(|ks| !ks.bcd_key_spaced.starts_with(&suffix))
+        {
+            return &self.bcd_keys[start + 1..start + 1 + end];
+        }
         &[]
     }
 
@@ -121,51 +121,51 @@ impl WebFeatures {
                 .by_compat_key
                 .as_ref()
                 .and_then(|by_key| by_key.get(bcd_key))
-            {
-                let sub_keys = self.sub_keys(bcd_key_spaced);
-                let sub_status = sub_keys
-                    .iter()
-                    .map(|sub_key| {
-                        self.feature_data_by_name(&sub_key.feature)
-                            .and_then(|feature| feature.status.by_compat_key.as_ref())
-                            .and_then(|by_key| by_key.get(&sub_key.bcd_key))
-                            .map(|status_for_key| status_for_key.baseline)
-                    })
-                    .collect::<Vec<_>>();
+        {
+            let sub_keys = self.sub_keys(bcd_key_spaced);
+            let sub_status = sub_keys
+                .iter()
+                .map(|sub_key| {
+                    self.feature_data_by_name(&sub_key.feature)
+                        .and_then(|feature| feature.status.by_compat_key.as_ref())
+                        .and_then(|by_key| by_key.get(&sub_key.bcd_key))
+                        .map(|status_for_key| status_for_key.baseline)
+                })
+                .collect::<Vec<_>>();
 
-                let asterisk = if sub_status
-                    .iter()
-                    .all(|baseline| baseline == &Some(status_for_key.baseline))
-                {
-                    false
-                } else {
-                    match status_for_key.baseline {
-                        BaselineHighLow::False => {
-                            let Support {
-                                chrome,
-                                chrome_android,
-                                firefox,
-                                firefox_android,
-                                safari,
-                                safari_ios,
-                                ..
-                            } = &status_for_key.support;
-                            !(chrome == chrome_android
-                                && firefox == firefox_android
-                                && safari == safari_ios)
-                        }
-                        BaselineHighLow::Low => !sub_status.iter().all(|ss| {
-                            matches!(ss, Some(BaselineHighLow::Low | BaselineHighLow::High))
-                        }),
-                        _ => true,
+            let asterisk = if sub_status
+                .iter()
+                .all(|baseline| baseline == &Some(status_for_key.baseline))
+            {
+                false
+            } else {
+                match status_for_key.baseline {
+                    BaselineHighLow::False => {
+                        let Support {
+                            chrome,
+                            chrome_android,
+                            firefox,
+                            firefox_android,
+                            safari,
+                            safari_ios,
+                            ..
+                        } = &status_for_key.support;
+                        !(chrome == chrome_android
+                            && firefox == firefox_android
+                            && safari == safari_ios)
                     }
-                };
-                return Some(Baseline {
-                    support: status_for_key,
-                    asterisk,
-                    feature,
-                });
-            }
+                    BaselineHighLow::Low => !sub_status
+                        .iter()
+                        .all(|ss| matches!(ss, Some(BaselineHighLow::Low | BaselineHighLow::High))),
+                    _ => true,
+                }
+            };
+            return Some(Baseline {
+                support: status_for_key,
+                asterisk,
+                feature,
+            });
+        }
         None
     }
 

--- a/crates/rari-data/src/baseline.rs
+++ b/crates/rari-data/src/baseline.rs
@@ -101,16 +101,13 @@ impl WebFeatures {
         if let Ok(start) = self
             .bcd_keys
             .binary_search_by_key(&bcd_key_spaced, |ks| &ks.bcd_key_spaced)
-        {
-            if start < self.bcd_keys.len() {
-                if let Some(end) = self.bcd_keys[start + 1..]
+            && start < self.bcd_keys.len()
+                && let Some(end) = self.bcd_keys[start + 1..]
                     .iter()
                     .position(|ks| !ks.bcd_key_spaced.starts_with(&suffix))
                 {
                     return &self.bcd_keys[start + 1..start + 1 + end];
                 }
-            }
-        }
         &[]
     }
 
@@ -118,8 +115,8 @@ impl WebFeatures {
     // https://github.com/mdn/yari/issues/11546#issuecomment-2531611136
     pub fn baseline_by_bcd_key(&self, bcd_key: &str) -> Option<Baseline<'_>> {
         let bcd_key_spaced = &spaced(bcd_key);
-        if let Some(feature) = self.feature_data_by_key(bcd_key_spaced) {
-            if let Some(status_for_key) = feature
+        if let Some(feature) = self.feature_data_by_key(bcd_key_spaced)
+            && let Some(status_for_key) = feature
                 .status
                 .by_compat_key
                 .as_ref()
@@ -169,7 +166,6 @@ impl WebFeatures {
                     feature,
                 });
             }
-        }
         None
     }
 

--- a/crates/rari-deps/src/npm.rs
+++ b/crates/rari-deps/src/npm.rs
@@ -39,13 +39,14 @@ fn get_version(package_name: &str, version_req: &VersionReq) -> Result<VersionEn
         .rfind(|(k, _)| version_req.matches(k))
     {
         if let Some((latest, _)) = package.versions.last()
-            && latest > &entry.version {
-                tracing::warn!(
-                    "Update for {package_name} available {} -> {}",
-                    entry.version,
-                    latest
-                );
-            }
+            && latest > &entry.version
+        {
+            tracing::warn!(
+                "Update for {package_name} available {} -> {}",
+                entry.version,
+                latest
+            );
+        }
         Ok(entry.clone())
     } else {
         Err(DepsError::VersionNotFound)

--- a/crates/rari-deps/src/npm.rs
+++ b/crates/rari-deps/src/npm.rs
@@ -38,15 +38,14 @@ fn get_version(package_name: &str, version_req: &VersionReq) -> Result<VersionEn
         .iter()
         .rfind(|(k, _)| version_req.matches(k))
     {
-        if let Some((latest, _)) = package.versions.last() {
-            if latest > &entry.version {
+        if let Some((latest, _)) = package.versions.last()
+            && latest > &entry.version {
                 tracing::warn!(
                     "Update for {package_name} available {} -> {}",
                     entry.version,
                     latest
                 );
             }
-        }
         Ok(entry.clone())
     } else {
         Err(DepsError::VersionNotFound)

--- a/crates/rari-deps/src/webref_css.rs
+++ b/crates/rari-deps/src/webref_css.rs
@@ -55,8 +55,8 @@ fn enrich_with_specs(data: &mut Value, url_to_title: &BTreeMap<String, String>) 
             };
 
             if let Some(href_val) = url_field {
-                if let Some(href_str) = href_val.as_str() {
-                    if let Ok(url) = Url::parse(href_str) {
+                if let Some(href_str) = href_val.as_str()
+                    && let Ok(url) = Url::parse(href_str) {
                         let mut url_without_fragment = url.clone();
                         url_without_fragment.set_fragment(None);
                         let title = url_to_title
@@ -67,7 +67,6 @@ fn enrich_with_specs(data: &mut Value, url_to_title: &BTreeMap<String, String>) 
                         let spec = SpecLink { title, url };
                         obj.insert("specLink".to_string(), serde_json::to_value(spec).unwrap());
                     }
-                }
                 obj.remove(field_name);
             }
 
@@ -171,24 +170,21 @@ fn process_browser_specs(folder: &Path) -> Result<BTreeMap<String, String>, Deps
         }
 
         // Also add release URL if different from main URL
-        if let Some(release) = &spec.release {
-            if release.url != spec.url {
+        if let Some(release) = &spec.release
+            && release.url != spec.url {
                 url_to_title.insert(release.url.clone(), spec.title.clone());
             }
-        }
 
         // Add series URLs if different
-        if let Some(release_url) = spec.series.release_url {
-            if release_url != spec.url {
+        if let Some(release_url) = spec.series.release_url
+            && release_url != spec.url {
                 url_to_title.insert(release_url.clone(), spec.title.clone());
             }
-        }
 
-        if let Some(nightly_url) = &spec.series.nightly_url {
-            if Some(nightly_url) != spec.nightly.as_ref().map(|n| &n.url) {
+        if let Some(nightly_url) = &spec.series.nightly_url
+            && Some(nightly_url) != spec.nightly.as_ref().map(|n| &n.url) {
                 url_to_title.insert(nightly_url.clone(), spec.title.clone());
             }
-        }
     }
 
     Ok(url_to_title)

--- a/crates/rari-deps/src/webref_css.rs
+++ b/crates/rari-deps/src/webref_css.rs
@@ -56,17 +56,18 @@ fn enrich_with_specs(data: &mut Value, url_to_title: &BTreeMap<String, String>) 
 
             if let Some(href_val) = url_field {
                 if let Some(href_str) = href_val.as_str()
-                    && let Ok(url) = Url::parse(href_str) {
-                        let mut url_without_fragment = url.clone();
-                        url_without_fragment.set_fragment(None);
-                        let title = url_to_title
-                            .get(url_without_fragment.as_str())
-                            .cloned()
-                            .unwrap_or_else(|| "CSS Specification".to_string());
+                    && let Ok(url) = Url::parse(href_str)
+                {
+                    let mut url_without_fragment = url.clone();
+                    url_without_fragment.set_fragment(None);
+                    let title = url_to_title
+                        .get(url_without_fragment.as_str())
+                        .cloned()
+                        .unwrap_or_else(|| "CSS Specification".to_string());
 
-                        let spec = SpecLink { title, url };
-                        obj.insert("specLink".to_string(), serde_json::to_value(spec).unwrap());
-                    }
+                    let spec = SpecLink { title, url };
+                    obj.insert("specLink".to_string(), serde_json::to_value(spec).unwrap());
+                }
                 obj.remove(field_name);
             }
 
@@ -171,20 +172,23 @@ fn process_browser_specs(folder: &Path) -> Result<BTreeMap<String, String>, Deps
 
         // Also add release URL if different from main URL
         if let Some(release) = &spec.release
-            && release.url != spec.url {
-                url_to_title.insert(release.url.clone(), spec.title.clone());
-            }
+            && release.url != spec.url
+        {
+            url_to_title.insert(release.url.clone(), spec.title.clone());
+        }
 
         // Add series URLs if different
         if let Some(release_url) = spec.series.release_url
-            && release_url != spec.url {
-                url_to_title.insert(release_url.clone(), spec.title.clone());
-            }
+            && release_url != spec.url
+        {
+            url_to_title.insert(release_url.clone(), spec.title.clone());
+        }
 
         if let Some(nightly_url) = &spec.series.nightly_url
-            && Some(nightly_url) != spec.nightly.as_ref().map(|n| &n.url) {
-                url_to_title.insert(nightly_url.clone(), spec.title.clone());
-            }
+            && Some(nightly_url) != spec.nightly.as_ref().map(|n| &n.url)
+        {
+            url_to_title.insert(nightly_url.clone(), spec.title.clone());
+        }
     }
 
     Ok(url_to_title)

--- a/crates/rari-doc/src/build.rs
+++ b/crates/rari-doc/src/build.rs
@@ -69,8 +69,8 @@ pub fn build_single_page(page: &Page) -> Result<(BuiltPage, String), DocError> {
     );
     let _enter = span.enter();
     let mut built_page = page.build()?;
-    if settings().json_issues {
-        if let BuiltPage::Doc(json_doc) = &mut built_page {
+    if settings().json_issues
+        && let BuiltPage::Doc(json_doc) = &mut built_page {
             let flaws = if let Some(issues) = IN_MEMORY
                 .get_events()
                 .get(page.full_path().to_string_lossy().as_ref())
@@ -81,7 +81,6 @@ pub fn build_single_page(page: &Page) -> Result<(BuiltPage, String), DocError> {
             };
             json_doc.doc.flaws = flaws;
         }
-    }
     let out_path = build_out_root()
         .expect("No BUILD_OUT_ROOT")
         .join(url_to_folder_path(page.url().trim_start_matches('/')));

--- a/crates/rari-doc/src/build.rs
+++ b/crates/rari-doc/src/build.rs
@@ -16,10 +16,10 @@ use rari_types::globals::{
     base_url, blog_root, build_out_root, contributor_spotlight_root, curriculum_root,
     generic_content_root, git_history, settings,
 };
-use rari_types::locale::{default_locale, Locale};
+use rari_types::locale::{Locale, default_locale};
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use sha2::{Digest, Sha256};
-use tracing::{span, Level};
+use tracing::{Level, span};
 
 use crate::cached_readers::{
     blog_files, contributor_spotlight_files, curriculum_files, generic_content_files,
@@ -27,7 +27,7 @@ use crate::cached_readers::{
 };
 use crate::contributors::contributors_txt;
 use crate::error::DocError;
-use crate::issues::{to_display_issues, IN_MEMORY};
+use crate::issues::{IN_MEMORY, to_display_issues};
 use crate::pages::build::copy_additional_files;
 use crate::pages::json::{BuiltPage, JsonDocMetadata};
 use crate::pages::page::{Page, PageBuilder, PageLike};
@@ -70,17 +70,18 @@ pub fn build_single_page(page: &Page) -> Result<(BuiltPage, String), DocError> {
     let _enter = span.enter();
     let mut built_page = page.build()?;
     if settings().json_issues
-        && let BuiltPage::Doc(json_doc) = &mut built_page {
-            let flaws = if let Some(issues) = IN_MEMORY
-                .get_events()
-                .get(page.full_path().to_string_lossy().as_ref())
-            {
-                Some(to_display_issues(issues.value().clone(), page))
-            } else {
-                Some(Default::default())
-            };
-            json_doc.doc.flaws = flaws;
-        }
+        && let BuiltPage::Doc(json_doc) = &mut built_page
+    {
+        let flaws = if let Some(issues) = IN_MEMORY
+            .get_events()
+            .get(page.full_path().to_string_lossy().as_ref())
+        {
+            Some(to_display_issues(issues.value().clone(), page))
+        } else {
+            Some(Default::default())
+        };
+        json_doc.doc.flaws = flaws;
+    }
     let out_path = build_out_root()
         .expect("No BUILD_OUT_ROOT")
         .join(url_to_folder_path(page.url().trim_start_matches('/')));

--- a/crates/rari-doc/src/cached_readers.rs
+++ b/crates/rari-doc/src/cached_readers.rs
@@ -142,11 +142,10 @@ pub fn read_sidebar(name: &str, locale: Locale, slug: &str) -> Result<Arc<MetaSi
         "jsref" => Arc::new(jsref::sidebar(slug, locale)?),
         _ => {
             let key = (name.to_string(), locale);
-            if cache_content() {
-                if let Some(sidebar) = CACHED_SIDEBAR_FILES.get(&key) {
+            if cache_content()
+                && let Some(sidebar) = CACHED_SIDEBAR_FILES.get(&key) {
                     return Ok(sidebar.clone());
                 }
-            }
             let mut file = content_root().to_path_buf();
             file.push("sidebars");
             file.push(name);

--- a/crates/rari-doc/src/cached_readers.rs
+++ b/crates/rari-doc/src/cached_readers.rs
@@ -143,9 +143,10 @@ pub fn read_sidebar(name: &str, locale: Locale, slug: &str) -> Result<Arc<MetaSi
         _ => {
             let key = (name.to_string(), locale);
             if cache_content()
-                && let Some(sidebar) = CACHED_SIDEBAR_FILES.get(&key) {
-                    return Ok(sidebar.clone());
-                }
+                && let Some(sidebar) = CACHED_SIDEBAR_FILES.get(&key)
+            {
+                return Ok(sidebar.clone());
+            }
             let mut file = content_root().to_path_buf();
             file.push("sidebars");
             file.push(name);

--- a/crates/rari-doc/src/contributors.rs
+++ b/crates/rari-doc/src/contributors.rs
@@ -74,14 +74,13 @@ pub fn contributors_txt(wiki_history: Option<&WikiHistoryEntry>, github_file_url
         &github_file_url.replace("blob", "commits"),
         "\n\n",
     ]);
-    if let Some(wh) = wiki_history {
-        if !wh.contributors.is_empty() {
+    if let Some(wh) = wiki_history
+        && !wh.contributors.is_empty() {
             out.extend([
                 "# Original Wiki contributors\n",
                 &wh.contributors.join("\n"),
                 "\n",
             ]);
         }
-    }
     out
 }

--- a/crates/rari-doc/src/contributors.rs
+++ b/crates/rari-doc/src/contributors.rs
@@ -75,12 +75,13 @@ pub fn contributors_txt(wiki_history: Option<&WikiHistoryEntry>, github_file_url
         "\n\n",
     ]);
     if let Some(wh) = wiki_history
-        && !wh.contributors.is_empty() {
-            out.extend([
-                "# Original Wiki contributors\n",
-                &wh.contributors.join("\n"),
-                "\n",
-            ]);
-        }
+        && !wh.contributors.is_empty()
+    {
+        out.extend([
+            "# Original Wiki contributors\n",
+            &wh.contributors.join("\n"),
+            "\n",
+        ]);
+    }
     out
 }

--- a/crates/rari-doc/src/error.rs
+++ b/crates/rari-doc/src/error.rs
@@ -2,9 +2,9 @@ use std::path::{PathBuf, StripPrefixError};
 
 use css_syntax::error::SyntaxError;
 use rari_md::error::MarkdownError;
+use rari_types::ArgError;
 use rari_types::error::EnvError;
 use rari_types::locale::LocaleError;
-use rari_types::ArgError;
 use thiserror::Error;
 
 use crate::helpers::l10n::L10nError;

--- a/crates/rari-doc/src/helpers/css_info.rs
+++ b/crates/rari-doc/src/helpers/css_info.rs
@@ -4,9 +4,9 @@ use std::sync::OnceLock;
 
 use indexmap::IndexMap;
 use itertools::Itertools;
+use rari_types::RariEnv;
 use rari_types::globals::data_dir;
 use rari_types::locale::Locale;
-use rari_types::RariEnv;
 use rari_utils::io::read_to_string;
 use serde_json::Value;
 use tracing::warn;
@@ -344,8 +344,6 @@ pub fn write_missing(out: &mut String, locale: Locale) -> Result<(), DocError> {
 }
 
 fn remove_me_replace_placeholder(s: &str, replacements: &[&str]) -> String {
-    
-    s
-        .replace("$1$", replacements.first().unwrap_or(&"$1$"))
+    s.replace("$1$", replacements.first().unwrap_or(&"$1$"))
         .replace("$2$", replacements.get(1).unwrap_or(&"$2$"))
 }

--- a/crates/rari-doc/src/helpers/css_info.rs
+++ b/crates/rari-doc/src/helpers/css_info.rs
@@ -344,8 +344,8 @@ pub fn write_missing(out: &mut String, locale: Locale) -> Result<(), DocError> {
 }
 
 fn remove_me_replace_placeholder(s: &str, replacements: &[&str]) -> String {
-    let s = s
-        .replace("$1$", replacements.first().unwrap_or(&"$1$"))
-        .replace("$2$", replacements.get(1).unwrap_or(&"$2$"));
+    
     s
+        .replace("$1$", replacements.first().unwrap_or(&"$1$"))
+        .replace("$2$", replacements.get(1).unwrap_or(&"$2$"))
 }

--- a/crates/rari-doc/src/helpers/l10n.rs
+++ b/crates/rari-doc/src/helpers/l10n.rs
@@ -45,16 +45,16 @@ static JSON_L10N_FILES: LazyLock<HashMap<String, JsonL10nFile>> = LazyLock::new(
         .filter_map(|f| {
             if let Ok(f) = f
                 && f.path().is_file()
-                    && f.path()
-                        .extension()
-                        .is_some_and(|ext| ext.eq_ignore_ascii_case("json"))
-                    && f.path()
-                        .file_stem()
-                        .and_then(|s| s.to_str())
-                        .is_some_and(|s| s.starts_with("L10n-"))
-                {
-                    return Some(f.path());
-                }
+                && f.path()
+                    .extension()
+                    .is_some_and(|ext| ext.eq_ignore_ascii_case("json"))
+                && f.path()
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .is_some_and(|s| s.starts_with("L10n-"))
+            {
+                return Some(f.path());
+            }
             None
         })
         .map(|f| {

--- a/crates/rari-doc/src/helpers/l10n.rs
+++ b/crates/rari-doc/src/helpers/l10n.rs
@@ -43,8 +43,8 @@ static JSON_L10N_FILES: LazyLock<HashMap<String, JsonL10nFile>> = LazyLock::new(
         .read_dir()
         .expect("unable to read jsondata dir")
         .filter_map(|f| {
-            if let Ok(f) = f {
-                if f.path().is_file()
+            if let Ok(f) = f
+                && f.path().is_file()
                     && f.path()
                         .extension()
                         .is_some_and(|ext| ext.eq_ignore_ascii_case("json"))
@@ -55,7 +55,6 @@ static JSON_L10N_FILES: LazyLock<HashMap<String, JsonL10nFile>> = LazyLock::new(
                 {
                     return Some(f.path());
                 }
-            }
             None
         })
         .map(|f| {

--- a/crates/rari-doc/src/helpers/subpages.rs
+++ b/crates/rari-doc/src/helpers/subpages.rs
@@ -11,7 +11,7 @@ use rari_types::locale::Locale;
 use super::l10n::l10n_json_data;
 use super::titles::api_page_title;
 use crate::error::DocError;
-use crate::html::links::{render_internal_link, LinkModifier};
+use crate::html::links::{LinkModifier, render_internal_link};
 use crate::pages::page::{Page, PageLike, PageReader};
 use crate::redirects::resolve_redirect;
 use crate::utils::COLLATOR;
@@ -295,7 +295,7 @@ pub fn get_sub_pages(
             return Err(DocError::RedirectedLink {
                 from: url.to_string(),
                 to: redirect.to_string(),
-            })
+            });
         }
         Some(redirect) => redirect,
         None => url,

--- a/crates/rari-doc/src/helpers/summary_hack.rs
+++ b/crates/rari-doc/src/helpers/summary_hack.rs
@@ -43,9 +43,9 @@ pub fn get_hacky_summary_md(page: &Page) -> Result<String, DocError> {
 /// ```
 pub fn strip_paragraph_unchecked(input: &str) -> &str {
     let out = input.trim().strip_prefix("<p>").unwrap_or(input);
-    let out = out.trim().strip_suffix("</p>").unwrap_or(out);
+    
 
-    out
+    (out.trim().strip_suffix("</p>").unwrap_or(out)) as _
 }
 
 pub fn text_content(html_str: &str) -> String {

--- a/crates/rari-doc/src/helpers/summary_hack.rs
+++ b/crates/rari-doc/src/helpers/summary_hack.rs
@@ -1,5 +1,5 @@
 use itertools::Itertools;
-use rari_md::{m2h_internal, M2HOptions};
+use rari_md::{M2HOptions, m2h_internal};
 use scraper::Html;
 
 use crate::error::DocError;
@@ -43,7 +43,6 @@ pub fn get_hacky_summary_md(page: &Page) -> Result<String, DocError> {
 /// ```
 pub fn strip_paragraph_unchecked(input: &str) -> &str {
     let out = input.trim().strip_prefix("<p>").unwrap_or(input);
-    
 
     (out.trim().strip_suffix("</p>").unwrap_or(out)) as _
 }

--- a/crates/rari-doc/src/helpers/title.rs
+++ b/crates/rari-doc/src/helpers/title.rs
@@ -23,19 +23,17 @@ pub fn page_title(doc: &impl PageLike, with_suffix: bool) -> Result<String, DocE
 
     out.push_str(doc.title());
 
-    if let Some(root_url) = root_doc_url(doc.url()) {
-        if root_url != doc.url() {
+    if let Some(root_url) = root_doc_url(doc.url())
+        && root_url != doc.url() {
             let root_doc = Page::from_url_with_fallback(root_url)?;
             out.push_str(" - ");
             out.push_str(root_doc.short_title().unwrap_or(root_doc.title()));
         }
-    }
-    if with_suffix {
-        if let Some(suffix) = doc.title_suffix() {
+    if with_suffix
+        && let Some(suffix) = doc.title_suffix() {
             out.push_str(" | ");
             out.push_str(suffix);
         }
-    }
     Ok(out)
 }
 

--- a/crates/rari-doc/src/helpers/title.rs
+++ b/crates/rari-doc/src/helpers/title.rs
@@ -24,16 +24,16 @@ pub fn page_title(doc: &impl PageLike, with_suffix: bool) -> Result<String, DocE
     out.push_str(doc.title());
 
     if let Some(root_url) = root_doc_url(doc.url())
-        && root_url != doc.url() {
-            let root_doc = Page::from_url_with_fallback(root_url)?;
-            out.push_str(" - ");
-            out.push_str(root_doc.short_title().unwrap_or(root_doc.title()));
-        }
-    if with_suffix
-        && let Some(suffix) = doc.title_suffix() {
-            out.push_str(" | ");
-            out.push_str(suffix);
-        }
+        && root_url != doc.url()
+    {
+        let root_doc = Page::from_url_with_fallback(root_url)?;
+        out.push_str(" - ");
+        out.push_str(root_doc.short_title().unwrap_or(root_doc.title()));
+    }
+    if with_suffix && let Some(suffix) = doc.title_suffix() {
+        out.push_str(" | ");
+        out.push_str(suffix);
+    }
     Ok(out)
 }
 

--- a/crates/rari-doc/src/helpers/webextapi.rs
+++ b/crates/rari-doc/src/helpers/webextapi.rs
@@ -4,7 +4,7 @@ use rari_utils::concat_strs;
 
 use super::l10n::l10n_json_data;
 use crate::error::DocError;
-use crate::helpers::subpages::{get_sub_pages, SubPagesSorter};
+use crate::helpers::subpages::{SubPagesSorter, get_sub_pages};
 use crate::helpers::titles::api_page_title;
 use crate::html::sidebar::{Details, MetaChildren, SidebarMetaEntry, SidebarMetaEntryContent};
 use crate::pages::page::{Page, PageLike};

--- a/crates/rari-doc/src/html/banner.rs
+++ b/crates/rari-doc/src/html/banner.rs
@@ -1,6 +1,6 @@
 use rari_types::templ::TemplType;
 use rari_types::{Arg, Quotes};
-use tracing::{span, Level};
+use tracing::{Level, span};
 
 use crate::error::DocError;
 use crate::pages::page::PageLike;

--- a/crates/rari-doc/src/html/bubble_up.rs
+++ b/crates/rari-doc/src/html/bubble_up.rs
@@ -35,10 +35,10 @@ pub fn bubble_up_curriculum_page(html: &mut Html) -> Result<(), DocError> {
         if matches!(
             strong.text().next(),
             Some("Notes" | "Note" | "General notes")
-        )
-            && let Some(bq) = strong.parent().and_then(|p| p.parent()) {
-                rews.push((bq.id(), "curriculum-notes"))
-            }
+        ) && let Some(bq) = strong.parent().and_then(|p| p.parent())
+        {
+            rews.push((bq.id(), "curriculum-notes"))
+        }
     }
 
     //let next_ul = parent.next_siblings().find(|s| s.value().is_element());

--- a/crates/rari-doc/src/html/bubble_up.rs
+++ b/crates/rari-doc/src/html/bubble_up.rs
@@ -35,11 +35,10 @@ pub fn bubble_up_curriculum_page(html: &mut Html) -> Result<(), DocError> {
         if matches!(
             strong.text().next(),
             Some("Notes" | "Note" | "General notes")
-        ) {
-            if let Some(bq) = strong.parent().and_then(|p| p.parent()) {
+        )
+            && let Some(bq) = strong.parent().and_then(|p| p.parent()) {
                 rews.push((bq.id(), "curriculum-notes"))
             }
-        }
     }
 
     //let next_ul = parent.next_siblings().find(|s| s.value().is_element());

--- a/crates/rari-doc/src/html/code.rs
+++ b/crates/rari-doc/src/html/code.rs
@@ -112,7 +112,7 @@ pub fn code_blocks(html: &mut Html) -> Option<Vec<Code>> {
     for code in examples {
         for node_id in &code.node_ids {
             if let Some(mut node) = html.tree.get_mut(*node_id) {
-                if let Node::Element(ref mut el) = node.value() {
+                if let Node::Element(el) = node.value() {
                     let class = el.attr("class").unwrap_or_default();
                     let claas = concat_strs!(
                         class,

--- a/crates/rari-doc/src/html/code.rs
+++ b/crates/rari-doc/src/html/code.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 use std::collections::HashSet;
 
 use ego_tree::NodeId;
-use html5ever::{namespace_url, ns, QualName};
+use html5ever::{QualName, namespace_url, ns};
 use rari_types::globals::settings;
 use rari_utils::concat_strs;
 use schemars::JsonSchema;
@@ -112,23 +112,24 @@ pub fn code_blocks(html: &mut Html) -> Option<Vec<Code>> {
     for code in examples {
         for node_id in &code.node_ids {
             if let Some(mut node) = html.tree.get_mut(*node_id)
-                && let Node::Element(el) = node.value() {
-                    let class = el.attr("class").unwrap_or_default();
-                    let claas = concat_strs!(
-                        class,
-                        if class.is_empty() { "" } else { " " },
-                        "live-sample---",
-                        code.id.as_str()
-                    );
-                    el.attrs.insert(
-                        QualName {
-                            prefix: None,
-                            ns: ns!(),
-                            local: "class".into(),
-                        },
-                        claas.into(),
-                    );
-                }
+                && let Node::Element(el) = node.value()
+            {
+                let class = el.attr("class").unwrap_or_default();
+                let claas = concat_strs!(
+                    class,
+                    if class.is_empty() { "" } else { " " },
+                    "live-sample---",
+                    code.id.as_str()
+                );
+                el.attrs.insert(
+                    QualName {
+                        prefix: None,
+                        ns: ns!(),
+                        local: "class".into(),
+                    },
+                    claas.into(),
+                );
+            }
         }
         result.push(code.into())
     }

--- a/crates/rari-doc/src/html/code.rs
+++ b/crates/rari-doc/src/html/code.rs
@@ -111,8 +111,8 @@ pub fn code_blocks(html: &mut Html) -> Option<Vec<Code>> {
     let mut result = Vec::with_capacity(examples.len());
     for code in examples {
         for node_id in &code.node_ids {
-            if let Some(mut node) = html.tree.get_mut(*node_id) {
-                if let Node::Element(el) = node.value() {
+            if let Some(mut node) = html.tree.get_mut(*node_id)
+                && let Node::Element(el) = node.value() {
                     let class = el.attr("class").unwrap_or_default();
                     let claas = concat_strs!(
                         class,
@@ -129,7 +129,6 @@ pub fn code_blocks(html: &mut Html) -> Option<Vec<Code>> {
                         claas.into(),
                     );
                 }
-            }
         }
         result.push(code.into())
     }

--- a/crates/rari-doc/src/html/fix_img.rs
+++ b/crates/rari-doc/src/html/fix_img.rs
@@ -28,13 +28,12 @@ pub fn handle_img(
                 return Ok(());
             }
             let mut file = page.full_path().parent().unwrap().join(&src);
-            if !file.try_exists().unwrap_or_default() {
-                if let Ok(en_us_page) =
+            if !file.try_exists().unwrap_or_default()
+                && let Ok(en_us_page) =
                     Page::from_url_with_locale_and_fallback(page.url(), default_locale())
                 {
                     file = en_us_page.full_path().parent().unwrap().join(&src);
                 }
-            }
             let (width, height) = img_size(el, &src, &file, data_issues)?;
             if let Some(width) = width {
                 el.set_attribute("width", &width)?;

--- a/crates/rari-doc/src/html/fix_img.rs
+++ b/crates/rari-doc/src/html/fix_img.rs
@@ -1,8 +1,8 @@
 use std::error::Error;
 use std::path::Path;
 
-use lol_html::html_content::Element;
 use lol_html::HandlerResult;
+use lol_html::html_content::Element;
 use rari_types::locale::default_locale;
 use tracing::warn;
 use url::{ParseOptions, Url};
@@ -31,9 +31,9 @@ pub fn handle_img(
             if !file.try_exists().unwrap_or_default()
                 && let Ok(en_us_page) =
                     Page::from_url_with_locale_and_fallback(page.url(), default_locale())
-                {
-                    file = en_us_page.full_path().parent().unwrap().join(&src);
-                }
+            {
+                file = en_us_page.full_path().parent().unwrap().join(&src);
+            }
             let (width, height) = img_size(el, &src, &file, data_issues)?;
             if let Some(width) = width {
                 el.set_attribute("width", &width)?;

--- a/crates/rari-doc/src/html/fix_link.rs
+++ b/crates/rari-doc/src/html/fix_link.rs
@@ -150,8 +150,8 @@ pub fn handle_internal_link(
         };
         if (original_href != resolved_href || remove_href) && !en_us_fallback {
             if let Some(pos) = el.get_attribute("data-sourcepos") {
-                if let Some((start, end)) = pos.split_once('-') {
-                    if let Some((line, col)) = start.split_once(':') {
+                if let Some((start, end)) = pos.split_once('-')
+                    && let Some((line, col)) = start.split_once(':') {
                         let line = line
                             .parse::<i64>()
                             .map(|l| l + i64::try_from(page.fm_offset()).unwrap_or(l - 1))
@@ -203,7 +203,6 @@ pub fn handle_internal_link(
                             el.set_attribute("data-flaw", &ic.to_string())?;
                         }
                     }
-                }
             } else {
                 let ic = get_issue_counter();
                 if remove_href {

--- a/crates/rari-doc/src/html/fix_link.rs
+++ b/crates/rari-doc/src/html/fix_link.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
-use lol_html::html_content::Element;
 use lol_html::HandlerResult;
+use lol_html::html_content::Element;
 use rari_types::fm_types::PageType;
 use rari_types::locale::default_locale;
 use rari_utils::concat_strs;
@@ -151,58 +151,59 @@ pub fn handle_internal_link(
         if (original_href != resolved_href || remove_href) && !en_us_fallback {
             if let Some(pos) = el.get_attribute("data-sourcepos") {
                 if let Some((start, end)) = pos.split_once('-')
-                    && let Some((line, col)) = start.split_once(':') {
-                        let line = line
-                            .parse::<i64>()
-                            .map(|l| l + i64::try_from(page.fm_offset()).unwrap_or(l - 1))
-                            .ok()
-                            .unwrap_or(-1);
-                        let col = col.parse::<i64>().ok().unwrap_or(0);
-                        let (end_line, end_col) = end
-                            .split_once(':')
-                            .map(|(end_line, end_col)| {
-                                let end_line = end_line
-                                    .parse::<i64>()
-                                    .map(|l| l + i64::try_from(page.fm_offset()).unwrap_or(l - 1))
-                                    .ok()
-                                    .unwrap_or(-1);
-                                let end_col = end_col.parse::<i64>().ok().unwrap_or(0);
-                                (end_line, end_col)
-                            })
-                            .unwrap_or((-1, -1));
-                        let ic = get_issue_counter();
-                        if remove_href {
-                            tracing::warn!(
-                                source = "broken-link",
-                                ic = ic,
-                                line = line,
-                                col = col,
-                                end_line = end_line,
-                                end_col = end_col,
-                                url = original_href,
-                            );
+                    && let Some((line, col)) = start.split_once(':')
+                {
+                    let line = line
+                        .parse::<i64>()
+                        .map(|l| l + i64::try_from(page.fm_offset()).unwrap_or(l - 1))
+                        .ok()
+                        .unwrap_or(-1);
+                    let col = col.parse::<i64>().ok().unwrap_or(0);
+                    let (end_line, end_col) = end
+                        .split_once(':')
+                        .map(|(end_line, end_col)| {
+                            let end_line = end_line
+                                .parse::<i64>()
+                                .map(|l| l + i64::try_from(page.fm_offset()).unwrap_or(l - 1))
+                                .ok()
+                                .unwrap_or(-1);
+                            let end_col = end_col.parse::<i64>().ok().unwrap_or(0);
+                            (end_line, end_col)
+                        })
+                        .unwrap_or((-1, -1));
+                    let ic = get_issue_counter();
+                    if remove_href {
+                        tracing::warn!(
+                            source = "broken-link",
+                            ic = ic,
+                            line = line,
+                            col = col,
+                            end_line = end_line,
+                            end_col = end_col,
+                            url = original_href,
+                        );
+                    } else {
+                        let source = if original_href.to_lowercase() == resolved_href.to_lowercase()
+                        {
+                            "ill-cased-link"
                         } else {
-                            let source =
-                                if original_href.to_lowercase() == resolved_href.to_lowercase() {
-                                    "ill-cased-link"
-                                } else {
-                                    "redirected-link"
-                                };
-                            tracing::warn!(
-                                source = source,
-                                ic = ic,
-                                line = line,
-                                col = col,
-                                end_line = end_line,
-                                end_col = end_col,
-                                url = original_href,
-                                redirect = resolved_href
-                            );
-                        }
-                        if data_issues {
-                            el.set_attribute("data-flaw", &ic.to_string())?;
-                        }
+                            "redirected-link"
+                        };
+                        tracing::warn!(
+                            source = source,
+                            ic = ic,
+                            line = line,
+                            col = col,
+                            end_line = end_line,
+                            end_col = end_col,
+                            url = original_href,
+                            redirect = resolved_href
+                        );
                     }
+                    if data_issues {
+                        el.set_attribute("data-flaw", &ic.to_string())?;
+                    }
+                }
             } else {
                 let ic = get_issue_counter();
                 if remove_href {

--- a/crates/rari-doc/src/html/modifier.rs
+++ b/crates/rari-doc/src/html/modifier.rs
@@ -21,8 +21,8 @@ use crate::error::DocError;
 /// If the node exists and is an element, this function adds or updates
 /// the specified attribute in the node's attributes list.
 pub fn insert_attribute(html: &mut Html, node_id: NodeId, key: &str, value: &str) {
-    if let Some(mut details) = html.tree.get_mut(node_id) {
-        if let Node::Element(el) = details.value() {
+    if let Some(mut details) = html.tree.get_mut(node_id)
+        && let Node::Element(el) = details.value() {
             el.attrs.insert(
                 QualName {
                     prefix: None,
@@ -32,7 +32,6 @@ pub fn insert_attribute(html: &mut Html, node_id: NodeId, key: &str, value: &str
                 value.into(),
             );
         }
-    }
 }
 
 /// Removes an attribute from a specified HTML node.
@@ -45,15 +44,14 @@ pub fn insert_attribute(html: &mut Html, node_id: NodeId, key: &str, value: &str
 /// If the node exists and is an element, this function removes the specified
 /// attribute from the node's attributes list, if it exists.
 pub fn remove_attribute(html: &mut Html, node_id: NodeId, key: &str) {
-    if let Some(mut details) = html.tree.get_mut(node_id) {
-        if let Node::Element(el) = details.value() {
+    if let Some(mut details) = html.tree.get_mut(node_id)
+        && let Node::Element(el) = details.value() {
             el.attrs.swap_remove(&QualName {
                 prefix: None,
                 ns: ns!(),
                 local: key.into(),
             });
         }
-    }
 }
 
 /// Retrieves the `id` attribute of an HTML node if it exists, prefixed with `#`.
@@ -66,13 +64,11 @@ pub fn remove_attribute(html: &mut Html, node_id: NodeId, key: &str) {
 /// * `Option<String>` - Returns `Some(String)` containing the `id` prefixed with `#` if found, or `None` if the node
 ///   has no `id` attribute.
 pub fn get_id(html: &Html, node_id: NodeId) -> Option<String> {
-    if let Some(node) = html.tree.get(node_id) {
-        if let Node::Element(node_el) = node.value() {
-            if let Some(id) = node_el.attr("id") {
+    if let Some(node) = html.tree.get(node_id)
+        && let Node::Element(node_el) = node.value()
+            && let Some(id) = node_el.attr("id") {
                 return Some(concat_strs!("#", id));
             }
-        }
-    }
     None
 }
 

--- a/crates/rari-doc/src/html/modifier.rs
+++ b/crates/rari-doc/src/html/modifier.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 use std::collections::HashSet;
 
 use ego_tree::NodeId;
-use html5ever::{namespace_url, ns, Attribute, QualName};
+use html5ever::{Attribute, QualName, namespace_url, ns};
 use rari_md::anchor::anchorize;
 use rari_utils::concat_strs;
 use scraper::node::{self};
@@ -22,16 +22,17 @@ use crate::error::DocError;
 /// the specified attribute in the node's attributes list.
 pub fn insert_attribute(html: &mut Html, node_id: NodeId, key: &str, value: &str) {
     if let Some(mut details) = html.tree.get_mut(node_id)
-        && let Node::Element(el) = details.value() {
-            el.attrs.insert(
-                QualName {
-                    prefix: None,
-                    ns: ns!(),
-                    local: key.into(),
-                },
-                value.into(),
-            );
-        }
+        && let Node::Element(el) = details.value()
+    {
+        el.attrs.insert(
+            QualName {
+                prefix: None,
+                ns: ns!(),
+                local: key.into(),
+            },
+            value.into(),
+        );
+    }
 }
 
 /// Removes an attribute from a specified HTML node.
@@ -45,13 +46,14 @@ pub fn insert_attribute(html: &mut Html, node_id: NodeId, key: &str, value: &str
 /// attribute from the node's attributes list, if it exists.
 pub fn remove_attribute(html: &mut Html, node_id: NodeId, key: &str) {
     if let Some(mut details) = html.tree.get_mut(node_id)
-        && let Node::Element(el) = details.value() {
-            el.attrs.swap_remove(&QualName {
-                prefix: None,
-                ns: ns!(),
-                local: key.into(),
-            });
-        }
+        && let Node::Element(el) = details.value()
+    {
+        el.attrs.swap_remove(&QualName {
+            prefix: None,
+            ns: ns!(),
+            local: key.into(),
+        });
+    }
 }
 
 /// Retrieves the `id` attribute of an HTML node if it exists, prefixed with `#`.
@@ -66,9 +68,10 @@ pub fn remove_attribute(html: &mut Html, node_id: NodeId, key: &str) {
 pub fn get_id(html: &Html, node_id: NodeId) -> Option<String> {
     if let Some(node) = html.tree.get(node_id)
         && let Node::Element(node_el) = node.value()
-            && let Some(id) = node_el.attr("id") {
-                return Some(concat_strs!("#", id));
-            }
+        && let Some(id) = node_el.attr("id")
+    {
+        return Some(concat_strs!("#", id));
+    }
     None
 }
 

--- a/crates/rari-doc/src/html/modifier.rs
+++ b/crates/rari-doc/src/html/modifier.rs
@@ -22,7 +22,7 @@ use crate::error::DocError;
 /// the specified attribute in the node's attributes list.
 pub fn insert_attribute(html: &mut Html, node_id: NodeId, key: &str, value: &str) {
     if let Some(mut details) = html.tree.get_mut(node_id) {
-        if let Node::Element(ref mut el) = details.value() {
+        if let Node::Element(el) = details.value() {
             el.attrs.insert(
                 QualName {
                     prefix: None,
@@ -46,7 +46,7 @@ pub fn insert_attribute(html: &mut Html, node_id: NodeId, key: &str, value: &str
 /// attribute from the node's attributes list, if it exists.
 pub fn remove_attribute(html: &mut Html, node_id: NodeId, key: &str) {
     if let Some(mut details) = html.tree.get_mut(node_id) {
-        if let Node::Element(ref mut el) = details.value() {
+        if let Node::Element(el) = details.value() {
             el.attrs.swap_remove(&QualName {
                 prefix: None,
                 ns: ns!(),

--- a/crates/rari-doc/src/html/rewriter.rs
+++ b/crates/rari-doc/src/html/rewriter.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 use std::collections::HashSet;
 
 use lol_html::html_content::ContentType;
-use lol_html::{element, rewrite_str, text, HtmlRewriter, RewriteStrSettings, Settings};
+use lol_html::{HtmlRewriter, RewriteStrSettings, Settings, element, rewrite_str, text};
 use rari_md::ext::DELIM_START;
 use rari_md::node_card::NoteCard;
 use rari_types::fm_types::PageType;

--- a/crates/rari-doc/src/html/sections.rs
+++ b/crates/rari-doc/src/html/sections.rs
@@ -34,11 +34,7 @@ pub fn split_sections(html: &Html) -> Result<Split<'_>, DocError> {
     let summary_selector = Selector::parse("html > p").unwrap();
     let summary = html.select(&summary_selector).find_map(|s| {
         let text = s.text().collect::<String>();
-        if !text.is_empty() {
-            Some(text)
-        } else {
-            None
-        }
+        if !text.is_empty() { Some(text) } else { None }
     });
     let mut sidebar = None;
 

--- a/crates/rari-doc/src/html/sidebar.rs
+++ b/crates/rari-doc/src/html/sidebar.rs
@@ -80,11 +80,10 @@ fn expand_details_and_mark_current(html: &mut Html, a_selector: Selector) -> Res
             parent_id = Some(parent.id());
         }
         while let Some(parent) = next {
-            if let Node::Element(el) = parent.value() {
-                if el.name() == "details" {
+            if let Node::Element(el) = parent.value()
+                && el.name() == "details" {
                     details.push(parent.id())
                 }
-            }
             next = parent.parent();
         }
     }
@@ -154,7 +153,8 @@ pub fn build_sidebar(sidebar: &FmTempl, doc: &Doc) -> Result<String, DocError> {
         };
         let span = span!(Level::ERROR, "sidebar", sidebar = name,);
         let _enter = span.enter();
-        let rendered_sidebar = match invoke(&rari_env, name, args) {
+        
+        match invoke(&rari_env, name, args) {
             Ok((rendered_sidebar, TemplType::Sidebar)) => rendered_sidebar,
             Ok((_, typ)) => {
                 let span = span!(Level::ERROR, "sidebar", sidebar = name,);
@@ -168,8 +168,7 @@ pub fn build_sidebar(sidebar: &FmTempl, doc: &Doc) -> Result<String, DocError> {
                 tracing::warn!("{e}");
                 Default::default()
             }
-        };
-        rendered_sidebar
+        }
     };
     postprocess_sidebar(&rendered_sidebar, doc)
 }

--- a/crates/rari-doc/src/html/sidebar.rs
+++ b/crates/rari-doc/src/html/sidebar.rs
@@ -8,23 +8,23 @@ use dashmap::DashMap;
 use indexmap::IndexMap;
 use rari_types::fm_types::PageType;
 use rari_types::globals::cache_content;
-use rari_types::locale::{default_locale, Locale};
+use rari_types::locale::{Locale, default_locale};
 use rari_types::templ::TemplType;
 use rari_types::{Arg, Quotes};
 use rari_utils::concat_strs;
 use scraper::{Html, Node, Selector};
 use serde::{Deserialize, Serialize, Serializer};
-use tracing::{span, Level};
+use tracing::{Level, span};
 
-use super::links::{render_link_from_page, render_link_via_page, LinkFlags, LinkModifier};
+use super::links::{LinkFlags, LinkModifier, render_link_from_page, render_link_via_page};
 use super::modifier::insert_attribute;
 use super::rewriter::post_process_html;
 use crate::cached_readers::read_sidebar;
 use crate::error::DocError;
 use crate::helpers;
 use crate::helpers::subpages::{
-    list_sub_pages_flattened_grouped_internal, list_sub_pages_flattened_internal,
-    list_sub_pages_nested_internal, ListSubPagesContext,
+    ListSubPagesContext, list_sub_pages_flattened_grouped_internal,
+    list_sub_pages_flattened_internal, list_sub_pages_nested_internal,
 };
 use crate::pages::page::{Page, PageLike};
 use crate::pages::types::doc::Doc;
@@ -81,9 +81,10 @@ fn expand_details_and_mark_current(html: &mut Html, a_selector: Selector) -> Res
         }
         while let Some(parent) = next {
             if let Node::Element(el) = parent.value()
-                && el.name() == "details" {
-                    details.push(parent.id())
-                }
+                && el.name() == "details"
+            {
+                details.push(parent.id())
+            }
             next = parent.parent();
         }
     }
@@ -153,7 +154,7 @@ pub fn build_sidebar(sidebar: &FmTempl, doc: &Doc) -> Result<String, DocError> {
         };
         let span = span!(Level::ERROR, "sidebar", sidebar = name,);
         let _enter = span.enter();
-        
+
         match invoke(&rari_env, name, args) {
             Ok((rendered_sidebar, TemplType::Sidebar)) => rendered_sidebar,
             Ok((_, typ)) => {
@@ -307,11 +308,7 @@ const fn default_depth() -> usize {
 
 /// depth == 0 => None which means infinite otherwise Some(depth).
 const fn depth_to_option(depth: usize) -> Option<usize> {
-    if depth == 0 {
-        None
-    } else {
-        Some(depth)
-    }
+    if depth == 0 { None } else { Some(depth) }
 }
 
 #[derive(Serialize, Deserialize, Default, Debug, PartialEq, Clone)]

--- a/crates/rari-doc/src/issues.rs
+++ b/crates/rari-doc/src/issues.rs
@@ -11,8 +11,8 @@ use serde::{Deserialize, Serialize};
 use tracing::field::{Field, Visit};
 use tracing::span::{Attributes, Id};
 use tracing::{Event, Subscriber};
-use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::Layer;
+use tracing_subscriber::registry::LookupSpan;
 
 use crate::pages::page::{Page, PageLike};
 

--- a/crates/rari-doc/src/pages/build.rs
+++ b/crates/rari-doc/src/pages/build.rs
@@ -128,11 +128,10 @@ impl BuildSection<'_> {
     pub fn make_toc_entry(&self, with_h3: bool) -> Option<TocEntry> {
         let id = self.id.clone();
         let text = self.heading.map(|h| h.inner_html());
-        if let (Some(id), Some(text)) = (id, text) {
-            if !self.is_h3 || with_h3 {
+        if let (Some(id), Some(text)) = (id, text)
+            && (!self.is_h3 || with_h3) {
                 return Some(TocEntry { id, text });
             }
-        }
         None
     }
 }

--- a/crates/rari-doc/src/pages/build.rs
+++ b/crates/rari-doc/src/pages/build.rs
@@ -23,10 +23,10 @@ use crate::helpers::parents::parents;
 use crate::helpers::title::{page_title, transform_title};
 use crate::html::banner::build_banner;
 use crate::html::bubble_up::bubble_up_curriculum_page;
-use crate::html::code::{code_blocks, Code};
+use crate::html::code::{Code, code_blocks};
 use crate::html::modifier::{add_missing_ids, insert_self_links_for_dts, remove_empty_p};
 use crate::html::rewriter::{post_process_html, post_process_inline_sidebar};
-use crate::html::sections::{split_sections, BuildSection, BuildSectionType, Split};
+use crate::html::sections::{BuildSection, BuildSectionType, Split, split_sections};
 use crate::html::sidebar::{
     build_sidebars, expand_details_and_mark_current_for_inline_sidebar, postprocess_sidebar,
 };
@@ -37,14 +37,14 @@ use crate::pages::templates::{
 };
 use crate::pages::types::blog::BlogPost;
 use crate::pages::types::curriculum::{
-    self, build_landing_modules, build_overview_modules, build_sidebar, curriculum_group,
-    prev_next_modules, prev_next_overview, Curriculum, Template,
+    self, Curriculum, Template, build_landing_modules, build_overview_modules, build_sidebar,
+    curriculum_group, prev_next_modules, prev_next_overview,
 };
 use crate::pages::types::doc::Doc;
 use crate::pages::types::spa::SPA;
 use crate::pages::types::utils::FmTempl;
 use crate::specs::extract_specifications;
-use crate::templ::render::{decode_ref, render, Rendered};
+use crate::templ::render::{Rendered, decode_ref, render};
 use crate::translations::other_translations;
 
 impl From<BuildSection<'_>> for Section {
@@ -129,9 +129,10 @@ impl BuildSection<'_> {
         let id = self.id.clone();
         let text = self.heading.map(|h| h.inner_html());
         if let (Some(id), Some(text)) = (id, text)
-            && (!self.is_h3 || with_h3) {
-                return Some(TocEntry { id, text });
-            }
+            && (!self.is_h3 || with_h3)
+        {
+            return Some(TocEntry { id, text });
+        }
         None
     }
 }

--- a/crates/rari-doc/src/pages/page.rs
+++ b/crates/rari-doc/src/pages/page.rs
@@ -2,12 +2,12 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use enum_dispatch::enum_dispatch;
+use rari_types::RariEnv;
 use rari_types::fm_types::{FeatureStatus, PageType};
 use rari_types::globals::{
     blog_root, contributor_spotlight_root, curriculum_root, generic_content_root,
 };
 use rari_types::locale::Locale;
-use rari_types::RariEnv;
 
 use super::json::BuiltPage;
 use super::types::contributors::contributor_spotlight_from_url;
@@ -19,7 +19,7 @@ use crate::pages::types::curriculum::Curriculum;
 use crate::pages::types::doc::Doc;
 use crate::pages::types::spa::SPA;
 use crate::pages::types::utils::FmTempl;
-use crate::resolve::{url_meta_from, UrlMeta};
+use crate::resolve::{UrlMeta, url_meta_from};
 use crate::utils::locale_and_typ_from_path;
 
 /// Represents a page in the documentation system.
@@ -193,7 +193,7 @@ impl Page {
                 PageCategory::BlogPost if blog_root().is_none() => return true,
                 PageCategory::Curriculum if curriculum_root().is_none() => return true,
                 PageCategory::ContributorSpotlight if contributor_spotlight_root().is_none() => {
-                    return true
+                    return true;
                 }
                 PageCategory::GenericPage if generic_content_root().is_none() => return true,
                 _ => {}
@@ -220,7 +220,7 @@ impl Page {
                 PageCategory::BlogPost if blog_root().is_none() => return true,
                 PageCategory::Curriculum if curriculum_root().is_none() => return true,
                 PageCategory::ContributorSpotlight if contributor_spotlight_root().is_none() => {
-                    return true
+                    return true;
                 }
                 PageCategory::GenericPage if generic_content_root().is_none() => return true,
                 _ => {}

--- a/crates/rari-doc/src/pages/types/blog.rs
+++ b/crates/rari-doc/src/pages/types/blog.rs
@@ -3,10 +3,10 @@ use std::sync::Arc;
 
 use chrono::{NaiveDate, NaiveDateTime};
 use rari_md::m2h;
+use rari_types::RariEnv;
 use rari_types::fm_types::{FeatureStatus, PageType};
 use rari_types::globals::blog_root;
 use rari_types::locale::Locale;
-use rari_types::RariEnv;
 use rari_utils::io::read_to_string;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};

--- a/crates/rari-doc/src/pages/types/contributors.rs
+++ b/crates/rari-doc/src/pages/types/contributors.rs
@@ -2,11 +2,11 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use rari_md::m2h;
+use rari_types::RariEnv;
 use rari_types::error::EnvError;
 use rari_types::fm_types::{FeatureStatus, PageType};
 use rari_types::globals::contributor_spotlight_root;
 use rari_types::locale::Locale;
-use rari_types::RariEnv;
 use rari_utils::concat_strs;
 use rari_utils::io::read_to_string;
 use schemars::JsonSchema;

--- a/crates/rari-doc/src/pages/types/curriculum.rs
+++ b/crates/rari-doc/src/pages/types/curriculum.rs
@@ -271,13 +271,11 @@ impl PageLike for Curriculum {
 }
 
 pub fn curriculum_group(parents: &[Parent]) -> Option<String> {
-    if parents.len() > 1 {
-        if let Some(group) = parents.get(parents.len() - 2) {
-            if group.title.ends_with("modules") {
+    if parents.len() > 1
+        && let Some(group) = parents.get(parents.len() - 2)
+            && group.title.ends_with("modules") {
                 return Some(group.title.to_string());
-            }
-        }
-    };
+            };
     None
 }
 
@@ -302,12 +300,11 @@ pub fn build_sidebar() -> Result<Vec<CurriculumSidebarEntry>, DocError> {
         Vec::new(),
         |mut acc: Vec<CurriculumSidebarEntry>, (_, entry)| {
             let lvl = entry.slug.split('/').count();
-            if lvl > 2 {
-                if let Some(last) = acc.last_mut() {
+            if lvl > 2
+                && let Some(last) = acc.last_mut() {
                     last.children.push(entry);
                     return acc;
                 }
-            }
 
             acc.push(entry);
             acc
@@ -402,12 +399,11 @@ fn grouped_index() -> Result<Vec<CurriculumIndexEntry>, DocError> {
         Vec::new(),
         |mut acc: Vec<CurriculumIndexEntry>, entry| {
             let lvl = entry.slug.as_deref().unwrap_or_default().split('/').count();
-            if lvl > 2 {
-                if let Some(last) = acc.last_mut() {
+            if lvl > 2
+                && let Some(last) = acc.last_mut() {
                     last.children.push(entry.clone());
                     return acc;
                 }
-            }
 
             acc.push(entry.clone());
             acc

--- a/crates/rari-doc/src/pages/types/curriculum.rs
+++ b/crates/rari-doc/src/pages/types/curriculum.rs
@@ -3,10 +3,10 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, LazyLock};
 
 use constcat::concat;
+use rari_types::RariEnv;
 use rari_types::fm_types::{FeatureStatus, PageType};
 use rari_types::globals::curriculum_root;
 use rari_types::locale::Locale;
-use rari_types::RariEnv;
 use rari_utils::io::read_to_string;
 use regex::Regex;
 use schemars::JsonSchema;
@@ -273,9 +273,10 @@ impl PageLike for Curriculum {
 pub fn curriculum_group(parents: &[Parent]) -> Option<String> {
     if parents.len() > 1
         && let Some(group) = parents.get(parents.len() - 2)
-            && group.title.ends_with("modules") {
-                return Some(group.title.to_string());
-            };
+        && group.title.ends_with("modules")
+    {
+        return Some(group.title.to_string());
+    };
     None
 }
 
@@ -301,10 +302,11 @@ pub fn build_sidebar() -> Result<Vec<CurriculumSidebarEntry>, DocError> {
         |mut acc: Vec<CurriculumSidebarEntry>, (_, entry)| {
             let lvl = entry.slug.split('/').count();
             if lvl > 2
-                && let Some(last) = acc.last_mut() {
-                    last.children.push(entry);
-                    return acc;
-                }
+                && let Some(last) = acc.last_mut()
+            {
+                last.children.push(entry);
+                return acc;
+            }
 
             acc.push(entry);
             acc
@@ -400,10 +402,11 @@ fn grouped_index() -> Result<Vec<CurriculumIndexEntry>, DocError> {
         |mut acc: Vec<CurriculumIndexEntry>, entry| {
             let lvl = entry.slug.as_deref().unwrap_or_default().split('/').count();
             if lvl > 2
-                && let Some(last) = acc.last_mut() {
-                    last.children.push(entry.clone());
-                    return acc;
-                }
+                && let Some(last) = acc.last_mut()
+            {
+                last.children.push(entry.clone());
+                return acc;
+            }
 
             acc.push(entry.clone());
             acc

--- a/crates/rari-doc/src/pages/types/doc.rs
+++ b/crates/rari-doc/src/pages/types/doc.rs
@@ -6,9 +6,9 @@ use std::sync::Arc;
 
 use pretty_yaml::config::{FormatOptions, LanguageOptions};
 use rari_md::m2h;
-use rari_types::fm_types::{FeatureStatus, PageType};
-use rari_types::locale::{default_locale, Locale};
 use rari_types::RariEnv;
+use rari_types::fm_types::{FeatureStatus, PageType};
+use rari_types::locale::{Locale, default_locale};
 use rari_utils::concat_strs;
 use rari_utils::io::read_to_string;
 use serde::{Deserialize, Serialize};
@@ -16,7 +16,7 @@ use serde_yaml_ng::Value;
 use tracing::debug;
 use validator::Validate;
 
-use crate::cached_readers::{doc_page_from_static_files, CACHED_DOC_PAGE_FILES};
+use crate::cached_readers::{CACHED_DOC_PAGE_FILES, doc_page_from_static_files};
 use crate::error::DocError;
 use crate::pages::page::{Page, PageCategory, PageLike, PageReader, PageWriter};
 use crate::pages::types::utils::FmTempl;
@@ -174,9 +174,10 @@ impl PageReader<Page> for Doc {
         }
 
         if let Some(cache) = CACHED_DOC_PAGE_FILES.get()
-            && let Some(doc) = cache.get(&path) {
-                return Ok(doc.clone());
-            }
+            && let Some(doc) = cache.get(&path)
+        {
+            return Ok(doc.clone());
+        }
         debug!("reading doc: {}", &path.display());
         let mut doc = read_doc(&path)?;
 
@@ -227,9 +228,10 @@ impl PageLike for Doc {
     fn short_title(&self) -> Option<&str> {
         self.meta.short_title.as_deref().or_else(|| {
             if self.meta.title.starts_with('<')
-                && let Some(end) = self.meta.title.find('>') {
-                    return Some(&self.meta.title[..end + 1]);
-                }
+                && let Some(end) = self.meta.title.find('>')
+            {
+                return Some(&self.meta.title[..end + 1]);
+            }
             None
         })
     }

--- a/crates/rari-doc/src/pages/types/doc.rs
+++ b/crates/rari-doc/src/pages/types/doc.rs
@@ -173,11 +173,10 @@ impl PageReader<Page> for Doc {
             return Ok(doc);
         }
 
-        if let Some(cache) = CACHED_DOC_PAGE_FILES.get() {
-            if let Some(doc) = cache.get(&path) {
+        if let Some(cache) = CACHED_DOC_PAGE_FILES.get()
+            && let Some(doc) = cache.get(&path) {
                 return Ok(doc.clone());
             }
-        }
         debug!("reading doc: {}", &path.display());
         let mut doc = read_doc(&path)?;
 
@@ -227,11 +226,10 @@ impl PageLike for Doc {
 
     fn short_title(&self) -> Option<&str> {
         self.meta.short_title.as_deref().or_else(|| {
-            if self.meta.title.starts_with('<') {
-                if let Some(end) = self.meta.title.find('>') {
+            if self.meta.title.starts_with('<')
+                && let Some(end) = self.meta.title.find('>') {
                     return Some(&self.meta.title[..end + 1]);
                 }
-            }
             None
         })
     }

--- a/crates/rari-doc/src/pages/types/generic.rs
+++ b/crates/rari-doc/src/pages/types/generic.rs
@@ -1,15 +1,15 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use rari_types::RariEnv;
 use rari_types::fm_types::{FeatureStatus, PageType};
 use rari_types::globals::generic_content_root;
 use rari_types::locale::Locale;
-use rari_types::RariEnv;
 use rari_utils::concat_strs;
 use rari_utils::io::read_to_string;
 use serde::Deserialize;
 
-use crate::cached_readers::{generic_content_config, generic_content_files, GenericPagesConfig};
+use crate::cached_readers::{GenericPagesConfig, generic_content_config, generic_content_files};
 use crate::error::DocError;
 use crate::pages::page::{Page, PageLike, PageReader};
 use crate::pages::types::utils::FmTempl;

--- a/crates/rari-doc/src/pages/types/spa.rs
+++ b/crates/rari-doc/src/pages/types/spa.rs
@@ -5,17 +5,17 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, LazyLock};
 
 use constcat::concat;
+use rari_types::RariEnv;
 use rari_types::fm_types::{FeatureStatus, PageType};
 use rari_types::globals::{content_translated_root, settings};
 use rari_types::locale::Locale;
-use rari_types::RariEnv;
 use rari_utils::concat_strs;
 
 use super::spa_homepage::{
     featured_articles, featured_contributor, latest_news, recent_contributions,
 };
 use crate::cached_readers::{
-    blog_files, generic_content_config, BasicSPA, BuildSPA, PaginationData, SPAData,
+    BasicSPA, BuildSPA, PaginationData, SPAData, blog_files, generic_content_config,
 };
 use crate::error::DocError;
 use crate::helpers::parents::parents;
@@ -314,8 +314,7 @@ const OBSERVATORY_TITLE: &str = "HTTP Observatory";
 const OBSERVATORY_REPORT_TITLE: &str = "Report";
 const OBSERVATORY_TITLE_FULL: &str = concat!(OBSERVATORY_TITLE, " | MDN");
 
-const OBSERVATORY_DESCRIPTION: &str =
-"Test your site’s HTTP headers, including CSP and HSTS, to find security problems and get actionable recommendations to make your website more secure. Test other websites to see how you compare.";
+const OBSERVATORY_DESCRIPTION: &str = "Test your site’s HTTP headers, including CSP and HSTS, to find security problems and get actionable recommendations to make your website more secure. Test other websites to see how you compare.";
 
 static POSTS_PER_PAGE: LazyLock<usize> = LazyLock::new(|| {
     if settings().blog_pagination {

--- a/crates/rari-doc/src/reader.rs
+++ b/crates/rari-doc/src/reader.rs
@@ -58,8 +58,8 @@ pub fn read_docs_parallel<P: 'static + Send, T: PageReader<P>>(
             let tx = tx.clone();
             let success = &success;
             Box::new(move |result| {
-                if let Ok(f) = result {
-                    if f.file_type().map(|ft| ft.is_file()).unwrap_or(false) {
+                if let Ok(f) = result
+                    && f.file_type().map(|ft| ft.is_file()).unwrap_or(false) {
                         let p = f.into_path();
                         match T::read(p, None) {
                             Ok(doc) => {
@@ -74,7 +74,6 @@ pub fn read_docs_parallel<P: 'static + Send, T: PageReader<P>>(
                             }
                         }
                     }
-                }
                 ignore::WalkState::Continue
             })
         });

--- a/crates/rari-doc/src/rss.rs
+++ b/crates/rari-doc/src/rss.rs
@@ -60,8 +60,7 @@ pub fn create_rss(
     base_url: &str,
 ) -> Result<(), DocError> {
     let title = "MDN Blog";
-    let description =
-      "The MDN Web Docs blog publishes articles about web development, open source software, web platform updates, tutorials, changes and updates to MDN, and more.";
+    let description = "The MDN Web Docs blog publishes articles about web development, open source software, web platform updates, tutorials, changes and updates to MDN, and more.";
     let link = concat_strs!(base_url, "/", default_locale().as_url_str(), "/blog/");
     let language = "en";
     let image = Image {

--- a/crates/rari-doc/src/search_index.rs
+++ b/crates/rari-doc/src/search_index.rs
@@ -9,9 +9,9 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::io::BufWriter;
 
+use rari_types::Popularities;
 use rari_types::globals::{self, build_out_root};
 use rari_types::locale::Locale;
-use rari_types::Popularities;
 use rari_utils::error::RariIoError;
 use rari_utils::io::read_to_string;
 use serde::Serialize;

--- a/crates/rari-doc/src/sidebars/apiref.rs
+++ b/crates/rari-doc/src/sidebars/apiref.rs
@@ -7,7 +7,7 @@ use crate::error::DocError;
 use crate::helpers::api_inheritance::inheritance;
 use crate::helpers::json_data::json_data_group;
 use crate::helpers::l10n::l10n_json_data;
-use crate::helpers::subpages::{get_sub_pages, SubPagesSorter};
+use crate::helpers::subpages::{SubPagesSorter, get_sub_pages};
 use crate::helpers::titles::api_page_title;
 use crate::html::sidebar::{
     Details, MetaChildren, MetaSidebar, SidebarMetaEntry, SidebarMetaEntryContent,

--- a/crates/rari-doc/src/sidebars/apiref.rs
+++ b/crates/rari-doc/src/sidebars/apiref.rs
@@ -85,7 +85,7 @@ pub fn sidebar(slug: &str, group: Option<&str>, locale: Locale) -> Result<MetaSi
 
     let mut entries = vec![];
 
-    if let Some([ref overview, ..]) = web_api_groups.map(|group| group.overview.as_slice()) {
+    if let Some([overview, ..]) = web_api_groups.map(|group| group.overview.as_slice()) {
         entries.push(SidebarMetaEntry {
             section: true,
             content: SidebarMetaEntryContent::Page(Doc::page_from_slug(

--- a/crates/rari-doc/src/sidebars/default_api_sidebar.rs
+++ b/crates/rari-doc/src/sidebars/default_api_sidebar.rs
@@ -22,7 +22,7 @@ pub fn sidebar(group: &str, locale: Locale) -> Result<MetaSidebar, DocError> {
 
     let mut entries = vec![];
 
-    if let [ref overview, ..] = web_api_groups.overview.as_slice() {
+    if let [overview, ..] = web_api_groups.overview.as_slice() {
         entries.push(SidebarMetaEntry {
             section: true,
             content: SidebarMetaEntryContent::Page(Doc::page_from_slug(

--- a/crates/rari-doc/src/templ/api.rs
+++ b/crates/rari-doc/src/templ/api.rs
@@ -6,7 +6,7 @@ use rari_types::globals::{deny_warnings, settings};
 use rari_types::locale::Locale;
 
 use crate::error::DocError;
-use crate::html::links::{render_link_via_page, LinkFlags};
+use crate::html::links::{LinkFlags, render_link_via_page};
 use crate::issues::get_issue_counter;
 use crate::pages::page::Page;
 use crate::percent::PATH_SEGMENT;
@@ -80,10 +80,11 @@ impl RariApi {
         };
         Page::from_url_with_fallback(url).map_err(|e| {
             if let DocError::PageNotFound(_, _) = e
-                && !matches!(warn, LinkWarn::No) {
-                    let ic = get_issue_counter();
-                    tracing::warn!(source = "templ-broken-link", ic = ic, url = url);
-                }
+                && !matches!(warn, LinkWarn::No)
+            {
+                let ic = get_issue_counter();
+                tracing::warn!(source = "templ-broken-link", ic = ic, url = url);
+            }
             e
         })
     }

--- a/crates/rari-doc/src/templ/api.rs
+++ b/crates/rari-doc/src/templ/api.rs
@@ -79,12 +79,11 @@ impl RariApi {
             None => url,
         };
         Page::from_url_with_fallback(url).map_err(|e| {
-            if let DocError::PageNotFound(_, _) = e {
-                if !matches!(warn, LinkWarn::No) {
+            if let DocError::PageNotFound(_, _) = e
+                && !matches!(warn, LinkWarn::No) {
                     let ic = get_issue_counter();
                     tracing::warn!(source = "templ-broken-link", ic = ic, url = url);
                 }
-            }
             e
         })
     }

--- a/crates/rari-doc/src/templ/render.rs
+++ b/crates/rari-doc/src/templ/render.rs
@@ -4,9 +4,9 @@ use rari_md::ext::{DELIM_END, DELIM_END_LEN, DELIM_START, DELIM_START_LEN};
 use rari_types::globals::deny_warnings;
 use rari_types::templ::TemplType;
 use rari_types::{AnyArg, RariEnv};
-use tracing::{span, warn, Level};
+use tracing::{Level, span, warn};
 
-use super::parser::{parse, Token};
+use super::parser::{Token, parse};
 use super::templs::invoke;
 use crate::error::DocError;
 

--- a/crates/rari-doc/src/templ/templs/api_list_alpha.rs
+++ b/crates/rari-doc/src/templ/templs/api_list_alpha.rs
@@ -2,7 +2,7 @@ use rari_templ_func::rari_f;
 use rari_types::fm_types::PageType;
 
 use crate::error::DocError;
-use crate::helpers::subpages::{get_sub_pages, SubPagesSorter};
+use crate::helpers::subpages::{SubPagesSorter, get_sub_pages};
 use crate::pages::page::PageLike;
 use crate::templ::api::RariApi;
 

--- a/crates/rari-doc/src/templ/templs/compat.rs
+++ b/crates/rari-doc/src/templ/templs/compat.rs
@@ -2,7 +2,7 @@ use rari_templ_func::rari_f;
 use rari_types::fm_types::PageType;
 
 use crate::error::DocError;
-use crate::helpers::subpages::{get_sub_pages, SubPagesSorter};
+use crate::helpers::subpages::{SubPagesSorter, get_sub_pages};
 use crate::pages::page::{Page, PageLike};
 
 #[rari_f(register = "crate::Templ")]
@@ -20,9 +20,10 @@ pub fn webextallcompattables() -> Result<String, DocError> {
     )?;
     for page in sub_pages.iter().filter_map(|page| {
         if page.page_type() == PageType::WebextensionApi
-            && let Page::Doc(doc) = page {
-                return Some(doc);
-            }
+            && let Page::Doc(doc) = page
+        {
+            return Some(doc);
+        }
         None
     }) {
         for feature_name in &page.meta.browser_compat {
@@ -61,7 +62,7 @@ mod test {
     use rari_types::RariEnv;
 
     use crate::error::DocError;
-    use crate::templ::render::{decode_ref, render, Rendered};
+    use crate::templ::render::{Rendered, decode_ref, render};
 
     #[test]
     fn test_compat_none() -> Result<(), DocError> {

--- a/crates/rari-doc/src/templ/templs/compat.rs
+++ b/crates/rari-doc/src/templ/templs/compat.rs
@@ -19,11 +19,10 @@ pub fn webextallcompattables() -> Result<String, DocError> {
         SubPagesSorter::default(),
     )?;
     for page in sub_pages.iter().filter_map(|page| {
-        if page.page_type() == PageType::WebextensionApi {
-            if let Page::Doc(doc) = page {
+        if page.page_type() == PageType::WebextensionApi
+            && let Page::Doc(doc) = page {
                 return Some(doc);
             }
-        }
         None
     }) {
         for feature_name in &page.meta.browser_compat {

--- a/crates/rari-doc/src/templ/templs/csssyntax.rs
+++ b/crates/rari-doc/src/templ/templs/csssyntax.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::sync::LazyLock;
 
-use css_syntax::syntax::{render_formal_syntax, CssType, LinkedToken, SyntaxInput};
+use css_syntax::syntax::{CssType, LinkedToken, SyntaxInput, render_formal_syntax};
 use rari_templ_func::rari_f;
 use tracing::{error, warn};
 

--- a/crates/rari-doc/src/templ/templs/firefox_for_developers.rs
+++ b/crates/rari-doc/src/templ/templs/firefox_for_developers.rs
@@ -5,7 +5,7 @@ use rari_types::locale::Locale;
 
 use crate::error::DocError;
 use crate::helpers::l10n::l10n_json_data;
-use crate::html::links::{render_link_via_page, LinkFlags};
+use crate::html::links::{LinkFlags, render_link_via_page};
 
 const OLD_VERSIONS: &[&str] = &["3.6", "3.5", "3", "2", "1.5"];
 

--- a/crates/rari-doc/src/templ/templs/inheritance_diagram.rs
+++ b/crates/rari-doc/src/templ/templs/inheritance_diagram.rs
@@ -161,11 +161,7 @@ fn triangle(out: &mut String, x: i32, y: i32, reverse: bool) -> Result<(), Error
 
 fn calculate_rect_width(text: &str) -> i32 {
     let width = text.len() as i32 * 8;
-    if width < 75 {
-        75
-    } else {
-        width
-    }
+    if width < 75 { 75 } else { width }
 }
 
 fn move_by(number: i32, delta: i32, reverse: bool) -> i32 {

--- a/crates/rari-doc/src/templ/templs/links/domxref.rs
+++ b/crates/rari-doc/src/templ/templs/links/domxref.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use rari_templ_func::rari_f;
 use rari_types::{AnyArg, ArgError};
-use tracing::{span, Level};
+use tracing::{Level, span};
 
 use crate::error::DocError;
 use crate::templ::api::RariApi;

--- a/crates/rari-doc/src/templ/templs/links/http.rs
+++ b/crates/rari-doc/src/templ/templs/links/http.rs
@@ -1,6 +1,6 @@
 use rari_templ_func::rari_f;
-use rari_types::locale::Locale;
 use rari_types::AnyArg;
+use rari_types::locale::Locale;
 
 use crate::error::DocError;
 use crate::templ::api::RariApi;

--- a/crates/rari-doc/src/templ/templs/links/svgxref.rs
+++ b/crates/rari-doc/src/templ/templs/links/svgxref.rs
@@ -1,6 +1,6 @@
 use rari_templ_func::rari_f;
-use rari_types::locale::Locale;
 use rari_types::AnyArg;
+use rari_types::locale::Locale;
 
 use crate::error::DocError;
 use crate::templ::api::RariApi;

--- a/crates/rari-doc/src/templ/templs/list_subpages_for_sidebar.rs
+++ b/crates/rari-doc/src/templ/templs/list_subpages_for_sidebar.rs
@@ -2,8 +2,8 @@ use rari_templ_func::rari_f;
 use rari_types::AnyArg;
 
 use crate::error::DocError;
-use crate::helpers::subpages::{get_sub_pages, SubPagesSorter};
-use crate::html::links::{render_internal_link, LinkModifier};
+use crate::helpers::subpages::{SubPagesSorter, get_sub_pages};
+use crate::html::links::{LinkModifier, render_internal_link};
 use crate::pages::page::{Page, PageLike};
 use crate::utils::{trim_after, trim_before};
 

--- a/crates/rari-doc/src/templ/templs/mod.rs
+++ b/crates/rari-doc/src/templ/templs/mod.rs
@@ -75,9 +75,10 @@ pub fn invoke(
         None => {
             TEMPL_RECORDER.with(|tx| {
                 if let Some(tx) = tx
-                    && let Err(e) = tx.send(name.to_string()) {
-                        error!("templ recorder: {e}");
-                    }
+                    && let Err(e) = tx.send(name.to_string())
+                {
+                    error!("templ recorder: {e}");
+                }
             });
             return Ok((format!("<s>unsupported templ: {name}</s>"), TemplType::None));
         } //

--- a/crates/rari-doc/src/templ/templs/mod.rs
+++ b/crates/rari-doc/src/templ/templs/mod.rs
@@ -74,11 +74,10 @@ pub fn invoke(
         None if deny_warnings() => return Err(DocError::UnknownMacro(name.to_string())),
         None => {
             TEMPL_RECORDER.with(|tx| {
-                if let Some(tx) = tx {
-                    if let Err(e) = tx.send(name.to_string()) {
+                if let Some(tx) = tx
+                    && let Err(e) = tx.send(name.to_string()) {
                         error!("templ recorder: {e}");
                     }
-                }
             });
             return Ok((format!("<s>unsupported templ: {name}</s>"), TemplType::None));
         } //

--- a/crates/rari-doc/src/templ/templs/previous_menu_next.rs
+++ b/crates/rari-doc/src/templ/templs/previous_menu_next.rs
@@ -49,8 +49,8 @@ fn previous_next_menu_internal(
 ) -> Result<String, DocError> {
     let mut out = String::new();
     out.push_str(r#"<ul class="prev-next">"#);
-    if let Some(prev) = prev {
-        if !prev.is_empty() {
+    if let Some(prev) = prev
+        && !prev.is_empty() {
             let page = RariApi::get_page(&concat_strs!(
                 "/",
                 locale.as_url_str(),
@@ -60,9 +60,8 @@ fn previous_next_menu_internal(
             let title = l10n_json_data("Template", "previous", locale)?;
             generate_link(&mut out, page.slug(), locale, title, "prev")?;
         }
-    }
-    if let Some(menu) = menu {
-        if !menu.is_empty() {
+    if let Some(menu) = menu
+        && !menu.is_empty() {
             let page = RariApi::get_page(&concat_strs!(
                 "/",
                 locale.as_url_str(),
@@ -75,9 +74,8 @@ fn previous_next_menu_internal(
             );
             generate_link(&mut out, page.slug(), locale, &title, "menu")?;
         }
-    }
-    if let Some(next) = next {
-        if !next.is_empty() {
+    if let Some(next) = next
+        && !next.is_empty() {
             let page = RariApi::get_page(&concat_strs!(
                 "/",
                 locale.as_url_str(),
@@ -87,7 +85,6 @@ fn previous_next_menu_internal(
             let title = l10n_json_data("Template", "next", locale)?;
             generate_link(&mut out, page.slug(), locale, title, "next")?;
         }
-    }
     out.push_str("</ul>");
     Ok(out)
 }

--- a/crates/rari-doc/src/templ/templs/previous_menu_next.rs
+++ b/crates/rari-doc/src/templ/templs/previous_menu_next.rs
@@ -50,41 +50,44 @@ fn previous_next_menu_internal(
     let mut out = String::new();
     out.push_str(r#"<ul class="prev-next">"#);
     if let Some(prev) = prev
-        && !prev.is_empty() {
-            let page = RariApi::get_page(&concat_strs!(
-                "/",
-                locale.as_url_str(),
-                "/docs/",
-                prev.as_str()
-            ))?;
-            let title = l10n_json_data("Template", "previous", locale)?;
-            generate_link(&mut out, page.slug(), locale, title, "prev")?;
-        }
+        && !prev.is_empty()
+    {
+        let page = RariApi::get_page(&concat_strs!(
+            "/",
+            locale.as_url_str(),
+            "/docs/",
+            prev.as_str()
+        ))?;
+        let title = l10n_json_data("Template", "previous", locale)?;
+        generate_link(&mut out, page.slug(), locale, title, "prev")?;
+    }
     if let Some(menu) = menu
-        && !menu.is_empty() {
-            let page = RariApi::get_page(&concat_strs!(
-                "/",
-                locale.as_url_str(),
-                "/docs/",
-                menu.as_str()
-            ))?;
-            let title = concat_strs!(
-                l10n_json_data("Template", "prev_next_menu", locale)?,
-                page.title()
-            );
-            generate_link(&mut out, page.slug(), locale, &title, "menu")?;
-        }
+        && !menu.is_empty()
+    {
+        let page = RariApi::get_page(&concat_strs!(
+            "/",
+            locale.as_url_str(),
+            "/docs/",
+            menu.as_str()
+        ))?;
+        let title = concat_strs!(
+            l10n_json_data("Template", "prev_next_menu", locale)?,
+            page.title()
+        );
+        generate_link(&mut out, page.slug(), locale, &title, "menu")?;
+    }
     if let Some(next) = next
-        && !next.is_empty() {
-            let page = RariApi::get_page(&concat_strs!(
-                "/",
-                locale.as_url_str(),
-                "/docs/",
-                next.as_str()
-            ))?;
-            let title = l10n_json_data("Template", "next", locale)?;
-            generate_link(&mut out, page.slug(), locale, title, "next")?;
-        }
+        && !next.is_empty()
+    {
+        let page = RariApi::get_page(&concat_strs!(
+            "/",
+            locale.as_url_str(),
+            "/docs/",
+            next.as_str()
+        ))?;
+        let title = l10n_json_data("Template", "next", locale)?;
+        generate_link(&mut out, page.slug(), locale, title, "next")?;
+    }
     out.push_str("</ul>");
     Ok(out)
 }

--- a/crates/rari-doc/src/templ/templs/subpages_with_summaries.rs
+++ b/crates/rari-doc/src/templ/templs/subpages_with_summaries.rs
@@ -1,7 +1,7 @@
 use rari_templ_func::rari_f;
 
 use crate::error::DocError;
-use crate::helpers::subpages::{get_sub_pages, SubPagesSorter};
+use crate::helpers::subpages::{SubPagesSorter, get_sub_pages};
 use crate::helpers::summary_hack::{get_hacky_summary_md, strip_paragraph_unchecked};
 use crate::pages::page::PageLike;
 

--- a/crates/rari-doc/src/templ/templs/svginfo.rs
+++ b/crates/rari-doc/src/templ/templs/svginfo.rs
@@ -1,5 +1,5 @@
 use rari_templ_func::rari_f;
-use rari_types::globals::{json_svg_data_lookup, SVGDataDescription};
+use rari_types::globals::{SVGDataDescription, json_svg_data_lookup};
 
 use super::links::svgxref::svgxref_internal;
 use crate::error::DocError;

--- a/crates/rari-doc/src/templ/templs/web_ext_examples.rs
+++ b/crates/rari-doc/src/templ/templs/web_ext_examples.rs
@@ -3,7 +3,7 @@ use rari_types::locale::Locale;
 
 use crate::error::DocError;
 use crate::helpers::l10n::l10n_json_data;
-use crate::helpers::web_ext_examples::{WebExtExample, WEB_EXT_EXAMPLES_DATA};
+use crate::helpers::web_ext_examples::{WEB_EXT_EXAMPLES_DATA, WebExtExample};
 
 #[rari_f(register = "crate::Templ")]
 pub fn webextexamples(heading: Option<String>) -> Result<String, DocError> {

--- a/crates/rari-doc/src/utils.rs
+++ b/crates/rari-doc/src/utils.rs
@@ -10,8 +10,8 @@ use std::fmt;
 use std::marker::PhantomData;
 use std::path::Path;
 use std::str::FromStr;
-use std::sync::mpsc::Sender;
 use std::sync::OnceLock;
+use std::sync::mpsc::Sender;
 
 use chrono::{NaiveDate, NaiveDateTime};
 use icu_collator::options::{CollatorOptions, Strength};
@@ -21,7 +21,7 @@ use icu_locale_core::locale;
 use rari_types::error::EnvError;
 use rari_types::globals::{blog_root, content_root, content_translated_root, settings};
 use rari_types::locale::{Locale, LocaleError};
-use serde::de::{self, value, SeqAccess, Visitor};
+use serde::de::{self, SeqAccess, Visitor, value};
 use serde::ser::SerializeSeq;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
@@ -191,19 +191,21 @@ pub(crate) fn locale_and_typ_from_path(path: &Path) -> Result<(Locale, PageCateg
     }
 
     if let Some(root) = blog_root()
-        && path.starts_with(root) {
-            return Ok((Locale::EnUs, PageCategory::BlogPost));
-        }
+        && path.starts_with(root)
+    {
+        return Ok((Locale::EnUs, PageCategory::BlogPost));
+    }
     if let Some(root) = content_translated_root()
         && let Ok(relative) = path.strip_prefix(root)
-            && let Some(locale_str) = relative.components().next() {
-                let locale_str = locale_str
-                    .as_os_str()
-                    .to_str()
-                    .ok_or(LocaleError::NoLocaleInPath)?;
-                let locale = Locale::from_str(locale_str)?;
-                return Ok((locale, PageCategory::Doc));
-            }
+        && let Some(locale_str) = relative.components().next()
+    {
+        let locale_str = locale_str
+            .as_os_str()
+            .to_str()
+            .ok_or(LocaleError::NoLocaleInPath)?;
+        let locale = Locale::from_str(locale_str)?;
+        return Ok((locale, PageCategory::Doc));
+    }
     Err(DocError::LocaleError(LocaleError::NoLocaleInPath))
 }
 
@@ -369,17 +371,19 @@ thread_local! {
 
 pub fn trim_after<'a>(input: &'a str, pat: Option<&str>) -> &'a str {
     if let Some(pat) = pat
-        && let Some(i) = input.find(pat) {
-            return &input[..=i];
-        }
+        && let Some(i) = input.find(pat)
+    {
+        return &input[..=i];
+    }
     input
 }
 
 pub fn trim_before<'a>(input: &'a str, pat: Option<&str>) -> &'a str {
     if let Some(pat) = pat
-        && let Some(i) = input.find(pat) {
-            return &input[i..];
-        }
+        && let Some(i) = input.find(pat)
+    {
+        return &input[i..];
+    }
     input
 }
 

--- a/crates/rari-doc/src/utils.rs
+++ b/crates/rari-doc/src/utils.rs
@@ -190,14 +190,13 @@ pub(crate) fn locale_and_typ_from_path(path: &Path) -> Result<(Locale, PageCateg
         return Ok((Locale::EnUs, PageCategory::Doc));
     }
 
-    if let Some(root) = blog_root() {
-        if path.starts_with(root) {
+    if let Some(root) = blog_root()
+        && path.starts_with(root) {
             return Ok((Locale::EnUs, PageCategory::BlogPost));
         }
-    }
-    if let Some(root) = content_translated_root() {
-        if let Ok(relative) = path.strip_prefix(root) {
-            if let Some(locale_str) = relative.components().next() {
+    if let Some(root) = content_translated_root()
+        && let Ok(relative) = path.strip_prefix(root)
+            && let Some(locale_str) = relative.components().next() {
                 let locale_str = locale_str
                     .as_os_str()
                     .to_str()
@@ -205,8 +204,6 @@ pub(crate) fn locale_and_typ_from_path(path: &Path) -> Result<(Locale, PageCateg
                 let locale = Locale::from_str(locale_str)?;
                 return Ok((locale, PageCategory::Doc));
             }
-        }
-    }
     Err(DocError::LocaleError(LocaleError::NoLocaleInPath))
 }
 
@@ -371,20 +368,18 @@ thread_local! {
 }
 
 pub fn trim_after<'a>(input: &'a str, pat: Option<&str>) -> &'a str {
-    if let Some(pat) = pat {
-        if let Some(i) = input.find(pat) {
+    if let Some(pat) = pat
+        && let Some(i) = input.find(pat) {
             return &input[..=i];
         }
-    }
     input
 }
 
 pub fn trim_before<'a>(input: &'a str, pat: Option<&str>) -> &'a str {
-    if let Some(pat) = pat {
-        if let Some(i) = input.find(pat) {
+    if let Some(pat) = pat
+        && let Some(i) = input.find(pat) {
             return &input[i..];
         }
-    }
     input
 }
 

--- a/crates/rari-doc/src/walker.rs
+++ b/crates/rari-doc/src/walker.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
-use ignore::types::TypesBuilder;
 use ignore::WalkBuilder;
+use ignore::types::TypesBuilder;
 use rari_types::globals::{content_root, content_translated_root, settings};
 
 /// Creates a `WalkBuilder` for walking through the specified paths globbing "index.md" files. The glob can be overridden.

--- a/crates/rari-lsp/Cargo.toml
+++ b/crates/rari-lsp/Cargo.toml
@@ -13,7 +13,7 @@ rari-types.workspace = true
 
 serde.workspace = true
 serde_json.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["io-std"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true
 anyhow.workspace = true

--- a/crates/rari-lsp/src/keywords.rs
+++ b/crates/rari-lsp/src/keywords.rs
@@ -1,5 +1,5 @@
-use rari_doc::templ::templs::TEMPL_MAP;
 use rari_doc::Templ;
+use rari_doc::templ::templs::TEMPL_MAP;
 
 pub(crate) type KeywordDocsMap = std::collections::HashMap<&'static str, &'static Templ>;
 

--- a/crates/rari-lsp/src/lsp.rs
+++ b/crates/rari-lsp/src/lsp.rs
@@ -1,9 +1,9 @@
 use std::str::FromStr;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
-use dashmap::mapref::one::{Ref, RefMut};
 use dashmap::DashMap;
+use dashmap::mapref::one::{Ref, RefMut};
 use lsp_textdocument::FullTextDocument;
 use rari_doc::find::doc_pages_from_slugish;
 use rari_doc::issues::{DIssue, DisplayIssue};
@@ -24,7 +24,7 @@ use tower_lsp_server::lsp_types::{
     TextDocumentContentChangeEvent, TextDocumentEdit, TextDocumentSyncCapability,
     TextDocumentSyncKind, TextEdit, Uri, WorkspaceEdit,
 };
-use tower_lsp_server::{jsonrpc, LanguageServer, UriExt};
+use tower_lsp_server::{LanguageServer, UriExt, jsonrpc};
 use tree_sitter::Tree;
 use tree_sitter_md::{MarkdownParser, MarkdownTree};
 

--- a/crates/rari-lsp/src/position.rs
+++ b/crates/rari-lsp/src/position.rs
@@ -33,10 +33,12 @@ pub(crate) fn retrieve_element_at_position(
     {}
     let mut node = query_cursor.node();
 
-    if node.grammar_name() == node.kind() && node.kind().len() == 1
-        && let Some(parent) = node.parent() {
-            node = parent
-        }
+    if node.grammar_name() == node.kind()
+        && node.kind().len() == 1
+        && let Some(parent) = node.parent()
+    {
+        node = parent
+    }
     match node.grammar_name() {
         "link_destination" => {
             let start_position = node.start_position();

--- a/crates/rari-lsp/src/position.rs
+++ b/crates/rari-lsp/src/position.rs
@@ -33,11 +33,10 @@ pub(crate) fn retrieve_element_at_position(
     {}
     let mut node = query_cursor.node();
 
-    if node.grammar_name() == node.kind() && node.kind().len() == 1 {
-        if let Some(parent) = node.parent() {
+    if node.grammar_name() == node.kind() && node.kind().len() == 1
+        && let Some(parent) = node.parent() {
             node = parent
         }
-    }
     match node.grammar_name() {
         "link_destination" => {
             let start_position = node.start_position();

--- a/crates/rari-md/src/dl.rs
+++ b/crates/rari-md/src/dl.rs
@@ -15,10 +15,11 @@ pub(crate) fn is_dl<'a>(list: &'a AstNode<'a>) -> bool {
                     return false;
                 }
                 if let Some(j) = i.first_child()
-                    && let NodeValue::Text(ref t) = j.data.borrow().value {
-                        //println!("{:?}", std::str::from_utf8(t));
-                        return t.starts_with(": ");
-                    }
+                    && let NodeValue::Text(ref t) = j.data.borrow().value
+                {
+                    //println!("{:?}", std::str::from_utf8(t));
+                    return t.starts_with(": ");
+                }
             }
             false
         })
@@ -40,17 +41,18 @@ pub(crate) fn convert_dl<'a>(list: &'a AstNode<'a>) {
                     break;
                 }
                 if let Some(j) = i.first_child()
-                    && let NodeValue::Text(ref mut t) = j.data.borrow_mut().value {
-                        match t.len() {
-                            0 => {}
-                            1 => {
-                                t.drain(0..1);
-                            }
-                            _ => {
-                                t.drain(0..2);
-                            }
+                    && let NodeValue::Text(ref mut t) = j.data.borrow_mut().value
+                {
+                    match t.len() {
+                        0 => {}
+                        1 => {
+                            t.drain(0..1);
+                        }
+                        _ => {
+                            t.drain(0..2);
                         }
                     }
+                }
             }
             item.data.borrow_mut().value = NodeValue::DescriptionDetails;
             item.detach();

--- a/crates/rari-md/src/dl.rs
+++ b/crates/rari-md/src/dl.rs
@@ -14,12 +14,11 @@ pub(crate) fn is_dl<'a>(list: &'a AstNode<'a>) -> bool {
                 if !matches!(i.data.borrow().value, NodeValue::Paragraph) {
                     return false;
                 }
-                if let Some(j) = i.first_child() {
-                    if let NodeValue::Text(ref t) = j.data.borrow().value {
+                if let Some(j) = i.first_child()
+                    && let NodeValue::Text(ref t) = j.data.borrow().value {
                         //println!("{:?}", std::str::from_utf8(t));
                         return t.starts_with(": ");
                     }
-                }
             }
             false
         })
@@ -40,8 +39,8 @@ pub(crate) fn convert_dl<'a>(list: &'a AstNode<'a>) {
                 if !matches!(i.data.borrow().value, NodeValue::Paragraph) {
                     break;
                 }
-                if let Some(j) = i.first_child() {
-                    if let NodeValue::Text(ref mut t) = j.data.borrow_mut().value {
+                if let Some(j) = i.first_child()
+                    && let NodeValue::Text(ref mut t) = j.data.borrow_mut().value {
                         match t.len() {
                             0 => {}
                             1 => {
@@ -52,7 +51,6 @@ pub(crate) fn convert_dl<'a>(list: &'a AstNode<'a>) {
                             }
                         }
                     }
-                }
             }
             item.data.borrow_mut().value = NodeValue::DescriptionDetails;
             item.detach();

--- a/crates/rari-md/src/html.rs
+++ b/crates/rari-md/src/html.rs
@@ -11,7 +11,7 @@ use rari_types::locale::Locale;
 use crate::anchor::anchorize;
 use crate::ctype::isspace;
 use crate::ext::DELIM_START;
-use crate::node_card::{is_callout, NoteCard};
+use crate::node_card::{NoteCard, is_callout};
 use crate::utils::{escape_href, tagfilter_block};
 
 pub struct RariContext {

--- a/crates/rari-md/src/lib.rs
+++ b/crates/rari-md/src/lib.rs
@@ -1,5 +1,5 @@
 use comrak::nodes::{AstNode, NodeValue};
-use comrak::{parse_document, Arena, ComrakOptions};
+use comrak::{Arena, ComrakOptions, parse_document};
 use html::{CustomFormatter, RariContext};
 use rari_types::locale::Locale;
 
@@ -99,7 +99,8 @@ mod test {
     #[test]
     fn render_code_tags() -> Result<(), anyhow::Error> {
         let out = m2h("`<select>`", Locale::EnUs)?;
-        assert_eq!(out,
+        assert_eq!(
+            out,
             "<p data-sourcepos=\"1:1-1:10\"><code data-sourcepos=\"1:1-1:10\">&lt;select&gt;</code></p>\n"
         );
         Ok(())
@@ -145,7 +146,10 @@ mod test {
     #[test]
     fn code_macro() -> Result<(), anyhow::Error> {
         let out = m2h(r#"`{{foo}}` bar"#, Locale::EnUs)?;
-        assert_eq!(out, "<p data-sourcepos=\"1:1-1:13\"><code data-sourcepos=\"1:1-1:9\">{{foo}}</code> bar</p>\n");
+        assert_eq!(
+            out,
+            "<p data-sourcepos=\"1:1-1:13\"><code data-sourcepos=\"1:1-1:9\">{{foo}}</code> bar</p>\n"
+        );
         Ok(())
     }
 
@@ -169,16 +173,25 @@ mod test {
     #[test]
     fn li_p() -> Result<(), anyhow::Error> {
         let out = m2h("- foo\n- bar\n", Locale::EnUs)?;
-        assert_eq!(out, "<ul data-sourcepos=\"1:1-2:5\">\n<li data-sourcepos=\"1:1-1:5\">foo</li>\n<li data-sourcepos=\"2:1-2:5\">bar</li>\n</ul>\n");
+        assert_eq!(
+            out,
+            "<ul data-sourcepos=\"1:1-2:5\">\n<li data-sourcepos=\"1:1-1:5\">foo</li>\n<li data-sourcepos=\"2:1-2:5\">bar</li>\n</ul>\n"
+        );
         let out = m2h("- foo\n\n- bar\n", Locale::EnUs)?;
-        assert_eq!(out, "<ul data-sourcepos=\"1:1-3:5\">\n<li data-sourcepos=\"1:1-2:0\">\n<p data-sourcepos=\"1:3-1:5\">foo</p>\n</li>\n<li data-sourcepos=\"3:1-3:5\">\n<p data-sourcepos=\"3:3-3:5\">bar</p>\n</li>\n</ul>\n");
+        assert_eq!(
+            out,
+            "<ul data-sourcepos=\"1:1-3:5\">\n<li data-sourcepos=\"1:1-2:0\">\n<p data-sourcepos=\"1:3-1:5\">foo</p>\n</li>\n<li data-sourcepos=\"3:1-3:5\">\n<p data-sourcepos=\"3:3-3:5\">bar</p>\n</li>\n</ul>\n"
+        );
         Ok(())
     }
 
     #[test]
     fn callout() -> Result<(), anyhow::Error> {
         let out = m2h("> [!CALLOUT]\n> foobar", Locale::EnUs)?;
-        assert_eq!(out, "<div class=\"callout\" data-sourcepos=\"1:1-2:8\">\n<p data-sourcepos=\"1:3-2:8\">\nfoobar</p>\n</div>\n");
+        assert_eq!(
+            out,
+            "<div class=\"callout\" data-sourcepos=\"1:1-2:8\">\n<p data-sourcepos=\"1:3-2:8\">\nfoobar</p>\n</div>\n"
+        );
         Ok(())
     }
 

--- a/crates/rari-md/src/node_card.rs
+++ b/crates/rari-md/src/node_card.rs
@@ -54,37 +54,38 @@ impl NoteCard {
 
 pub(crate) fn is_callout<'a>(block_quote: &'a AstNode<'a>, locale: Locale) -> Option<NoteCard> {
     if let Some(child) = block_quote.first_child()
-        && let Some(marker) = child.first_child() {
-            let mut data = marker.data.borrow_mut();
-            if let NodeValue::Text(ref text) = data.value {
-                if text.starts_with(NoteCard::Callout.prefix()) {
-                    if text.trim() == NoteCard::Callout.prefix() {
-                        marker.detach();
-                    } else if let Some(tail) = text.strip_prefix(NoteCard::Callout.prefix()) {
-                        data.value = NodeValue::Text(tail.trim().to_string());
-                    }
-                    return Some(NoteCard::Callout);
+        && let Some(marker) = child.first_child()
+    {
+        let mut data = marker.data.borrow_mut();
+        if let NodeValue::Text(ref text) = data.value {
+            if text.starts_with(NoteCard::Callout.prefix()) {
+                if text.trim() == NoteCard::Callout.prefix() {
+                    marker.detach();
+                } else if let Some(tail) = text.strip_prefix(NoteCard::Callout.prefix()) {
+                    data.value = NodeValue::Text(tail.trim().to_string());
                 }
-                if text.starts_with(NoteCard::Warning.prefix()) {
-                    if text.trim() == NoteCard::Warning.prefix() {
-                        remove_leading_space_if_zh_locale(marker, locale);
-                        marker.detach();
-                    } else if let Some(tail) = text.strip_prefix(NoteCard::Warning.prefix()) {
-                        data.value = NodeValue::Text(tail.trim().to_string());
-                    }
-                    return Some(NoteCard::Warning);
+                return Some(NoteCard::Callout);
+            }
+            if text.starts_with(NoteCard::Warning.prefix()) {
+                if text.trim() == NoteCard::Warning.prefix() {
+                    remove_leading_space_if_zh_locale(marker, locale);
+                    marker.detach();
+                } else if let Some(tail) = text.strip_prefix(NoteCard::Warning.prefix()) {
+                    data.value = NodeValue::Text(tail.trim().to_string());
                 }
-                if text.starts_with(NoteCard::Note.prefix()) {
-                    if text.trim() == NoteCard::Note.prefix() {
-                        remove_leading_space_if_zh_locale(marker, locale);
-                        marker.detach();
-                    } else if let Some(tail) = text.strip_prefix(NoteCard::Note.prefix()) {
-                        data.value = NodeValue::Text(tail.trim().to_string());
-                    }
-                    return Some(NoteCard::Note);
+                return Some(NoteCard::Warning);
+            }
+            if text.starts_with(NoteCard::Note.prefix()) {
+                if text.trim() == NoteCard::Note.prefix() {
+                    remove_leading_space_if_zh_locale(marker, locale);
+                    marker.detach();
+                } else if let Some(tail) = text.strip_prefix(NoteCard::Note.prefix()) {
+                    data.value = NodeValue::Text(tail.trim().to_string());
                 }
+                return Some(NoteCard::Note);
             }
         }
+    }
     None
 }
 
@@ -99,9 +100,10 @@ fn remove_leading_space_if_zh_locale(node: &AstNode, locale: Locale) {
     // > This is a note.
     // ```
     if let Some(next_sibling) = node.next_sibling()
-        && matches!(next_sibling.data.borrow().value, NodeValue::SoftBreak) {
-            next_sibling.detach();
-        }
+        && matches!(next_sibling.data.borrow().value, NodeValue::SoftBreak)
+    {
+        next_sibling.detach();
+    }
 }
 
 /// Returns the default title for an alert type

--- a/crates/rari-md/src/node_card.rs
+++ b/crates/rari-md/src/node_card.rs
@@ -53,8 +53,8 @@ impl NoteCard {
 }
 
 pub(crate) fn is_callout<'a>(block_quote: &'a AstNode<'a>, locale: Locale) -> Option<NoteCard> {
-    if let Some(child) = block_quote.first_child() {
-        if let Some(marker) = child.first_child() {
+    if let Some(child) = block_quote.first_child()
+        && let Some(marker) = child.first_child() {
             let mut data = marker.data.borrow_mut();
             if let NodeValue::Text(ref text) = data.value {
                 if text.starts_with(NoteCard::Callout.prefix()) {
@@ -85,7 +85,6 @@ pub(crate) fn is_callout<'a>(block_quote: &'a AstNode<'a>, locale: Locale) -> Op
                 }
             }
         }
-    }
     None
 }
 
@@ -99,11 +98,10 @@ fn remove_leading_space_if_zh_locale(node: &AstNode, locale: Locale) {
     // > [!NOTE]
     // > This is a note.
     // ```
-    if let Some(next_sibling) = node.next_sibling() {
-        if matches!(next_sibling.data.borrow().value, NodeValue::SoftBreak) {
+    if let Some(next_sibling) = node.next_sibling()
+        && matches!(next_sibling.data.borrow().value, NodeValue::SoftBreak) {
             next_sibling.detach();
         }
-    }
 }
 
 /// Returns the default title for an alert type

--- a/crates/rari-sitemap/src/lib.rs
+++ b/crates/rari-sitemap/src/lib.rs
@@ -5,8 +5,8 @@ use std::io::{BufWriter, Write as _};
 use std::path::{Path, PathBuf};
 
 use chrono::{NaiveDate, Utc};
-use flate2::write::GzEncoder;
 use flate2::Compression;
+use flate2::write::GzEncoder;
 use rari_doc::build::SitemapMeta;
 use rari_types::error::EnvError;
 use rari_types::globals::build_out_root;

--- a/crates/rari-templ-func/src/lib.rs
+++ b/crates/rari-templ-func/src/lib.rs
@@ -1,12 +1,12 @@
 extern crate proc_macro;
 use std::fmt::Write;
 
-use darling::ast::NestedMeta;
 use darling::FromMeta;
+use darling::ast::NestedMeta;
 use proc_macro::TokenStream;
-use quote::{format_ident, quote, ToTokens};
+use quote::{ToTokens, format_ident, quote};
 use syn::punctuated::Punctuated;
-use syn::{parse_macro_input, parse_quote, Lit};
+use syn::{Lit, parse_macro_input, parse_quote};
 
 enum Complete {
     None,

--- a/crates/rari-tools/src/add_redirect.rs
+++ b/crates/rari-tools/src/add_redirect.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use rari_doc::resolve::{url_meta_from, UrlMeta};
+use rari_doc::resolve::{UrlMeta, url_meta_from};
 use rari_types::locale::Locale;
 
 use crate::error::ToolError;

--- a/crates/rari-tools/src/fix/issues.rs
+++ b/crates/rari-tools/src/fix/issues.rs
@@ -3,7 +3,7 @@ use std::io::{BufWriter, Write};
 
 use rari_doc::issues::{DIssue, IN_MEMORY};
 use rari_doc::pages::page::{Page, PageBuilder, PageLike};
-use tracing::{span, Level};
+use tracing::{Level, span};
 
 use crate::error::ToolError;
 

--- a/crates/rari-tools/src/git.rs
+++ b/crates/rari-tools/src/git.rs
@@ -21,12 +21,12 @@ pub fn exec_git_with_test_fallback(args: &[impl AsRef<OsStr>], root: impl AsRef<
 }
 
 pub fn exec_git(args: &[impl AsRef<OsStr>], root: impl AsRef<Path>) -> Output {
-    let output = Command::new("git")
+    
+    Command::new("git")
         .args(args)
         .current_dir(root)
         .output()
-        .expect("failed to execute process");
-    output
+        .expect("failed to execute process")
 }
 
 fn exec_git_internal(
@@ -34,10 +34,10 @@ fn exec_git_internal(
     args: &[impl AsRef<OsStr>],
     root: impl AsRef<Path>,
 ) -> Output {
-    let output = Command::new(command)
+    
+    Command::new(command)
         .args(args)
         .current_dir(root)
         .output()
-        .expect("failed to execute process");
-    output
+        .expect("failed to execute process")
 }

--- a/crates/rari-tools/src/git.rs
+++ b/crates/rari-tools/src/git.rs
@@ -21,7 +21,6 @@ pub fn exec_git_with_test_fallback(args: &[impl AsRef<OsStr>], root: impl AsRef<
 }
 
 pub fn exec_git(args: &[impl AsRef<OsStr>], root: impl AsRef<Path>) -> Output {
-    
     Command::new("git")
         .args(args)
         .current_dir(root)
@@ -34,7 +33,6 @@ fn exec_git_internal(
     args: &[impl AsRef<OsStr>],
     root: impl AsRef<Path>,
 ) -> Output {
-    
     Command::new(command)
         .args(args)
         .current_dir(root)

--- a/crates/rari-tools/src/history.rs
+++ b/crates/rari-tools/src/history.rs
@@ -68,16 +68,14 @@ fn modification_times(path: &Path) -> Result<(), ToolError> {
                 date = *date_data;
             }
 
-            if let Some(data) = data.get(2) {
-                if let Some(parent_hash) = data.split(' ').nth(1) {
+            if let Some(data) = data.get(2)
+                && let Some(parent_hash) = data.split(' ').nth(1) {
                     parents.insert(parent_hash, HistoryEntry::new(date, hash));
                 }
-            }
-        } else if line.ends_with("index.md") {
-            if let Ok(rel_path) = PathBuf::from(line).strip_prefix("files") {
+        } else if line.ends_with("index.md")
+            && let Ok(rel_path) = PathBuf::from(line).strip_prefix("files") {
                 history.insert(rel_path.to_path_buf(), HistoryEntry::new(date, hash));
             }
-        }
     }
 
     // Replace merged commit dates with their parent date.

--- a/crates/rari-tools/src/history.rs
+++ b/crates/rari-tools/src/history.rs
@@ -5,8 +5,8 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::thread::spawn;
 
-use rari_types::globals::{content_root, content_translated_root};
 use rari_types::HistoryEntry;
+use rari_types::globals::{content_root, content_translated_root};
 
 use crate::error::ToolError;
 use crate::git::exec_git;
@@ -69,13 +69,15 @@ fn modification_times(path: &Path) -> Result<(), ToolError> {
             }
 
             if let Some(data) = data.get(2)
-                && let Some(parent_hash) = data.split(' ').nth(1) {
-                    parents.insert(parent_hash, HistoryEntry::new(date, hash));
-                }
-        } else if line.ends_with("index.md")
-            && let Ok(rel_path) = PathBuf::from(line).strip_prefix("files") {
-                history.insert(rel_path.to_path_buf(), HistoryEntry::new(date, hash));
+                && let Some(parent_hash) = data.split(' ').nth(1)
+            {
+                parents.insert(parent_hash, HistoryEntry::new(date, hash));
             }
+        } else if line.ends_with("index.md")
+            && let Ok(rel_path) = PathBuf::from(line).strip_prefix("files")
+        {
+            history.insert(rel_path.to_path_buf(), HistoryEntry::new(date, hash));
+        }
     }
 
     // Replace merged commit dates with their parent date.

--- a/crates/rari-tools/src/move.rs
+++ b/crates/rari-tools/src/move.rs
@@ -4,12 +4,12 @@ use std::fs::create_dir_all;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use dialoguer::theme::ColorfulTheme;
 use dialoguer::Confirm;
+use dialoguer::theme::ColorfulTheme;
 use rari_doc::{
     helpers::subpages::get_sub_pages,
     pages::page::{self, Page, PageCategory, PageLike, PageWriter},
-    resolve::{build_url, url_meta_from, UrlMeta}, //  url_path_to_path_buf
+    resolve::{UrlMeta, build_url, url_meta_from}, //  url_path_to_path_buf
     utils::root_for_locale,
 };
 use rari_types::locale::Locale;

--- a/crates/rari-tools/src/redirects.rs
+++ b/crates/rari-tools/src/redirects.rs
@@ -399,11 +399,10 @@ fn fix_redirects_internal(
         })?;
         if to.starts_with('/') {
             let (bare_url, hash) = to.split_once('#').map(|(u, h)| (u, Some(h))).unwrap_or((&to, None));
-            if let Ok(page) = Page::from_url(bare_url) {
-                if page.url() != bare_url {
+            if let Ok(page) = Page::from_url(bare_url)
+                && page.url() != bare_url {
                     to = if let Some(hash) = hash { concat_strs!(page.url(), "#", hash) } else { page.url().to_string() } ;
                 }
-            }
         }
         let locale_map = acc.entry(locale).or_default();
         locale_map.insert(from, to);
@@ -662,8 +661,8 @@ fn validate_to_url(url: &str, locale: Locale) -> Result<(), ToolError> {
                 locale
             )));
         }
-        if let Ok(page) = Page::from_url(bare_url) {
-            if page.url() != bare_url {
+        if let Ok(page) = Page::from_url(bare_url)
+            && page.url() != bare_url {
                 return Err(ToolError::InvalidRedirectToURL(format!(
                     "To-URL '{}' does not equal page url '{}' for '{}' for locale '{}'.",
                     bare_url,
@@ -672,7 +671,6 @@ fn validate_to_url(url: &str, locale: Locale) -> Result<(), ToolError> {
                     locale
                 )));
             }
-        }
     } else {
         return Err(ToolError::InvalidRedirectToURL(format!(
             "To-URL '{url}' has to be external (https://) or start with '/' for locale '{locale}'."
@@ -690,8 +688,8 @@ fn is_vanity_redirect_url(url: &str) -> bool {
 }
 
 fn check_url_invalid_symbols(url: &str) -> Result<(), ToolError> {
-    if let Some(symbol_index) = url.find(FORBIDDEN_URL_SYMBOLS) {
-        if let Some(escaped_symbol) = &url[symbol_index..]
+    if let Some(symbol_index) = url.find(FORBIDDEN_URL_SYMBOLS)
+        && let Some(escaped_symbol) = &url[symbol_index..]
             .chars()
             .next()
             .map(|c| c.escape_default())
@@ -700,7 +698,6 @@ fn check_url_invalid_symbols(url: &str) -> Result<(), ToolError> {
                 "URL '{url}' contains forbidden symbol '{escaped_symbol}'."
             )));
         }
-    }
     Ok(())
 }
 

--- a/crates/rari-tools/src/redirects.rs
+++ b/crates/rari-tools/src/redirects.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use rari_doc::pages::page::{Page, PageLike};
-use rari_doc::resolve::{url_meta_from, UrlMeta};
+use rari_doc::resolve::{UrlMeta, url_meta_from};
 use rari_doc::utils::root_for_locale;
 use rari_types::globals::deny_warnings;
 use rari_types::locale::Locale;
@@ -574,7 +574,8 @@ fn validate_from_url(url: &str, locale: Locale) -> Result<(), ToolError> {
     let parts: Vec<&str> = url.split('/').collect();
     if parts.len() < 4 {
         return Err(ToolError::InvalidRedirectFromURL(format!(
-            "From-URL '{url}' does not have enough parts for locale validation for locale '{locale}'."        )));
+            "From-URL '{url}' does not have enough parts for locale validation for locale '{locale}'."
+        )));
     }
 
     let from_locale = parts[1];
@@ -662,15 +663,16 @@ fn validate_to_url(url: &str, locale: Locale) -> Result<(), ToolError> {
             )));
         }
         if let Ok(page) = Page::from_url(bare_url)
-            && page.url() != bare_url {
-                return Err(ToolError::InvalidRedirectToURL(format!(
-                    "To-URL '{}' does not equal page url '{}' for '{}' for locale '{}'.",
-                    bare_url,
-                    page.url(),
-                    path.display(),
-                    locale
-                )));
-            }
+            && page.url() != bare_url
+        {
+            return Err(ToolError::InvalidRedirectToURL(format!(
+                "To-URL '{}' does not equal page url '{}' for '{}' for locale '{}'.",
+                bare_url,
+                page.url(),
+                path.display(),
+                locale
+            )));
+        }
     } else {
         return Err(ToolError::InvalidRedirectToURL(format!(
             "To-URL '{url}' has to be external (https://) or start with '/' for locale '{locale}'."
@@ -693,11 +695,11 @@ fn check_url_invalid_symbols(url: &str) -> Result<(), ToolError> {
             .chars()
             .next()
             .map(|c| c.escape_default())
-        {
-            return Err(ToolError::InvalidRedirectToURL(format!(
-                "URL '{url}' contains forbidden symbol '{escaped_symbol}'."
-            )));
-        }
+    {
+        return Err(ToolError::InvalidRedirectToURL(format!(
+            "URL '{url}' contains forbidden symbol '{escaped_symbol}'."
+        )));
+    }
     Ok(())
 }
 

--- a/crates/rari-tools/src/remove.rs
+++ b/crates/rari-tools/src/remove.rs
@@ -3,8 +3,8 @@ use std::collections::BTreeSet;
 use std::ffi::OsStr;
 use std::path::PathBuf;
 
-use dialoguer::theme::ColorfulTheme;
 use dialoguer::Confirm;
+use dialoguer::theme::ColorfulTheme;
 use rari_doc::error::DocError;
 use rari_doc::helpers::subpages::get_sub_pages;
 use rari_doc::pages::page::{self, Page, PageCategory, PageLike};
@@ -13,7 +13,7 @@ use rari_doc::reader::read_docs_parallel;
 use rari_doc::resolve::build_url;
 use rari_doc::utils::root_for_locale;
 use rari_types::locale::Locale;
-use rayon::iter::{once, IntoParallelIterator, ParallelIterator};
+use rayon::iter::{IntoParallelIterator, ParallelIterator, once};
 
 use crate::error::ToolError;
 use crate::git::exec_git_with_test_fallback;
@@ -51,7 +51,9 @@ pub fn remove(
                 &redirect,
             );
         } else {
-            tracing::info!("Deleting without a redirect. Consider using the --redirect option with a related page instead.");
+            tracing::info!(
+                "Deleting without a redirect. Consider using the --redirect option with a related page instead."
+            );
         }
     }
 

--- a/crates/rari-tools/src/sidebars.rs
+++ b/crates/rari-tools/src/sidebars.rs
@@ -10,7 +10,7 @@ use rari_doc::html::sidebar::{
 };
 use rari_doc::redirects::resolve_redirect;
 use rari_types::globals::content_root;
-use rari_types::locale::{default_locale, Locale};
+use rari_types::locale::{Locale, default_locale};
 use rari_utils::concat_strs;
 
 use crate::error::ToolError;
@@ -64,12 +64,12 @@ impl LinkFixer for CaseFixer {
     fn fix_link(&self, link: Option<String>) -> Option<String> {
         if let Some(link) = &link
             && let Some(slug) = link.strip_prefix("/")
-                && let Some(redirect) =
-                    resolve_redirect(&concat_strs!(EN_US_DOCS_SLASH_PREFIX, slug))
-                    && let Some(new_slug) = redirect.strip_prefix(EN_US_DOCS_SLASH_PREFIX)
-                        && new_slug != slug {
-                            return Some(concat_strs!("/", new_slug));
-                        }
+            && let Some(redirect) = resolve_redirect(&concat_strs!(EN_US_DOCS_SLASH_PREFIX, slug))
+            && let Some(new_slug) = redirect.strip_prefix(EN_US_DOCS_SLASH_PREFIX)
+            && new_slug != slug
+        {
+            return Some(concat_strs!("/", new_slug));
+        }
         link
     }
 }

--- a/crates/rari-tools/src/sidebars.rs
+++ b/crates/rari-tools/src/sidebars.rs
@@ -62,19 +62,14 @@ static EN_US_DOCS_SLASH_PREFIX: &str = concatcp!("/", default_locale().as_url_st
 
 impl LinkFixer for CaseFixer {
     fn fix_link(&self, link: Option<String>) -> Option<String> {
-        if let Some(link) = &link {
-            if let Some(slug) = link.strip_prefix("/") {
-                if let Some(redirect) =
+        if let Some(link) = &link
+            && let Some(slug) = link.strip_prefix("/")
+                && let Some(redirect) =
                     resolve_redirect(&concat_strs!(EN_US_DOCS_SLASH_PREFIX, slug))
-                {
-                    if let Some(new_slug) = redirect.strip_prefix(EN_US_DOCS_SLASH_PREFIX) {
-                        if new_slug != slug {
+                    && let Some(new_slug) = redirect.strip_prefix(EN_US_DOCS_SLASH_PREFIX)
+                        && new_slug != slug {
                             return Some(concat_strs!("/", new_slug));
                         }
-                    }
-                }
-            }
-        }
         link
     }
 }

--- a/crates/rari-tools/src/sync_translated_content.rs
+++ b/crates/rari-tools/src/sync_translated_content.rs
@@ -335,9 +335,10 @@ fn resolve<'a>(
 
     let page = Page::from_url(resolved_url);
     if let Ok(page) = page
-        && page.slug() != slug {
-            return Cow::Owned(page.slug().to_string());
-        }
+        && page.slug() != slug
+    {
+        return Cow::Owned(page.slug().to_string());
+    }
     Cow::Borrowed(slug)
 }
 

--- a/crates/rari-tools/src/sync_translated_content.rs
+++ b/crates/rari-tools/src/sync_translated_content.rs
@@ -334,11 +334,10 @@ fn resolve<'a>(
         .unwrap_or(&en_us_url_lc);
 
     let page = Page::from_url(resolved_url);
-    if let Ok(page) = page {
-        if page.slug() != slug {
+    if let Ok(page) = page
+        && page.slug() != slug {
             return Cow::Owned(page.slug().to_string());
         }
-    }
     Cow::Borrowed(slug)
 }
 

--- a/crates/rari-tools/src/tests/fixtures/docs.rs
+++ b/crates/rari-tools/src/tests/fixtures/docs.rs
@@ -1,11 +1,11 @@
 use std::fs;
 use std::path::PathBuf;
 
-use fake::faker::lorem::en::Paragraph;
 use fake::Fake;
+use fake::faker::lorem::en::Paragraph;
 use indoc::formatdoc;
 use rari_doc::pages::page::PageCategory;
-use rari_doc::resolve::{build_url, url_meta_from, UrlMeta};
+use rari_doc::resolve::{UrlMeta, build_url, url_meta_from};
 use rari_doc::utils::root_for_locale;
 use rari_types::locale::Locale;
 

--- a/crates/rari-tools/src/tests/fixtures/wikihistory.rs
+++ b/crates/rari-tools/src/tests/fixtures/wikihistory.rs
@@ -3,9 +3,9 @@ use std::fs;
 use std::path::PathBuf;
 
 use chrono::{DateTime, SecondsFormat};
+use fake::Fake;
 use fake::faker::chrono::en::DateTimeBetween;
 use fake::faker::internet::en::Username;
-use fake::Fake;
 use rari_doc::utils::root_for_locale;
 use rari_types::locale::Locale;
 use serde_json::Value;

--- a/crates/rari-types/src/globals.rs
+++ b/crates/rari-types/src/globals.rs
@@ -8,7 +8,7 @@ use serde::Deserialize;
 use crate::error::EnvError;
 use crate::locale::Locale;
 use crate::settings::{Deps, Settings};
-use crate::{globals, HistoryEntry, Popularities};
+use crate::{HistoryEntry, Popularities, globals};
 
 #[inline(always)]
 pub fn content_root() -> &'static Path {

--- a/crates/rari-types/src/settings.rs
+++ b/crates/rari-types/src/settings.rs
@@ -105,22 +105,24 @@ impl Settings {
 
     #[cfg(feature = "testing")]
     pub fn new() -> Result<Self, ConfigError> {
-        std::env::set_var(
-            "CONTENT_ROOT",
-            std::env::var("TESTING_CONTENT_ROOT").unwrap(),
-        );
-        std::env::set_var(
-            "CONTENT_TRANSLATED_ROOT",
-            std::env::var("TESTING_CONTENT_TRANSLATED_ROOT").unwrap(),
-        );
-        std::env::set_var(
-            "CACHE_CONTENT",
-            std::env::var("TESTING_CACHE_CONTENT").unwrap(),
-        );
-        std::env::set_var(
-            "READER_IGNORES_GITIGNORE",
-            std::env::var("TESTING_READER_IGNORES_GITIGNORE").unwrap(),
-        );
+        unsafe {
+            std::env::set_var(
+                "CONTENT_ROOT",
+                std::env::var("TESTING_CONTENT_ROOT").unwrap(),
+            );
+            std::env::set_var(
+                "CONTENT_TRANSLATED_ROOT",
+                std::env::var("TESTING_CONTENT_TRANSLATED_ROOT").unwrap(),
+            );
+            std::env::set_var(
+                "CACHE_CONTENT",
+                std::env::var("TESTING_CACHE_CONTENT").unwrap(),
+            );
+            std::env::set_var(
+                "READER_IGNORES_GITIGNORE",
+                std::env::var("TESTING_READER_IGNORES_GITIGNORE").unwrap(),
+            );
+        }
         Self::new_internal()
     }
     #[cfg(not(feature = "testing"))]

--- a/crates/rari-types/src/templ.rs
+++ b/crates/rari-types/src/templ.rs
@@ -1,6 +1,6 @@
 use darling::FromMeta;
 use proc_macro2::TokenStream;
-use quote::{quote, ToTokens};
+use quote::{ToTokens, quote};
 
 use crate::{Arg, RariEnv};
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

- Bumps the Rust version from 1.81 to 1.90.
- Bumps the Rust edition from 2021 to 2024.
- Pins the Rust version in `lint-test-clippy` workflow.

### Motivation

Ensures consistency, and avoids unexpected test, build or release failures.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Same as:

- https://github.com/mdn/rumba/pull/679
- https://github.com/mdn/watify/pull/47