### PR TITLE
chore(csssyntax): refine errors

### DIFF
--- a/crates/rari-doc/src/templ/templs/csssyntax.rs
+++ b/crates/rari-doc/src/templ/templs/csssyntax.rs
@@ -48,7 +48,9 @@ pub fn csssyntax(name: Option<String>) -> Result<String, DocError> {
                 css_syntax::error::SyntaxError::NoSyntaxFound,
             ));
         }
-        _ if env.slug.starts_with("orphaned/") || env.slug.starts_with("conflicting/") => {
+        rari_types::fm_types::PageType::None
+            if env.slug.starts_with("orphaned/") || env.slug.starts_with("conflicting/") =>
+        {
             warn!(
                 "CSS syntax not available for conflicting/orphaned page: {}",
                 env.slug
@@ -58,7 +60,7 @@ pub fn csssyntax(name: Option<String>) -> Result<String, DocError> {
             ));
         }
         _ => {
-            error!("No Css Page: {}", env.slug);
+            error!("CSS syntax not available for page type {:?}", page_type);
             return Err(DocError::CssPageTypeRequired);
         }
     };


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Updates the `csssyntax` macro error messages:

1. Only warn (don't error) for conflicted/orphaned pages. (They have no page type.)
2. Mention page type in error message for unsupported page type.

### Motivation

Avoids the 7 errors remaining after https://github.com/mdn/rari/pull/449.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
