### PR TITLE
fix(cssinfo): update CSS guides urls

### DIFF
--- a/crates/rari-doc/src/helpers/css_info.rs
+++ b/crates/rari-doc/src/helpers/css_info.rs
@@ -113,7 +113,7 @@ pub fn css_info_properties(
         out.push((
             "animationType",
             Cow::Owned(RariApi::link(
-                "/Web/CSS/CSS_animated_properties",
+                "/Web/CSS/Guides/Animations/Animatable_properties",
                 Some(locale),
                 Some(get_css_l10n_for_locale("animationType", locale)),
                 false,
@@ -305,7 +305,7 @@ pub fn get_for_locale(locale: Locale, lookup: &Value) -> &Value {
 pub fn css_computed(locale: Locale) -> Result<String, DocError> {
     let copy = l10n_json_data("Template", "xref_csscomputed", locale)?;
     RariApi::link(
-        "/Web/CSS/CSS_cascade/Value_processing#computed_value",
+        "/Web/CSS/Guides/Cascade/Property_value_processing#computed_value",
         Some(locale),
         Some(copy),
         false,
@@ -317,7 +317,7 @@ pub fn css_computed(locale: Locale) -> Result<String, DocError> {
 pub fn css_inherited(locale: Locale) -> Result<String, DocError> {
     let copy = l10n_json_data("Template", "xref_cssinherited", locale)?;
     RariApi::link(
-        "/Web/CSS/CSS_cascade/Inheritance",
+        "/Web/CSS/Guides/Cascade/Inheritance",
         Some(locale),
         Some(copy),
         false,
@@ -329,7 +329,7 @@ pub fn css_inherited(locale: Locale) -> Result<String, DocError> {
 pub fn css_initial(locale: Locale) -> Result<String, DocError> {
     let copy = l10n_json_data("Template", "xref_cssinitial", locale)?;
     RariApi::link(
-        "/Web/CSS/CSS_cascade/Value_processing#initial_value",
+        "/Web/CSS/Guides/Cascade/Property_value_processing#initial_value",
         Some(locale),
         Some(copy),
         false,


### PR DESCRIPTION
### Description

- The following URLs were incorrect and caused redirection errors:
  - Web/CSS/CSS_animated_properties
  - Web/CSS/CSS_cascade/Value_processing
  - Web/CSS/CSS_cascade/Inheritance
- This affects all macros since the change in CSS categories.

### Motivation

Enable the removal of redirect errors on English, German (auto), and translation repositories.
Enable the removal of redirects from the `_redirects` file without causing incorrect link errors.

### Additional details

```
BEGIN_COMMIT_OVERRIDE
fix(cssinfo): update CSS guides urls (#508)
END_COMMIT_OVERRIDE
```

### Related issues and pull requests

Fix #507
