### PR TITLE
chore(embed_live_sample): accept allow-downloads as sandbox value

### DIFF
--- a/crates/rari-doc/src/templ/templs/embeds/embed_live_sample.rs
+++ b/crates/rari-doc/src/templ/templs/embeds/embed_live_sample.rs
@@ -85,7 +85,10 @@ pub fn embedlivesample(
     out.push_str(r#"sandbox=""#);
     if let Some(sandbox) = sandbox {
         let is_sane = sandbox.split_ascii_whitespace().all(|attr| {
-            if matches!(attr, "allow-modals" | "allow-forms" | "allow-popups") {
+            if matches!(
+                attr,
+                "allow-downloads" | "allow-modals" | "allow-forms" | "allow-popups"
+            ) {
                 true
             } else {
                 let ic = get_issue_counter();


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Updates the `embedlivesample` macro, adding `allow-downloads` to the list of accepted sandbox value.

### Motivation

Allow broken download examples to be fixed.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Fixes https://github.com/mdn/rari/issues/458.
