### PR TITLE
fix(doc): build generic pages only in en-US

### DIFF
--- a/crates/rari-doc/src/cached_readers.rs
+++ b/crates/rari-doc/src/cached_readers.rs
@@ -258,12 +258,7 @@ fn gather_generic_content() -> Result<HashMap<String, Page>, DocError> {
                     None
                 }
             })
-            .flat_map(|generic| {
-                Locale::for_generic_and_spas()
-                    .iter()
-                    .map(|locale| Page::GenericPage(Arc::new(generic.as_locale(*locale))))
-                    .collect::<Vec<_>>()
-            })
+            .map(|generic| Page::GenericPage(Arc::new(generic.as_locale(Locale::EnUs))))
             .map(|page| (page.url().to_ascii_lowercase(), page))
             .collect())
     } else {


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Builds generic pages only in en-US.

### Motivation

Avoid duplicated "translated" pages of `/about`, `/community` etc.

### Additional details

Note: This does not affect the SPAs (`/observatory`, `/play`), which are translatable.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
