### PR TITLE
fix(cssxref): Correct `fit-content()` slug and `calc()` example anchor

### DIFF
--- a/crates/rari-doc/src/templ/templs/links/cssxref.rs
+++ b/crates/rari-doc/src/templ/templs/links/cssxref.rs
@@ -20,7 +20,7 @@ use crate::templ::api::RariApi;
 /// # Examples
 /// * `{{CSSxRef("color")}}` -> links to CSS property at `/Web/CSS/Reference/Properties/color`
 /// * `{{CSSxRef("background-color", "background color")}}` -> custom display text
-/// * `{{CSSxRef("calc()", "", "#syntax")}}` -> links to calc() function with anchor at `/Web/CSS/Reference/Values/calc`
+/// * `{{CSSxRef("calc()", "", "#syntax")}}` -> links to calc() function with anchor at `/Web/CSS/Reference/Values/calc#syntax`
 /// * `{{CSSxRef("&lt;color&gt;")}}` -> links to color data type at `/Web/CSS/Reference/Values/color_value`
 /// * `{{CSSxRef(":hover")}}` -> links to pseudo-class at `/Web/CSS/Reference/Selectors/:hover`
 /// * `{{CSSxRef("@media")}}` -> links to at-rule at `/Web/CSS/Reference/At-rules/@media`
@@ -80,7 +80,7 @@ pub fn cssxref_internal(
         "&lt;overflow&gt;" | "<overflow>" => "overflow_value",
         "&lt;position&gt;" | "<position>" => "position_value",
         ":host()" => ":host_function",
-        "fit-content()" => "fit_content_function",
+        "fit-content()" => "fit-content_function",
         _ => slug,
     };
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

This PR fixes the following:

- Updates `fit_content_function` to `fit-content_function` to match the file slug in [`fit-content()`](https://github.com/mdn/content/blob/7c5cdb65b3f9b9cfe05e34a602eaf08d61195b3e/files/en-us/web/css/reference/values/fit-content_function/index.md?plain=1#L3).
- Includes the anchor fragment in the example that shows how to use the 3rd parameter of the macro.

### Motivation

The incorrect `fit_content_function` mapping will not work for `{{cssxref("fit-content()")}}`
