### PR TITLE
fix(doc): compute baseline status for multiple BCD keys

### DIFF
--- a/crates/rari-data/src/baseline.rs
+++ b/crates/rari-data/src/baseline.rs
@@ -289,7 +289,7 @@ pub struct Support {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     safari_ios: Option<String>,
 }
-#[derive(Deserialize, Serialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(rename_all = "snake_case")]
 pub enum BaselineHighLow {
     High,

--- a/crates/rari-doc/src/baseline.rs
+++ b/crates/rari-doc/src/baseline.rs
@@ -20,27 +20,38 @@ static WEB_FEATURES: LazyLock<Option<WebFeatures>> = LazyLock::new(|| {
     }
 });
 
-/// Retrieves the baseline support status for a given browser compatibility key.
+/// Retrieves the baseline support status for the given browser compatibility keys.
 ///
-/// This function looks up the baseline support status for the provided browser compatibility key
-/// in the `WEB_FEATURES` static variable. If it contains the specified key, it returns the corresponding
-/// `SupportStatusWithByKey`. If the key is not found, it returns `None`.
+/// When a page lists multiple keys, the **lowest** baseline status among them is used:
+/// 1. If any key is missing from web-features, no banner is shown (`None`).
+/// 2. If all keys are present but any is `false` (not baseline), the result is `false`.
+/// 3. If all are present and none is `false` but any is `low`, the result is `low`.
+/// 4. Otherwise all are `high`, and the result is `high`.
 ///
 /// # Arguments
 ///
-/// * `browser_compat` - A slice of strings that holds the browser compatibility keys to be looked up. This function
-///   only deals with single keys, so the slice should contain only one element.
+/// * `browser_compat` - The browser compatibility keys for the page. All must be present in
+///   web-features; if any is missing, this returns `None`.
 ///
 /// # Returns
 ///
-/// * `Option<&'static SupportStatusWithByKey>` - Returns `Some(&SupportStatusWithByKey)` if the key is found,
-///   or `None` if the key is not found or `WEB_FEATURES` is not initialized.
+/// * `Option<Baseline>` - The combined baseline (lowest of all keys), or `None` if any key
+///   is missing or `WEB_FEATURES` is not initialized.
 pub(crate) fn get_baseline<'a>(browser_compat: &[String]) -> Option<Baseline<'a>> {
-    if let Some(ref web_features) = *WEB_FEATURES {
-        return match &browser_compat {
-            &[bcd_key] => web_features.baseline_by_bcd_key(bcd_key.as_str()),
-            _ => None,
-        };
+    let wf = WEB_FEATURES.as_ref();
+    let web_features = wf.as_ref()?;
+    if browser_compat.is_empty() {
+        return None;
     }
-    None
+    let baselines: Vec<Baseline<'_>> = browser_compat
+        .iter()
+        .filter_map(|bcd_key| web_features.baseline_by_bcd_key(bcd_key.as_str()))
+        .collect();
+    if baselines.len() != browser_compat.len() {
+        return None;
+    }
+    baselines
+        .into_iter()
+        // max to get the "lowest" baseline (worst status)
+        .max_by_key(|b| b.support.baseline)
 }


### PR DESCRIPTION
Fixes https://github.com/mdn/fred/issues/1321

<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

The `get_baseline` function accepts an array of BCD keys and returns a baseline status. But it was returning `None` for pages that have multiple BCD keys, e.g. `@scope` https://github.com/mdn/content/blob/main/files/en-us/web/css/reference/at-rules/%40scope/index.md 

```
---
title: "@scope"
slug: Web/CSS/Reference/At-rules/@scope
page-type: css-at-rule
browser-compat:
  - css.at-rules.scope
  - css.selectors.nesting.at-scope
sidebar: cssref
---
```

The code had a comment about this:

```
/// * `browser_compat` - A slice of strings that holds the browser compatibility keys to be looked up. This function
///   only deals with single keys, so the slice should contain only one element.
```

I'm a little unclear on the meaning of that "should contain only one element," but I think it's not correct to just return `None` for pages with multiple BCD keys, so I've updated the function to actually support multiple BCD keys.

The way I implemented it, if any of the BCD keys don't have a Baseline status, we'll return `None`. Otherwise, we'll return the lowest Baseline status in the set, i.e. if one of them is `BaselineHighLow::False` we'll return `False`, if any of them is `::Low` we'll return `Low`, otherwise all of them are `::High` and we'll return `High`.

I tested this on my machine by checking out https://github.com/mdn/content and building it, then replacing `content/node_modules/@mdn/rari/bin/rari` with a symlink to my built version of `rari`. Then, my local `http://localhost:5042/en-US/docs/Web/CSS/Reference/At-rules/@scope` page showed the correct Baseline status (low).

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

My goal was to fix the Baseline status on the `@scope` page. (I bet there are other pages that will be fixed by this, too.)

<!-- ❓ Why are you making these changes and how do they help? -->

### Related issues and pull requests

Fixes https://github.com/mdn/fred/issues/1321

I added both BCD keys to the Baseline status for `@scope` in https://github.com/web-platform-dx/web-features/pull/3704 which merged to main on Jan 30, released in v3.15.0 on Feb 4.
