### PR TITLE
chore(cli): warn in GitHub Actions without GITHUB_TOKEN

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -137,6 +137,8 @@ jobs:
       - name: Build Rari
         if: inputs.rari-binary-artifact-id == ''
         working-directory: mdn/rari
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: cargo build --release
 
       - name: Prepare rari binary
@@ -162,6 +164,9 @@ jobs:
           ADDITIONAL_LOCALES_FOR_GENERICS_AND_SPAS: de
 
           BLOG_PAGINATION: ${{ steps.privileged.outputs.BLOG_PAGINATION }}
+
+          # Increase GitHub API limit.
+          GITHUB_TOKEN: ${{ github.token }}
 
           PARTIAL_BUILD: ${{ inputs.partial }}
           FILE_LIST: ${{ github.workspace }}/files.txt

--- a/.github/workflows/_test-content-run.yml
+++ b/.github/workflows/_test-content-run.yml
@@ -63,6 +63,7 @@ jobs:
         working-directory: rari
         env:
           CONTENT_ROOT: ${{ github.workspace }}/content/files
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: target/release/rari ${{ inputs.command }}
 
       - name: Diff content


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Warn if Rari runs in GitHub Actions without `GITHUB_TOKEN`.

### Motivation

Make it easy to identify workflow runs where we forgot to provide the `GITHUB_TOKEN`.

### Additional details

Tested via 9d26e582108c98c5dc953cf245821d6b9be6e080, and works as expected:

<img width="1148" height="604" alt="image" src="https://github.com/user-attachments/assets/43284e55-d9ed-4f33-9a94-754216712875" />


### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
