### PR TITLE
feat(homepage): source latest news from blog

### DIFF
--- a/crates/rari-doc/src/cached_readers.rs
+++ b/crates/rari-doc/src/cached_readers.rs
@@ -800,7 +800,6 @@ pub struct PaginationData {
 #[serde(rename_all = "camelCase")]
 pub struct HomePageData {
     pub featured_articles: Vec<String>,
-    pub latest_news: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/rari-doc/src/pages/types/spa.rs
+++ b/crates/rari-doc/src/pages/types/spa.rs
@@ -212,7 +212,7 @@ impl SPA {
                     )?,
                     featured_contributor: featured_contributor(self.locale)?,
                     latest_news: ItemContainer {
-                        items: latest_news(&home_page_data.latest_news)?,
+                        items: latest_news()?,
                     },
                     recent_contributions: ItemContainer {
                         items: recent_contributions()?,

--- a/crates/rari-doc/src/pages/types/spa_homepage.rs
+++ b/crates/rari-doc/src/pages/types/spa_homepage.rs
@@ -8,7 +8,7 @@ use rari_types::locale::Locale;
 use rari_utils::concat_strs;
 use regex::Regex;
 
-use crate::cached_readers::contributor_spotlight_files;
+use crate::cached_readers::{blog_files, contributor_spotlight_files};
 use crate::error::DocError;
 use crate::helpers::parents::parents;
 use crate::helpers::summary_hack::{get_hacky_summary_md, text_content};
@@ -18,31 +18,25 @@ use crate::pages::json::{
 };
 use crate::pages::page::{Page, PageLike};
 
-pub fn latest_news(urls: &[String]) -> Result<Vec<HomePageLatestNewsItem>, DocError> {
-    urls.iter()
-        .filter_map(|url| match Page::from_url_with_fallback(url) {
-            Ok(Page::BlogPost(post)) => Some(Ok(HomePageLatestNewsItem {
-                url: post.url().to_string(),
-                title: post.title().to_string(),
-                author: Some(post.meta.author.clone()),
-                source: NameUrl {
-                    name: "developer.mozilla.org".to_string(),
-                    url: concat_strs!("/", Locale::default().as_url_str(), "/blog/"),
-                },
-                published_at: post.meta.date,
-                summary: post.meta.description.clone(),
-            })),
-            Err(DocError::PageNotFound(url, category)) => {
-                tracing::warn!("page not found {url} ({category:?})");
-                None
-            }
-            Err(e) => Some(Err(e)),
-            x => {
-                tracing::debug!("{x:?}");
-                None
-            }
+pub fn latest_news() -> Result<Vec<HomePageLatestNewsItem>, DocError> {
+    Ok(blog_files()
+        .sorted_meta
+        .iter()
+        .rev()
+        .filter(|meta| !meta.sponsored)
+        .take(4)
+        .map(|meta| HomePageLatestNewsItem {
+            url: meta.url.clone(),
+            title: meta.title.clone(),
+            author: Some(meta.author.clone()),
+            source: NameUrl {
+                name: "developer.mozilla.org".to_string(),
+                url: concat_strs!("/", Locale::default().as_url_str(), "/blog/"),
+            },
+            published_at: meta.date,
+            summary: meta.description.clone(),
         })
-        .collect()
+        .collect())
 }
 
 pub fn featured_articles(


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Update the homepage SPA, using the most recently published non-sponsored blog posts as latest news instead of the hard-coded list in generic-content.

### Motivation

Ensure that the list is always up to date, reducing maintenance effort.

### Additional details

See [Latest news](https://rari-pr632.review.mdn.allizom.net/en-US/#:~:text=Latest%20news) in review deployment.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
