### PR TITLE
fix(fix_img): decode percent-encoded `src` before looking up image on disk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2679,6 +2679,7 @@ dependencies = [
  "sha2",
  "strum",
  "svg_metadata",
+ "tempfile",
  "thiserror 2.0.18",
  "tracing",
  "tracing-subscriber",

--- a/crates/rari-doc/Cargo.toml
+++ b/crates/rari-doc/Cargo.toml
@@ -63,3 +63,4 @@ css-syntax = { path = "../css-syntax", features = ["rari"] }
 [dev-dependencies]
 rari-types = { path = "../rari-types", features = ["testing"] }
 indoc.workspace = true
+tempfile = "3"

--- a/crates/rari-doc/src/html/fix_img.rs
+++ b/crates/rari-doc/src/html/fix_img.rs
@@ -163,80 +163,11 @@ pub fn img_size(
 
 #[cfg(test)]
 mod tests {
-    use std::path::{Path, PathBuf};
-
     use lol_html::{RewriteStrSettings, element, rewrite_str};
-    use rari_types::RariEnv;
-    use rari_types::fm_types::{FeatureStatus, PageType};
-    use rari_types::locale::Locale;
     use url::Url;
 
     use super::handle_img;
-    use crate::error::DocError;
-    use crate::pages::page::PageLike;
-    use crate::pages::types::utils::FmTempl;
-
-    struct TestPage {
-        path: PathBuf,
-        url: String,
-    }
-
-    impl PageLike for TestPage {
-        fn url(&self) -> &str {
-            &self.url
-        }
-        fn slug(&self) -> &str {
-            ""
-        }
-        fn title(&self) -> &str {
-            ""
-        }
-        fn short_title(&self) -> Option<&str> {
-            None
-        }
-        fn locale(&self) -> Locale {
-            Locale::EnUs
-        }
-        fn content(&self) -> &str {
-            ""
-        }
-        fn rari_env(&self) -> Option<RariEnv<'_>> {
-            None
-        }
-        fn render(&self) -> Result<String, DocError> {
-            Ok(String::new())
-        }
-        fn title_suffix(&self) -> Option<&str> {
-            None
-        }
-        fn page_type(&self) -> PageType {
-            PageType::None
-        }
-        fn status(&self) -> &[FeatureStatus] {
-            &[]
-        }
-        fn full_path(&self) -> &Path {
-            &self.path
-        }
-        fn path(&self) -> &Path {
-            &self.path
-        }
-        fn base_slug(&self) -> &str {
-            ""
-        }
-        fn trailing_slash(&self) -> bool {
-            false
-        }
-        fn fm_offset(&self) -> usize {
-            0
-        }
-        fn raw_content(&self) -> &str {
-            ""
-        }
-        fn banners(&self) -> Option<&[FmTempl]> {
-            None
-        }
-    }
+    use crate::test_utils::TestPage;
 
     // Minimal GIF recognised by imagesize: the format detector reads a 12-byte
     // header, then the GIF size parser seeks to byte 6 and reads width/height
@@ -278,6 +209,7 @@ mod tests {
         let page = TestPage {
             path: tmp.join("index.md"),
             url: "/en-US/docs/Test".to_string(),
+            ..Default::default()
         };
 
         // comrak encodes `é` (U+00E9, UTF-8 0xC3 0xA9) as `%C3%A9`.

--- a/crates/rari-doc/src/html/fix_img.rs
+++ b/crates/rari-doc/src/html/fix_img.rs
@@ -34,7 +34,7 @@ pub fn handle_img(
             // Check if the file exists in the current locale.
             // The src may be percent-encoded (comrak encodes non-ASCII characters
             // in URLs), so decode it before constructing the filesystem path.
-            let decoded_src = percent_decode_str(&src).decode_utf8_lossy();
+            let decoded_src = percent_decode_str(&src).decode_utf8()?;
             let mut file = page
                 .full_path()
                 .parent()

--- a/crates/rari-doc/src/html/fix_img.rs
+++ b/crates/rari-doc/src/html/fix_img.rs
@@ -148,3 +148,135 @@ pub fn img_size(
     };
     Ok((width, height))
 }
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    use lol_html::{RewriteStrSettings, element, rewrite_str};
+    use rari_types::RariEnv;
+    use rari_types::fm_types::{FeatureStatus, PageType};
+    use rari_types::locale::Locale;
+    use url::Url;
+
+    use super::handle_img;
+    use crate::error::DocError;
+    use crate::pages::page::PageLike;
+    use crate::pages::types::utils::FmTempl;
+
+    struct TestPage {
+        path: PathBuf,
+        url: String,
+    }
+
+    impl PageLike for TestPage {
+        fn url(&self) -> &str {
+            &self.url
+        }
+        fn slug(&self) -> &str {
+            ""
+        }
+        fn title(&self) -> &str {
+            ""
+        }
+        fn short_title(&self) -> Option<&str> {
+            None
+        }
+        fn locale(&self) -> Locale {
+            Locale::EnUs
+        }
+        fn content(&self) -> &str {
+            ""
+        }
+        fn rari_env(&self) -> Option<RariEnv<'_>> {
+            None
+        }
+        fn render(&self) -> Result<String, DocError> {
+            Ok(String::new())
+        }
+        fn title_suffix(&self) -> Option<&str> {
+            None
+        }
+        fn page_type(&self) -> PageType {
+            PageType::None
+        }
+        fn status(&self) -> &[FeatureStatus] {
+            &[]
+        }
+        fn full_path(&self) -> &Path {
+            &self.path
+        }
+        fn path(&self) -> &Path {
+            &self.path
+        }
+        fn base_slug(&self) -> &str {
+            ""
+        }
+        fn trailing_slash(&self) -> bool {
+            false
+        }
+        fn fm_offset(&self) -> usize {
+            0
+        }
+        fn raw_content(&self) -> &str {
+            ""
+        }
+        fn banners(&self) -> Option<&[FmTempl]> {
+            None
+        }
+    }
+
+    // Minimal valid GIF (10 bytes): imagesize only needs the 6-byte header
+    // followed by width and height as little-endian u16.
+    const TINY_GIF: &[u8] = b"GIF89a\x01\x00\x01\x00";
+
+    fn rewrite_img(html: &str, page: &TestPage) -> String {
+        let options = Url::options();
+        let base = Url::parse(&format!(
+            "http://rari.placeholder{}{}",
+            page.url,
+            if page.url.ends_with('/') { "" } else { "/" }
+        ))
+        .unwrap();
+        let base_url = options.base_url(Some(&base));
+        rewrite_str(
+            html,
+            RewriteStrSettings {
+                element_content_handlers: vec![element!("img[src]", |el| {
+                    handle_img(el, page, false, &base, &base_url)
+                })],
+                ..Default::default()
+            },
+        )
+        .unwrap()
+    }
+
+    /// Filenames with non-ASCII characters (e.g. accents, Cyrillic) are
+    /// percent-encoded by the Markdown renderer (comrak).  `handle_img` must
+    /// decode them before constructing the filesystem path, otherwise the file
+    /// is never found and no `width`/`height` attributes are set.
+    #[test]
+    fn test_accented_filename_gets_dimensions() {
+        let tmp = std::env::temp_dir().join("rari-test-accented-img");
+        std::fs::create_dir_all(&tmp).unwrap();
+        // Actual filename on disk uses the literal UTF-8 character.
+        std::fs::write(tmp.join("bézier.gif"), TINY_GIF).unwrap();
+
+        let page = TestPage {
+            path: tmp.join("index.md"),
+            url: "/en-US/docs/Test".to_string(),
+        };
+
+        // comrak encodes `é` (U+00E9, UTF-8 0xC3 0xA9) as `%C3%A9`.
+        let output = rewrite_img(r#"<img src="b%C3%A9zier.gif">"#, &page);
+
+        assert!(
+            output.contains("width=\"1\""),
+            "expected width attribute; got: {output}"
+        );
+        assert!(
+            output.contains("height=\"1\""),
+            "expected height attribute; got: {output}"
+        );
+    }
+}

--- a/crates/rari-doc/src/html/fix_img.rs
+++ b/crates/rari-doc/src/html/fix_img.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 
 use lol_html::HandlerResult;
 use lol_html::html_content::Element;
+use percent_encoding::percent_decode_str;
 use rari_types::locale::default_locale;
 use tracing::warn;
 use url::{ParseOptions, Url};
@@ -30,8 +31,15 @@ pub fn handle_img(
             let src = src.to_lowercase();
             let url = base_url.parse(&src)?;
 
-            // Check if the file exists in the current locale
-            let mut file = page.full_path().parent().unwrap().join(&src);
+            // Check if the file exists in the current locale.
+            // The src may be percent-encoded (comrak encodes non-ASCII characters
+            // in URLs), so decode it before constructing the filesystem path.
+            let decoded_src = percent_decode_str(&src).decode_utf8_lossy();
+            let mut file = page
+                .full_path()
+                .parent()
+                .unwrap()
+                .join(decoded_src.as_ref());
             let mut final_url_path = url.path().to_string();
 
             // If file doesn't exist in translated locale, try en-US fallback
@@ -40,7 +48,11 @@ pub fn handle_img(
                 && let Ok(en_us_page) =
                     Page::from_url_with_locale_and_fallback(page.url(), default_locale())
             {
-                let en_us_file = en_us_page.full_path().parent().unwrap().join(&src);
+                let en_us_file = en_us_page
+                    .full_path()
+                    .parent()
+                    .unwrap()
+                    .join(decoded_src.as_ref());
                 if en_us_file.try_exists().unwrap_or_default() {
                     // Rewrite URL to point to en-US asset
                     let en_us_url = en_us_page.url();
@@ -226,9 +238,10 @@ mod tests {
         }
     }
 
-    // Minimal valid GIF (10 bytes): imagesize only needs the 6-byte header
-    // followed by width and height as little-endian u16.
-    const TINY_GIF: &[u8] = b"GIF89a\x01\x00\x01\x00";
+    // Minimal GIF recognised by imagesize: the format detector reads a 12-byte
+    // header, then the GIF size parser seeks to byte 6 and reads width/height
+    // as little-endian u16 values. 12 bytes is therefore the minimum.
+    const TINY_GIF: &[u8] = b"GIF89a\x01\x00\x01\x00\x00\x00";
 
     fn rewrite_img(html: &str, page: &TestPage) -> String {
         let options = Url::options();

--- a/crates/rari-doc/src/html/fix_img.rs
+++ b/crates/rari-doc/src/html/fix_img.rs
@@ -201,13 +201,12 @@ mod tests {
     /// is never found and no `width`/`height` attributes are set.
     #[test]
     fn test_accented_filename_gets_dimensions() {
-        let tmp = std::env::temp_dir().join("rari-test-accented-img");
-        std::fs::create_dir_all(&tmp).unwrap();
+        let tmp = tempfile::TempDir::new().unwrap();
         // Actual filename on disk uses the literal UTF-8 character.
-        std::fs::write(tmp.join("bézier.gif"), TINY_GIF).unwrap();
+        std::fs::write(tmp.path().join("bézier.gif"), TINY_GIF).unwrap();
 
         let page = TestPage {
-            path: tmp.join("index.md"),
+            path: tmp.path().join("index.md"),
             url: "/en-US/docs/Test".to_string(),
             ..Default::default()
         };

--- a/crates/rari-doc/src/lib.rs
+++ b/crates/rari-doc/src/lib.rs
@@ -61,3 +61,6 @@ pub mod utils;
 pub mod walker;
 
 pub use templ::templs::Templ;
+
+#[cfg(test)]
+pub mod test_utils;

--- a/crates/rari-doc/src/test_utils.rs
+++ b/crates/rari-doc/src/test_utils.rs
@@ -1,0 +1,103 @@
+use std::path::{Path, PathBuf};
+
+use rari_types::RariEnv;
+use rari_types::fm_types::{FeatureStatus, PageType};
+use rari_types::locale::Locale;
+
+use crate::error::DocError;
+use crate::pages::page::PageLike;
+use crate::pages::types::utils::FmTempl;
+
+/// Minimal [`PageLike`] implementation for unit tests.
+///
+/// Only `url`, `path`/`full_path`, and `locale` carry real data;
+/// every other method returns a harmless empty/default value.
+pub struct TestPage {
+    pub path: PathBuf,
+    pub url: String,
+    pub locale: Locale,
+}
+
+impl Default for TestPage {
+    fn default() -> Self {
+        Self {
+            path: PathBuf::new(),
+            url: String::new(),
+            locale: Locale::EnUs,
+        }
+    }
+}
+
+impl PageLike for TestPage {
+    fn url(&self) -> &str {
+        &self.url
+    }
+
+    fn slug(&self) -> &str {
+        ""
+    }
+
+    fn title(&self) -> &str {
+        ""
+    }
+
+    fn short_title(&self) -> Option<&str> {
+        None
+    }
+
+    fn locale(&self) -> Locale {
+        self.locale
+    }
+
+    fn content(&self) -> &str {
+        ""
+    }
+
+    fn rari_env(&self) -> Option<RariEnv<'_>> {
+        None
+    }
+
+    fn render(&self) -> Result<String, DocError> {
+        Ok(String::new())
+    }
+
+    fn title_suffix(&self) -> Option<&str> {
+        None
+    }
+
+    fn page_type(&self) -> PageType {
+        PageType::None
+    }
+
+    fn status(&self) -> &[FeatureStatus] {
+        &[]
+    }
+
+    fn full_path(&self) -> &Path {
+        &self.path
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn base_slug(&self) -> &str {
+        ""
+    }
+
+    fn trailing_slash(&self) -> bool {
+        false
+    }
+
+    fn fm_offset(&self) -> usize {
+        0
+    }
+
+    fn raw_content(&self) -> &str {
+        ""
+    }
+
+    fn banners(&self) -> Option<&[FmTempl]> {
+        None
+    }
+}


### PR DESCRIPTION
### Description

Updates the `fix_img` logic to percent-decode `src` attribute values before constructing the filesystem path, so images with non-ASCII filenames (e.g. `bézier.gif`, `безымянный.png`) are correctly found on disk and have their `width`/`height` attributes set.

### Motivation

Ensure that attachments with non-ASCII characters get width/height in the rendered HTML.

### Additional details

The same class of bug existed in yari, where it manifested as an explicit warning:

```
Could not find enough matches for src: b%C3%A9zier_2_big.gif, index 0 out of bounds
```

In rari the failure was silent, the file simply wasn't found, no flaw was recorded, but no dimensions were set.

A real example from translated-content:

- `files/ru/learn_web_development/core/structuring_content/basic_html_syntax/безымянный.png` was referenced as `![](безымянный.png)`.

### Related issues and pull requests

Fixes https://github.com/mdn/rari/issues/629.