### PR TITLE
feat(baseline): show banner when all bcd keys share a feature

### DIFF
--- a/crates/rari-doc/src/baseline.rs
+++ b/crates/rari-doc/src/baseline.rs
@@ -20,21 +20,10 @@ static WEB_FEATURES: LazyLock<Option<WebFeatures>> = LazyLock::new(|| {
     }
 });
 
-/// Retrieves the baseline support status for a given browser compatibility key.
+/// Looks up baseline support status for the given browser compatibility keys in `WEB_FEATURES`.
 ///
-/// This function looks up the baseline support status for the provided browser compatibility key
-/// in the `WEB_FEATURES` static variable. If it contains the specified key, it returns the corresponding
-/// `SupportStatusWithByKey`. If the key is not found, it returns `None`.
-///
-/// # Arguments
-///
-/// * `browser_compat` - A slice of strings that holds the browser compatibility keys to be looked up. This function
-///   only deals with single keys, so the slice should contain only one element.
-///
-/// # Returns
-///
-/// * `Option<&'static SupportStatusWithByKey>` - Returns `Some(&SupportStatusWithByKey)` if the key is found,
-///   or `None` if the key is not found or `WEB_FEATURES` is not initialized.
+/// Returns the baseline for the keys' shared web feature, or `None` if the keys belong to
+/// different features or none, or `WEB_FEATURES` is not initialized.
 pub(crate) fn get_baseline<'a>(browser_compat: &[String]) -> Option<Baseline<'a>> {
     if let Some(ref web_features) = *WEB_FEATURES {
         return get_baseline_from(browser_compat, web_features);
@@ -46,10 +35,15 @@ fn get_baseline_from<'a>(
     browser_compat: &[String],
     web_features: &'a WebFeatures,
 ) -> Option<Baseline<'a>> {
-    match browser_compat {
-        [bcd_key] => web_features.baseline_by_bcd_key(bcd_key.as_str()),
-        _ => None,
-    }
+    let first = web_features.baseline_by_bcd_key(browser_compat.first()?.as_str())?;
+    browser_compat[1..]
+        .iter()
+        .all(|key| {
+            web_features
+                .baseline_by_bcd_key(key.as_str())
+                .is_some_and(|b| b.feature.id == first.feature.id)
+        })
+        .then_some(first)
 }
 
 #[cfg(test)]
@@ -98,7 +92,18 @@ mod tests {
     }
 
     #[test]
-    fn multiple_keys() {
+    fn multiple_one_missing() {
+        assert!(get(&["api.high", "api.NonExistent"]).is_none());
+    }
+
+    #[test]
+    fn multiple_different_features() {
         assert!(get(&["api.high", "api.low"]).is_none());
+    }
+
+    #[test]
+    fn multiple_same_feature() {
+        let b = get(&["api.high", "api.high-adjacent"]).unwrap();
+        assert_eq!(b.support.baseline, BaselineHighLow::High);
     }
 }

--- a/crates/rari-doc/tests/fixtures/web-features.json
+++ b/crates/rari-doc/tests/fixtures/web-features.json
@@ -9,10 +9,11 @@
         "baseline": "high",
         "support": {},
         "by_compat_key": {
-          "api.high": { "baseline": "high", "support": {} }
+          "api.high": { "baseline": "high", "support": {} },
+          "api.high-adjacent": { "baseline": "high", "support": {} }
         }
       },
-      "compat_features": ["api.high"]
+      "compat_features": ["api.high", "api.high-adjacent"]
     },
     "low": {
       "kind": "feature",


### PR DESCRIPTION
Adds some tests to the `get_baseline` function to ease this - and future - changes.

Adds baseline data to a doc, which means a baseline banner will show, if all the bcd keys share the same web feature. This fixes https://github.com/mdn/fred/issues/1321 and ~100 other cases.