### PR TITLE
feat(md): support custom heading IDs

### DIFF
--- a/crates/rari-md/src/anchor.rs
+++ b/crates/rari-md/src/anchor.rs
@@ -3,6 +3,16 @@ use std::sync::LazyLock;
 
 use regex::Regex;
 
+/// Extracts a custom heading ID from `{#id}` syntax at the end of heading text.
+/// Returns the custom ID if found.
+pub fn extract_heading_id(content: &str) -> Option<&str> {
+    static HEADING_ID_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"\s*\{#([\w-]+)\}\s*$").unwrap());
+    HEADING_ID_RE
+        .captures(content)
+        .map(|c| c.get(1).unwrap().as_str())
+}
+
 pub fn anchorize(content: &str) -> Cow<'_, str> {
     static REJECTED_CHARS: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r#"[*<>"$#%&+,/:;=?@\[\]^`{|}~')(\\]"#).unwrap());
@@ -24,5 +34,57 @@ pub fn anchorize(content: &str) -> Cow<'_, str> {
         }
     } else {
         Cow::Borrowed("sect")
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn extract_simple_id() {
+        assert_eq!(
+            extract_heading_id("Heading {#custom-id}"),
+            Some("custom-id")
+        );
+    }
+
+    #[test]
+    fn extract_id_with_underscores() {
+        assert_eq!(
+            extract_heading_id("Heading {#my_custom_id}"),
+            Some("my_custom_id")
+        );
+    }
+
+    #[test]
+    fn extract_id_trailing_whitespace() {
+        assert_eq!(
+            extract_heading_id("Heading {#custom-id}  "),
+            Some("custom-id")
+        );
+    }
+
+    #[test]
+    fn no_id_when_not_at_end() {
+        assert_eq!(
+            extract_heading_id("Heading {#custom-id} trailing text"),
+            None
+        );
+    }
+
+    #[test]
+    fn no_id_without_hash() {
+        assert_eq!(extract_heading_id("Heading {custom-id}"), None);
+    }
+
+    #[test]
+    fn no_id_plain_heading() {
+        assert_eq!(extract_heading_id("Plain heading text"), None);
+    }
+
+    #[test]
+    fn no_id_empty_braces() {
+        assert_eq!(extract_heading_id("Heading {#}"), None);
     }
 }

--- a/crates/rari-md/src/html.rs
+++ b/crates/rari-md/src/html.rs
@@ -1,14 +1,16 @@
 use core::str;
 use std::collections::HashMap;
 use std::io::Write;
+use std::sync::LazyLock;
 
 use comrak::create_formatter;
 use comrak::html::{collect_text, render_math_code_block, render_sourcepos, write_opening_tag};
-use comrak::nodes::NodeValue;
+use comrak::nodes::{AstNode, NodeValue};
 use itertools::Itertools;
 use rari_types::locale::Locale;
+use regex::Regex;
 
-use crate::anchor::anchorize;
+use crate::anchor::{anchorize, extract_heading_id};
 use crate::ctype::isspace;
 use crate::ext::DELIM_START;
 use crate::node_card::{NoteCard, is_callout};
@@ -17,6 +19,29 @@ use crate::utils::{escape_href, tagfilter_block};
 pub struct RariContext {
     pub stack: Vec<Option<NoteCard>>,
     pub locale: Locale,
+}
+
+fn find_last_text_node<'a>(node: &'a AstNode<'a>) -> Option<&'a AstNode<'a>> {
+    for child in node.reverse_children() {
+        if matches!(child.data.borrow().value, NodeValue::Text(_)) {
+            return Some(child);
+        }
+        if let Some(text_node) = find_last_text_node(child) {
+            return Some(text_node);
+        }
+    }
+    None
+}
+
+fn strip_heading_id_suffix<'a>(heading: &'a AstNode<'a>) {
+    static HEADING_ID_SUFFIX: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"\s*\{#[\w-]+\}\s*$").unwrap());
+    if let Some(last_text) = find_last_text_node(heading) {
+        let mut data = last_text.data.borrow_mut();
+        if let NodeValue::Text(ref mut t) = data.value {
+            *t = HEADING_ID_SUFFIX.replace(t.as_str(), "").into_owned();
+        }
+    }
 }
 
 create_formatter!(CustomFormatter<RariContext>, {
@@ -162,6 +187,9 @@ create_formatter!(CustomFormatter<RariContext>, {
                 let is_templ = raw_id.contains(DELIM_START);
                 if is_templ {
                     write!(context, " data-update-id")?;
+                } else if let Some(custom_id) = extract_heading_id(&raw_id) {
+                    write!(context, " id=\"{custom_id}\"")?;
+                    strip_heading_id_suffix(node);
                 } else {
                     let id = anchorize(&raw_id);
                     write!(context, " id=\"{id}\"")?;

--- a/crates/rari-md/src/lib.rs
+++ b/crates/rari-md/src/lib.rs
@@ -250,6 +250,65 @@ mod test {
     }
 
     #[test]
+    fn heading_custom_id() -> Result<(), anyhow::Error> {
+        let out = m2h_internal(
+            "## Heading {#custom-id}",
+            Locale::EnUs,
+            M2HOptions { sourcepos: false },
+        )?;
+        assert_eq!(out, "<h2 id=\"custom-id\">Heading</h2>\n");
+        Ok(())
+    }
+
+    #[test]
+    fn heading_custom_id_with_bold() -> Result<(), anyhow::Error> {
+        let out = m2h_internal(
+            "## Heading **bold** {#my-id}",
+            Locale::EnUs,
+            M2HOptions { sourcepos: false },
+        )?;
+        assert_eq!(out, "<h2 id=\"my-id\">Heading <strong>bold</strong></h2>\n");
+        Ok(())
+    }
+
+    #[test]
+    fn heading_no_custom_id() -> Result<(), anyhow::Error> {
+        let out = m2h_internal(
+            "## Regular heading",
+            Locale::EnUs,
+            M2HOptions { sourcepos: false },
+        )?;
+        assert_eq!(out, "<h2 id=\"regular_heading\">Regular heading</h2>\n");
+        Ok(())
+    }
+
+    #[test]
+    fn heading_custom_id_not_at_end() -> Result<(), anyhow::Error> {
+        let out = m2h_internal(
+            "## Heading {#id} trailing",
+            Locale::EnUs,
+            M2HOptions { sourcepos: false },
+        )?;
+        // {#id} not at end, so it's treated as regular text and anchorized
+        assert_eq!(
+            out,
+            "<h2 id=\"heading_id_trailing\">Heading {#id} trailing</h2>\n"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn heading_h3_custom_id() -> Result<(), anyhow::Error> {
+        let out = m2h_internal(
+            "### Exemples {#examples}",
+            Locale::Fr,
+            M2HOptions { sourcepos: false },
+        )?;
+        assert_eq!(out, "<h3 id=\"examples\">Exemples</h3>\n");
+        Ok(())
+    }
+
+    #[test]
     fn escape_hrefs() -> Result<(), anyhow::Error> {
         fn eh(s: &str) -> Result<String, anyhow::Error> {
             let mut out = Vec::with_capacity(s.len());


### PR DESCRIPTION
### Description

Add support for custom heading IDs:

```md
## Heading {#custom-id}
```

Renders to

```html
<h2 id="custom-id">Heading</h2>
```

### Motivation

Allow translated content to use the same heading IDs as en-US, making locale-agnostic fragment links work across locales.

### Additional details

This was discussed in https://github.com/orgs/mdn/discussions/387.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
