### PR TITLE
fix(cssinfo): follow the css reorg

### DIFF
--- a/crates/rari-doc/src/templ/templs/cssinfo.rs
+++ b/crates/rari-doc/src/templ/templs/cssinfo.rs
@@ -21,15 +21,12 @@ pub fn cssinfo() -> Result<String, DocError> {
         .slug
         .strip_prefix("Web/CSS/Reference/At-rules/")
         .and_then(|at_rule| {
-            println!("At1-rule: {}", at_rule);
             if at_rule.starts_with('@') {
                 Some(&at_rule[..at_rule.find('/').unwrap_or(at_rule.len())])
             } else {
                 None
             }
         });
-
-    println!("At2-rule: {:?}", at_rule);
 
     let data = mdn_data_files();
     let css_info_data = if let Some(at_rule) = at_rule {


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

This changes the at rule extraction from the slug to be compatible with the css reference reorganization.

### Motivation

Formal definition errors, Example: https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@counter-style/negative#formal_definition

### Additional details

### Before

<img width="500" height="113" alt="image" src="https://github.com/user-attachments/assets/03d3a7f1-aea1-4158-b194-8e0a52072b75" />

### After

<img width="500" height="207" alt="image" src="https://github.com/user-attachments/assets/95e2f5e7-bd00-4801-8035-c525371055b1" />
