### PR TITLE
fix(sidebar): skip missing pages

### DIFF
--- a/crates/rari-doc/src/html/sidebar.rs
+++ b/crates/rari-doc/src/html/sidebar.rs
@@ -274,7 +274,9 @@ impl MetaSidebar {
         let mut out = String::new();
         out.push_str("<ol>");
         for entry in &self.entries {
-            entry.render(&mut out, locale, slug, &self.l10n)?;
+            // Ignore error to avoid empty sidebar.
+            // Doc errors like PageNotFound will show up as flaws.
+            let _ = entry.render(&mut out, locale, slug, &self.l10n);
         }
         out.push_str("</ol>");
         Ok(out)


### PR DESCRIPTION
### Description

Makes the sidebar rendering more resilient by skipping invalid entries.

### Motivation

The sidebar was empty in the case of a non-existing pages referenced.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Fixes https://github.com/mdn/rari/issues/396.