### PR TITLE
ci(build-content-and-diff): use --fast option

### DIFF
--- a/.github/workflows/build-content-and-diff.yml
+++ b/.github/workflows/build-content-and-diff.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Generate diff
         working-directory: rari-pr
-        run: cargo run -p diff-test diff --html --value --out "$DIFF" --verbose "$BUILD_BASE" "$BUILD_PR"
+        run: cargo run -p diff-test diff --fast --html --value --out "$DIFF" --verbose "$BUILD_BASE" "$BUILD_PR"
 
       - name: Upload diff
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Updates the `build-content-and-diff` workflow to run `diff-test` with `--fast`.

### Motivation

Avoid check failures when there are a lot of changes.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Successfully tested in the following PRs:

- https://github.com/mdn/rari/pull/390
- https://github.com/mdn/rari/pull/434
- https://github.com/mdn/rari/pull/436