### PR TITLE
fix(doc): lowercase local image sources

### DIFF
--- a/crates/rari-doc/src/html/fix_img.rs
+++ b/crates/rari-doc/src/html/fix_img.rs
@@ -25,6 +25,11 @@ pub fn handle_img(
             && !url.path().starts_with("/assets/")
             && !url.path().starts_with("/shared-assets/")
         {
+            // MDN content requires all filenames to be lowercase, so we
+            // normalise the src path to avoid case-sensitivity issues on Linux.
+            let src = src.to_lowercase();
+            let url = base_url.parse(&src)?;
+
             // Check if the file exists in the current locale
             let mut file = page.full_path().parent().unwrap().join(&src);
             let mut final_url_path = url.path().to_string();


### PR DESCRIPTION
### Description

Lowercases local image sources.

### Motivation

Avoids that `![…](Guide/boxbg.png)` causes the following flaw:

```
Error opening /home/runner/work/dex/dex/mdn/content/files/en-us/web/api/css_painting_api/Guide/boxbg.png: No such file or directory (os error 2)
```

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1462.
