### PR TITLE
fix(doc): map "No such file or directory" error in read_doc()`

### DIFF
--- a/crates/rari-doc/src/pages/types/doc.rs
+++ b/crates/rari-doc/src/pages/types/doc.rs
@@ -373,7 +373,13 @@ pub fn doc_from_raw(raw: String, full_path: impl Into<PathBuf>) -> Result<Doc, D
 
 fn read_doc(path: impl Into<PathBuf>) -> Result<Doc, DocError> {
     let full_path = path.into();
-    let raw = read_to_string(&full_path)?;
+    let raw = read_to_string(&full_path).map_err(|e| {
+        if e.source.kind() == std::io::ErrorKind::NotFound {
+            DocError::PageNotFound(full_path.display().to_string(), PageCategory::Doc)
+        } else {
+            DocError::RariIoError(e)
+        }
+    })?;
     doc_from_raw(raw, full_path)
 }
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Updates the IO error handling logic, mapping `NotFound` into `DocError::PageNotFound` directly in `read_doc()`.

### Motivation

Improve the following error message noticed in https://github.com/mdn/rari/pull/449:

```
ERROR page{file="/path/to/mdn/translated-content/files/pt-br/learn_web_development/howto/tools_and_setup/how_do_you_host_your_website_on_google_app_engine/index.md"}: rari_doc::pages::types::doc: Super doc not found for pt-BR:Learn_web_development/Howto/Tools_and_setup/How_do_you_host_your_website_on_Google_App_Engine io error: No such file or directory (os error 2) (/path/to/mdn/content/files/en-us/learn_web_development/howto/tools_and_setup/how_do_you_host_your_website_on_google_app_engine/index.md)
```

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
