### PR TITLE
fix(svginfo): update SVG Element url

### DIFF
--- a/crates/rari-doc/src/templ/templs/svginfo.rs
+++ b/crates/rari-doc/src/templ/templs/svginfo.rs
@@ -43,7 +43,10 @@ pub fn svginfo() -> Result<String, DocError> {
                     elements.push(svgxref_internal(element_name, env.locale)?)
                 } else {
                     let anchor = to_snake_case(element);
-                    let url = format!("/{}/docs/Web/SVG/Element#{anchor}", env.locale.as_url_str());
+                    let url = format!(
+                        "/{}/docs/Web/SVG/Reference/Element#{anchor}",
+                        env.locale.as_url_str()
+                    );
                     let display = l10n_json_data("SVG", element, env.locale).unwrap_or(element);
                     let link =
                         RariApi::link(&url, Some(env.locale), Some(display), false, None, false)?;


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Updates the `svginfo` to the reorganized SVG page structure.

### Motivation

This was causing the following flaw/issue:

> Macro svginfo produces link /en-US/docs/Web/SVG/Element which is a redirect

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->
```
BEGIN_COMMIT_OVERRIDE
fix(svginfo): update SVG Element url (#490)
END_COMMIT_OVERRIDE
```

### Related issues and pull requests

Noticed in https://github.com/mdn/content/pull/42834.