### PR TITLE
fix(doc): add tracing context to `build_doc()`

### DIFF
--- a/crates/rari-doc/src/pages/build.rs
+++ b/crates/rari-doc/src/pages/build.rs
@@ -8,6 +8,7 @@ use rari_types::globals::{base_url, content_branch, git_history, popularities};
 use rari_types::locale::Locale;
 use rari_utils::concat_strs;
 use scraper::Html;
+use tracing::{Level, span};
 
 use super::json::{
     BuiltPage, Compat, ContributorSpotlightHyData, JsonBlogPostDoc, JsonBlogPostPage,
@@ -218,6 +219,15 @@ fn build_content<T: PageLike>(page: &T) -> Result<PageContent, DocError> {
 }
 
 fn build_doc(doc: &Doc) -> Result<BuiltPage, DocError> {
+    let span = span!(
+        Level::ERROR,
+        "page",
+        locale = doc.locale().as_url_str(),
+        slug = doc.slug(),
+        file = doc.full_path().to_string_lossy().as_ref(),
+    );
+    let _enter = span.enter();
+
     let PageContent {
         body,
         toc,


### PR DESCRIPTION
### Description

Adds tracing context to `build_doc()`.

### Motivation

When running `content fix-flaws`, the error messages were missing important context.

### Additional details

#### Before

```
Took:     3.175s for reading 28240 docs
ERROR rari_doc::templ::parser: invalid char, '<' break at 1 source="templ_parser"
ERROR rari_doc::templ::parser: invalid char, '<' break at 1 source="templ_parser"
ERROR rari_doc::templ::parser: invalid char, '<' break at 1 source="templ_parser"
ERROR rari_doc::templ::parser: invalid char, '<' break at 1 source="templ_parser"
Took:     4.888s for fixing 0 docs
```

#### After

```
Took:     3.249s for reading 28240 docs
ERROR page{locale="de" slug="Web/CSS/Reference/Properties/mask-border-outset" file="/path/to/translated-content-de/files/de/web/css/reference/properties/mask-border-outset/index.md"}: rari_doc::templ::parser: invalid char, '<' break at 1 source="templ_parser"
ERROR page{locale="de" slug="Web/CSS/Reference/Properties/mask-border-outset" file="/path/to/translated-content-de/files/de/web/css/reference/properties/mask-border-outset/index.md"}: rari_doc::templ::parser: invalid char, '<' break at 1 source="templ_parser"
ERROR page{locale="de" slug="Web/CSS/Reference/Properties/mask-border-outset" file="/path/to/translated-content-de/files/de/web/css/reference/properties/mask-border-outset/index.md"}: rari_doc::templ::parser: invalid char, '<' break at 1 source="templ_parser"
ERROR page{locale="de" slug="Web/CSS/Reference/Properties/mask-border-outset" file="/path/to/translated-content-de/files/de/web/css/reference/properties/mask-border-outset/index.md"}: rari_doc::templ::parser: invalid char, '<' break at 1 source="templ_parser"
Took:     5.160s for fixing 0 docs
```

### Related issues and pull requests

Fixes https://github.com/mdn/rari/issues/367.