### PR TITLE
feat(doc): collect fragment IDs into `index.json`

### DIFF
--- a/crates/rari-doc/src/html/modifier.rs
+++ b/crates/rari-doc/src/html/modifier.rs
@@ -238,3 +238,44 @@ pub fn add_missing_ids(html: &mut Html) -> Result<(), DocError> {
     }
     Ok(())
 }
+
+/// Collects all fragment IDs from elements with an `id` attribute, in document order.
+///
+/// Skips the `quick_links` sidebar section id, which is extracted into the page
+/// sidebar by `split_sections` and not part of the body addressable via `#fragment`.
+/// IDs have already been lowercased by `post_process_html` at this point.
+pub fn collect_fragment_ids(html: &Html) -> Vec<String> {
+    let selector = Selector::parse("*[id]").unwrap();
+    html.select(&selector)
+        .filter_map(|el| el.attr("id"))
+        .filter(|id| !id.trim().is_empty() && *id != "quick_links")
+        .map(String::from)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn collects_ids_in_document_order() {
+        let html = Html::parse_fragment(
+            r#"<h2 id="examples">Examples</h2>
+            <dl><dt id="term-a">A</dt><dd>x</dd><dt id="term-b">B</dt></dl>
+            <h3 id="subsection">Subsection</h3>"#,
+        );
+        assert_eq!(
+            collect_fragment_ids(&html),
+            vec!["examples", "term-a", "term-b", "subsection"],
+        );
+    }
+
+    #[test]
+    fn skips_quick_links_sidebar_id() {
+        let html = Html::parse_fragment(
+            r#"<section id="quick_links"></section>
+            <h2 id="examples">Examples</h2>"#,
+        );
+        assert_eq!(collect_fragment_ids(&html), vec!["examples"]);
+    }
+}

--- a/crates/rari-doc/src/pages/build.rs
+++ b/crates/rari-doc/src/pages/build.rs
@@ -25,7 +25,9 @@ use crate::helpers::title::{TitleFormat, page_title, render_title, transform_tit
 use crate::html::banner::build_banner;
 use crate::html::bubble_up::bubble_up_curriculum_page;
 use crate::html::code::{Code, code_blocks};
-use crate::html::modifier::{add_missing_ids, insert_self_links_for_dts, remove_empty_p};
+use crate::html::modifier::{
+    add_missing_ids, collect_fragment_ids, insert_self_links_for_dts, remove_empty_p,
+};
 use crate::html::rewriter::{post_process_html, post_process_inline_sidebar};
 use crate::html::sections::{BuildSection, BuildSectionType, Split, split_sections};
 use crate::html::sidebar::{
@@ -141,6 +143,7 @@ impl BuildSection<'_> {
 pub struct PageContent {
     body: Vec<Section>,
     toc: Vec<TocEntry>,
+    fragments: Vec<String>,
     summary: Option<String>,
     sidebar: Option<String>,
     live_samples: Option<Vec<Code>>,
@@ -208,10 +211,12 @@ fn build_content<T: PageLike>(page: &T) -> Result<PageContent, DocError> {
         Some(sidebars.into_iter().collect::<Result<String, _>>()?)
     };
     let toc = make_toc(&sections, matches!(page.page_type(), PageType::Curriculum));
+    let fragments = collect_fragment_ids(&fragment);
     let body = sections.into_iter().map(Into::into).collect();
     Ok(PageContent {
         body,
         toc,
+        fragments,
         summary,
         sidebar,
         live_samples,
@@ -231,6 +236,7 @@ fn build_doc(doc: &Doc) -> Result<BuiltPage, DocError> {
     let PageContent {
         body,
         toc,
+        fragments,
         summary,
         sidebar,
         live_samples,
@@ -312,6 +318,7 @@ fn build_doc(doc: &Doc) -> Result<BuiltPage, DocError> {
             body,
             sidebar_html,
             toc,
+            fragments,
             baseline,
             modified,
             summary,
@@ -344,6 +351,7 @@ fn build_blog_post(post: &BlogPost) -> Result<BuiltPage, DocError> {
     let PageContent {
         body,
         toc,
+        fragments,
         live_samples,
         ..
     } = build_content(post)?;
@@ -356,6 +364,7 @@ fn build_blog_post(post: &BlogPost) -> Result<BuiltPage, DocError> {
             locale: post.locale(),
             body,
             toc,
+            fragments,
             summary: Some(post.meta.description.clone()),
             live_samples,
             ..Default::default()
@@ -386,12 +395,18 @@ fn build_blog_post(post: &BlogPost) -> Result<BuiltPage, DocError> {
 
 fn build_generic_page(page: &Generic) -> Result<BuiltPage, DocError> {
     let built = build_content(page);
-    let PageContent { body, toc, .. } = built?;
+    let PageContent {
+        body,
+        toc,
+        fragments,
+        ..
+    } = built?;
     Ok(BuiltPage::GenericPage(Box::new(JsonGenericPage {
         hy_data: JsonGenericHyData {
             sections: body,
             title: page.meta.title.clone(),
             toc,
+            fragments,
         },
         short_title: page.meta.short_title.clone(),
         page_title: if let Some(suffix) = &page.meta.title_suffix {
@@ -419,7 +434,12 @@ fn build_spa(spa: &SPA) -> Result<BuiltPage, DocError> {
 }
 
 fn build_curriculum(curriculum: &Curriculum) -> Result<BuiltPage, DocError> {
-    let PageContent { body, toc, .. } = build_content(curriculum)?;
+    let PageContent {
+        body,
+        toc,
+        fragments,
+        ..
+    } = build_content(curriculum)?;
     let sidebar = build_sidebar().ok();
     let group = curriculum_group(&parents(curriculum));
     let modules = match curriculum.meta.template {
@@ -444,6 +464,7 @@ fn build_curriculum(curriculum: &Curriculum) -> Result<BuiltPage, DocError> {
             body,
             sidebar,
             toc,
+            fragments,
             group,
             modules,
             prev_next,

--- a/crates/rari-doc/src/pages/json.rs
+++ b/crates/rari-doc/src/pages/json.rs
@@ -273,6 +273,8 @@ pub struct JsonDoc {
     #[serde(rename = "titleHTML")]
     pub title_html: String,
     pub toc: Vec<TocEntry>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub fragments: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub baseline: Option<Baseline<'static>>,
     #[serde(rename = "browserCompat", skip_serializing_if = "Vec::is_empty")]
@@ -449,6 +451,8 @@ pub struct JsonCurriculumDoc {
     pub title: String,
     pub summary: Option<String>,
     pub toc: Vec<TocEntry>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub fragments: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sidebar: Option<Vec<CurriculumSidebarEntry>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -527,6 +531,8 @@ pub struct JsonBlogPostDoc {
     pub title: String,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub toc: Vec<TocEntry>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub fragments: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub live_samples: Option<Vec<Code>>,
 }
@@ -936,6 +942,8 @@ pub struct JsonGenericHyData {
     pub sections: Vec<Section>,
     pub title: String,
     pub toc: Vec<TocEntry>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub fragments: Vec<String>,
 }
 
 /// Represents the outermost generic page structure in the documentation system. This is written to


### PR DESCRIPTION
### Description

Collects fragment IDs per page, and exposes them on the built `index.json`.

### Motivation

First step towards validating fragment links, both in MDN content, and in BCD.

### Additional details

Walk `*[id]` in document order after `add_missing_ids` and expose the result as `fragments` on `Json*Doc`. Skip live samples and sidebar.

### Related issues and pull requests

Fixes https://github.com/mdn/rari/issues/113.
