### PR TITLE
ci(test): remove sccache from format

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,10 +48,6 @@ jobs:
   format:
     needs: build
     runs-on: ubuntu-latest
-    
-    env:
-      RUSTC_WRAPPER: sccache
-      SCCACHE_GHA_ENABLED: true
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -61,9 +57,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@9a1d20035bdbcbc899baabe1e402e85bc33639bc # 1.90
         with:
           components: rustfmt
-
-      - name: sccache-cache
-        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
 
       - name: Run fmt
         run: cargo fmt -- --check


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Removes sccache from the `format` job in the `test` workflow.

### Motivation

`cargo fmt` neither needs nor uses sccache.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
