### PR TITLE
fix(doc): fix `{{Next}}` + `{{NextMenu}}` issues

### DIFF
--- a/crates/rari-doc/src/issues.rs
+++ b/crates/rari-doc/src/issues.rs
@@ -589,7 +589,9 @@ pub fn to_display_issues(issues: Vec<Issue>, page: &Page) -> DisplayIssues {
 fn is_fixable_template(macro_name: Option<&str>) -> bool {
     matches!(
         macro_name,
-        Some("previous" | "previousmenu" | "previousnext" | "previousmenunext")
+        Some(
+            "previous" | "previousmenu" | "previousnext" | "previousmenunext" | "next" | "nextmenu"
+        )
     )
 }
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Add `{{Next}}` and `{{NextMenu}}` to the list of fixable menu macros.

### Motivation

Ensure that slugs get auto-fixed when the pages move.

### Additional details

See [Diff content](https://github.com/mdn/rari/actions/runs/24238891382/job/70768531084?pr=619#step:8:1) and [Diff translated-content](https://github.com/mdn/rari/actions/runs/24238891382/job/70768531084?pr=619#step:9:1) steps in the [fix-flaws](https://github.com/mdn/rari/actions/runs/24238891382/job/70768531084?pr=619) test run.

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1462.