### PR TITLE
fix(badges): use span role=img with aria-label + move inside link

### DIFF
--- a/crates/rari-doc/src/html/links.rs
+++ b/crates/rari-doc/src/html/links.rs
@@ -55,7 +55,6 @@ pub fn render_internal_link(
     if modifier.code {
         out.push_str("</code>");
     }
-    out.push_str("</a>");
     if !modifier.badges.is_empty() {
         if modifier.badges.contains(&FeatureStatus::Experimental) {
             write_experimental(out, modifier.badge_locale)?;
@@ -67,6 +66,7 @@ pub fn render_internal_link(
             write_deprecated(out, modifier.badge_locale)?;
         }
     }
+    out.push_str("</a>");
     Ok(())
 }
 

--- a/crates/rari-doc/src/templ/templs/badges.rs
+++ b/crates/rari-doc/src/templ/templs/badges.rs
@@ -73,8 +73,6 @@ pub fn write_badge(
     let title = html_escape::encode_quoted_attribute(title);
     write!(
         out,
-        r#"<abbr class="icon icon-{typ}" title="{title}">
-<span class="visually-hidden">{abbreviation}</span>
-</abbr>"#
+        r#"<span role="img" class="icon icon-{typ}" title="{title}" aria-label="{abbreviation}"></span>"#
     )
 }


### PR DESCRIPTION
### Description

Moves the "inline" badges inside the links, and changes them to `<span role="img">`.

### Motivation

Ensures that the badges are accessible by screen readers.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Fixes https://github.com/mdn/rari/issues/344.
