### PR TITLE
style(lefthook): add config

### DIFF
--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -1,0 +1,24 @@
+pre-commit:
+  parallel: true
+  commands:
+    fmt:
+      glob: "*.rs"
+      run: cargo fmt --all
+      stage_fixed: true
+
+    clippy:
+      glob: "*.rs"
+      run: cargo clippy --all-features --workspace -- -Dwarnings
+
+pre-push:
+  parallel: true
+  commands:
+    test:
+      run: cargo test --verbose --workspace --all-targets --no-fail-fast
+
+    test-doc:
+      run: cargo test --verbose --workspace --doc --features doctest --no-fail-fast
+
+output:
+  - summary
+  - failure


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Add Lefthook config.

### Motivation

Runs `cargo fmt` and `cargo clippy` automatically on the staged changes on pre-commit, and runs the tests before pushing.

### Additional details

Notes:

- Lefthook will not be installed automatically, but when [installed globally](https://lefthook.dev/installation/), it can be enabled by running `lefthook install`.
- Running the tests took 30 seconds for the first time, then less than 10 seconds.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
