### PR TITLE
fix(fix-flaws): apply suggestions in order

### DIFF
--- a/crates/rari-tools/src/fix/issues.rs
+++ b/crates/rari-tools/src/fix/issues.rs
@@ -52,11 +52,15 @@ pub fn get_fixable_issues(page: &Page) -> Result<Vec<DIssue>, ToolError> {
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct SearchReplaceWithOffset {
+    /// Byte offset in the source where the search string begins
     offset: usize,
+    /// Text to find at the specified offset
     search: String,
+    /// Text to replace the search string with
     replace: String,
 }
 
+/// Converts issues into offset-based search/replace suggestions
 pub fn collect_suggestions(raw: &str, issues: &[DIssue]) -> Vec<SearchReplaceWithOffset> {
     let mut suggestions = issues
         .iter()
@@ -85,6 +89,7 @@ pub fn collect_suggestions(raw: &str, issues: &[DIssue]) -> Vec<SearchReplaceWit
     suggestions
 }
 
+/// Applies search/replace suggestions to raw content, returning the modified text
 pub fn apply_suggestions(
     raw: &str,
     suggestions: &[SearchReplaceWithOffset],


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Rewrites the fix-flaws logic to apply suggestions in order, based on the actual location of the broken link, rather than in order of occurrence of the link (reference).

### Motivation

The `fix-flaws` command was failing in content on a page with multiple duplicate link references.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Fixes https://github.com/mdn/rari/issues/366.
