### PR TITLE
chore(doc): ignore shared assets when handling images

### DIFF
--- a/crates/rari-doc/src/html/fix_img.rs
+++ b/crates/rari-doc/src/html/fix_img.rs
@@ -21,7 +21,10 @@ pub fn handle_img(
 ) -> HandlerResult {
     if let Some(src) = el.get_attribute("src") {
         let url = base_url.parse(&src)?;
-        if url.host() == base.host() && !url.path().starts_with("/assets/") {
+        if url.host() == base.host()
+            && !url.path().starts_with("/assets/")
+            && !url.path().starts_with("/shared-assets/")
+        {
             el.set_attribute("src", url.path())?;
             // Leave dimensions alone if we have a `width` attribute
             if el.get_attribute("width").is_some() {


### PR DESCRIPTION
### Description

Updates image handling to ignore shared assets.

### Motivation

Prevent errors related to shared assets from showing up in content PR Review Companion comments like [this one](https://github.com/mdn/content/pull/42408#issuecomment-3656723614).

### Additional details

It would be nice if the shared-assets repository automatically maintained a JSON file with information about all assets, but since we don't have that, we should better avoid these errors for now, as they're not actionable from a contributor's point of view.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
