### PR TITLE
chore(rustfmt): disable unstable features

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,2 +1,0 @@
-imports_granularity = "Module"
-group_imports = "StdExternalCrate"


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Removes the Rust formatter config, which enabled the following unstable features only available in nightly channel:

- [group_import](https://redirect.github.com/rust-lang/rustfmt/issues/5083)
- [imports_granularity](https://redirect.github.com/rust-lang/rustfmt/issues/4991)

### Motivation

Avoid [unstable feature warnings](https://github.com/mdn/rari/actions/runs/19030206604/job/54342094610#step:5:15) when running `cargo fmt`. 

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
