### PR TITLE
fix(doc): follow redirects when copying meta

### DIFF
--- a/crates/rari-doc/src/pages/types/doc.rs
+++ b/crates/rari-doc/src/pages/types/doc.rs
@@ -214,7 +214,14 @@ impl PageReader<Page> for Doc {
                         path
                     );
                 }
-                _ => {}
+                Err(err) => {
+                    tracing::error!(
+                        "Super doc not found for {}:{} {}",
+                        doc.meta.locale.as_url_str(),
+                        doc.meta.slug,
+                        err
+                    );
+                }
             }
         }
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Updates the logic that merges the frontmatter of a translated page with the original page, to take into consideration redirects.

### Motivation

Avoid errors due to translated content not being up to date with en-US moves.

### Additional details

The specific errors that prompted this when building locally with content and translated-content:

```
ERROR page{locale="es" slug="Web/CSS/border-inline-start-color" file="/path/to/mdn/translated-content/files/es/web/css/border-inline-start-color/index.md"}:page{locale="es" slug="Web/CSS/border-inline-start-color" file="/path/to/mdn/translated-content/files/es/web/css/border-inline-start-color/index.md"}:templ{templ="csssyntax" line=65 col=0 end_line=65 end_col=13}: rari_doc::templ::templs::csssyntax: No Css Page: Web/CSS/border-inline-start-color
ERROR page{locale="es" slug="Web/CSS/height" file="/path/to/mdn/translated-content/files/es/web/css/height/index.md"}:page{locale="es" slug="Web/CSS/height" file="/path/to/mdn/translated-content/files/es/web/css/height/index.md"}:templ{templ="csssyntax" line=104 col=0 end_line=104 end_col=13}: rari_doc::templ::templs::csssyntax: No Css Page: Web/CSS/height
ERROR page{locale="es" slug="Web/CSS/flex-grow" file="/path/to/mdn/translated-content/files/es/web/css/flex-grow/index.md"}:page{locale="es" slug="Web/CSS/flex-grow" file="/path/to/mdn/translated-content/files/es/web/css/flex-grow/index.md"}:templ{templ="csssyntax" line=37 col=0 end_line=37 end_col=13}: rari_doc::templ::templs::csssyntax: No Css Page: Web/CSS/flex-grow
```

After this change, there are only 7 errors left on a full build:

```terminal
% cargo run build --all --templ-stats
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.26s
     Running `target/debug/rari build --all --issues /path/to/mdn/rari/issues-after.json --templ-stats`
Building everything 🛠️
ERROR page{file="/path/to/mdn/translated-content/files/pt-br/learn_web_development/howto/tools_and_setup/how_do_you_host_your_website_on_google_app_engine/index.md"}: rari_doc::pages::types::doc: Super doc not found for pt-BR:Learn_web_development/Howto/Tools_and_setup/How_do_you_host_your_website_on_Google_App_Engine io error: No such file or directory (os error 2) (/path/to/mdn/content/files/en-us/learn_web_development/howto/tools_and_setup/how_do_you_host_your_website_on_google_app_engine/index.md)
Took:     7.760s for reading 48771 docs
Took:  440.782ms to build spas (131)
ERROR page{locale="ko" slug="orphaned/Web/CSS/-webkit-overflow-scrolling" file="/path/to/mdn/translated-content/files/ko/orphaned/web/css/-webkit-overflow-scrolling/index.md"}:page{locale="ko" slug="orphaned/Web/CSS/-webkit-overflow-scrolling" file="/path/to/mdn/translated-content/files/ko/orphaned/web/css/-webkit-overflow-scrolling/index.md"}:templ{templ="csssyntax" line=21 col=0 end_line=21 end_col=13}: rari_doc::templ::templs::csssyntax: No Css Page: orphaned/Web/CSS/-webkit-overflow-scrolling
ERROR page{locale="es" slug="conflicting/Web/CSS_a6ba0198499c2f7f7947719c0dfd9166" file="/path/to/mdn/translated-content/files/es/conflicting/web/css_a6ba0198499c2f7f7947719c0dfd9166/index.md"}:page{locale="es" slug="conflicting/Web/CSS_a6ba0198499c2f7f7947719c0dfd9166" file="/path/to/mdn/translated-content/files/es/conflicting/web/css_a6ba0198499c2f7f7947719c0dfd9166/index.md"}:templ{templ="csssyntax" line=16 col=0 end_line=16 end_col=13}: rari_doc::templ::templs::csssyntax: No Css Page: conflicting/Web/CSS_a6ba0198499c2f7f7947719c0dfd9166
ERROR page{locale="es" slug="conflicting/Web/CSS/clip" file="/path/to/mdn/translated-content/files/es/conflicting/web/css/clip/index.md"}:page{locale="es" slug="conflicting/Web/CSS/clip" file="/path/to/mdn/translated-content/files/es/conflicting/web/css/clip/index.md"}:templ{templ="csssyntax" line=20 col=0 end_line=20 end_col=13}: rari_doc::templ::templs::csssyntax: No Css Page: conflicting/Web/CSS/clip
ERROR page{locale="pt-BR" slug="orphaned/Web/CSS/-webkit-overflow-scrolling" file="/path/to/mdn/translated-content/files/pt-br/orphaned/web/css/-webkit-overflow-scrolling/index.md"}:page{locale="pt-BR" slug="orphaned/Web/CSS/-webkit-overflow-scrolling" file="/path/to/mdn/translated-content/files/pt-br/orphaned/web/css/-webkit-overflow-scrolling/index.md"}:templ{templ="csssyntax" line=23 col=0 end_line=23 end_col=13}: rari_doc::templ::templs::csssyntax: No Css Page: orphaned/Web/CSS/-webkit-overflow-scrolling
ERROR page{locale="es" slug="orphaned/Web/CSS/-webkit-overflow-scrolling" file="/path/to/mdn/translated-content/files/es/orphaned/web/css/-webkit-overflow-scrolling/index.md"}:page{locale="es" slug="orphaned/Web/CSS/-webkit-overflow-scrolling" file="/path/to/mdn/translated-content/files/es/orphaned/web/css/-webkit-overflow-scrolling/index.md"}:templ{templ="csssyntax" line=21 col=0 end_line=21 end_col=13}: rari_doc::templ::templs::csssyntax: No Css Page: orphaned/Web/CSS/-webkit-overflow-scrolling
ERROR page{locale="es" slug="orphaned/Web/CSS/-moz-context-properties" file="/path/to/mdn/translated-content/files/es/orphaned/web/css/-moz-context-properties/index.md"}:page{locale="es" slug="orphaned/Web/CSS/-moz-context-properties" file="/path/to/mdn/translated-content/files/es/orphaned/web/css/-moz-context-properties/index.md"}:templ{templ="csssyntax" line=41 col=0 end_line=41 end_col=13}: rari_doc::templ::templs::csssyntax: No Css Page: orphaned/Web/CSS/-moz-context-properties
Took:   190.425s to build content docs (48771)
Took:  239.948ms to build search index
Took:  626.114ms to build generic pages (100)
Took:    5.000µs to build curriculum pages (0)
Took:  624.250µs to build blog (1)
Took:  226.741ms to build contributor spotlights (120)
Took:  384.620ms to write sitemaps (49123)
--- templ summary ---
 1  embedinteractiveexample     3
 2  jsxref(「reflect.           1
```

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
