### PR TITLE
don't panic in recent_contributions_from_git

### DIFF
--- a/crates/rari-doc/src/pages/types/spa_homepage.rs
+++ b/crates/rari-doc/src/pages/types/spa_homepage.rs
@@ -84,12 +84,12 @@ pub fn featured_articles(
 }
 
 pub fn recent_contributions() -> Result<Vec<HomePageRecentContribution>, DocError> {
-    let mut content = recent_contributions_from_git(content_root(), "mdn/content")?;
+    let mut content = recent_contributions_from_git(content_root(), "mdn/content").unwrap_or_default();
     if let Some(translated_root) = content_translated_root() {
         content.extend(recent_contributions_from_git(
             translated_root,
             "mdn/translated-content",
-        )?);
+        ).unwrap_or_default());
     };
     content.sort_by(|a, b| a.updated_at.cmp(&b.updated_at));
     Ok(content)
@@ -105,8 +105,7 @@ fn recent_contributions_from_git(
     let output = Command::new("git")
         .args(["rev-parse", "--show-toplevel"])
         .current_dir(path)
-        .output()
-        .expect("failed to execute git rev-parse");
+        .output()?;
 
     let repo_root_raw = String::from_utf8_lossy(&output.stdout);
     let repo_root = repo_root_raw.trim();
@@ -120,8 +119,7 @@ fn recent_contributions_from_git(
             "-z",
         ])
         .current_dir(repo_root)
-        .output()
-        .expect("failed to execute process");
+        .output()?;
 
     let output_str = String::from_utf8_lossy(&output.stdout);
     Ok(output_str


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

<!-- ✍️ Summarize your changes in one or two sentences -->

return empty vec instead of panic if `recent_contributions_from_git` fails. 

### Motivation

<!-- ❓ Why are you making these changes and how do they help? -->

in general, handling non-critical errors is better than panic and terminating the entire process. being unable to render recent contributions from git shouldn't prevent access to the rest of the doc content.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

the calls to git in `recent_contributions_from_git` can fail for a number of reasons; a couple I encountered while trying to locally build and serve the `mdn/content` project repo:

- when there is no git repo; instead using downloaded zip archive (git repo with full history is about 451 MB, vs 68 MB for just the current main branch .zip from github)
- when the git repo is on an external drive (on windows; drive using exFAT partition), `git rev-parse --show-toplevel` fails: `fatal: detected dubious ownership in repository at 'F:/...' is on a file system that does not record ownership`

in each case, `repo_root == ""` which causes `Command::current_dir` to fail.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

(this should) Fixes #528 - which I encountered as described above
