### PR TITLE
chore(types): remove legacy_live_samples_base_url from settings

### DIFF
--- a/crates/rari-types/src/settings.rs
+++ b/crates/rari-types/src/settings.rs
@@ -72,7 +72,6 @@ pub struct Settings {
     pub cache_content: bool,
     pub base_url: String,
     pub live_samples_base_url: String,
-    pub legacy_live_samples_base_url: String,
     pub interactive_examples_base_url: String,
     pub additional_locales_for_generics_and_spas: Vec<Locale>,
     pub reader_ignores_gitignore: bool,


### PR DESCRIPTION
### Description

Removes the `legacy_live_samples_base_url` setting from the types.

### Motivation

It is no longer used anywhere, see [this search](https://github.com/search?q=repo%3Amdn%2Frari%20legacy_live_samples_base_url&type=code).

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
