### PR TITLE
fix(css-syntax): regenerate `css_syntax.json` on parse failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,6 +573,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.12",
+ "tracing",
  "url",
 ]
 

--- a/crates/css-syntax/Cargo.toml
+++ b/crates/css-syntax/Cargo.toml
@@ -14,6 +14,7 @@ serde.workspace = true
 url.workspace = true
 html-escape.workspace = true
 itertools.workspace = true
+tracing.workspace = true
 rari-types = { workspace = true, optional = true }
 rari-deps = { workspace = true, optional = true }
 


### PR DESCRIPTION
### Description

Updates `@webref/css` loading to regenerate the `css_syntax.json` if it failed to parse (indicating the format has changed since it was generated, most likely due to a rari update).

### Motivation

Avoids trouble for contributors when we release rari with https://github.com/mdn/rari/pull/375.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Fixes https://github.com/mdn/rari/issues/377.