### PR TITLE
chore(cli): count issues by locale

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,6 @@
 [env]
 TESTING_CONTENT_ROOT = { value = "tests/data/content/files", relative = true }
 TESTING_CONTENT_TRANSLATED_ROOT = { value = "tests/data/translated_content/files", relative = true }
+TESTING_BLOG_ROOT = { value = "tests/data/blog/posts", relative = true }
 TESTING_CACHE_CONTENT = "0"
 TESTING_READER_IGNORES_GITIGNORE = "1"

--- a/crates/rari-cli/main.rs
+++ b/crates/rari-cli/main.rs
@@ -29,7 +29,7 @@ use rari_doc::pages::page::Page;
 use rari_doc::pages::types::doc::Doc;
 use rari_doc::reader::read_docs_parallel;
 use rari_doc::search_index::build_search_index;
-use rari_doc::utils::TEMPL_RECORDER_SENDER;
+use rari_doc::utils::{TEMPL_RECORDER_SENDER, locale_and_typ_from_path};
 use rari_sitemap::Sitemaps;
 use rari_tools::add_redirect::add_redirect;
 use rari_tools::fix::fixer::fix_all;
@@ -553,7 +553,9 @@ fn main() -> Result<(), Error> {
                 let mut by_locale: std::collections::BTreeMap<Option<Locale>, (usize, usize)> =
                     std::collections::BTreeMap::new();
                 for entry in events.iter() {
-                    let locale = locale_from_path(entry.key());
+                    let locale = locale_and_typ_from_path(Path::new(entry.key()))
+                        .ok()
+                        .map(|(l, _)| l);
                     let stats = by_locale.entry(locale).or_default();
                     stats.0 += 1;
                     stats.1 += entry.value().len();
@@ -593,7 +595,7 @@ fn main() -> Result<(), Error> {
                     std::collections::BTreeMap<String, Vec<rari_doc::issues::Issue>>,
                 > = std::collections::BTreeMap::new();
                 for (file, issues) in memory_layer.sorted_issues() {
-                    if let Some(locale) = locale_from_path(&file) {
+                    if let Ok((locale, _)) = locale_and_typ_from_path(Path::new(&file)) {
                         by_locale.entry(locale).or_default().insert(file, issues);
                     }
                 }
@@ -848,12 +850,4 @@ fn update(version: Option<String>) -> Result<(), Error> {
     let status = update.update()?;
     info!("\n\nrari updated to `{}`", status.version());
     Ok(())
-}
-
-fn locale_from_path(path: &str) -> Option<Locale> {
-    Path::new(path).components().find_map(|c| {
-        c.as_os_str()
-            .to_str()
-            .and_then(|s| Locale::from_str(s).ok())
-    })
 }

--- a/crates/rari-cli/main.rs
+++ b/crates/rari-cli/main.rs
@@ -243,6 +243,11 @@ struct BuildArgs {
         help = "Write all issues to path <ISSUES> (defaults to BUILD_OUT_ROOT/issues.json)"
     )]
     issues: Option<PathBuf>,
+    #[arg(
+        long,
+        help = "Write per-locale issues to BUILD_OUT_ROOT/{locale}/issues.json"
+    )]
+    issues_per_locale: bool,
     #[arg(long, help = "Annotate html with 'data-flaw' attributes")]
     data_issues: bool,
     #[arg(long, help = "Add flaws field to index.json for docs")]
@@ -584,6 +589,32 @@ fn main() -> Result<(), Error> {
                 let file = File::create(&issues_path).unwrap();
                 let mut buffed = BufWriter::new(file);
                 serde_json::to_writer_pretty(&mut buffed, &memory_layer.sorted_issues()).unwrap();
+            }
+
+            if args.issues_per_locale {
+                let mut by_locale: std::collections::BTreeMap<
+                    Locale,
+                    std::collections::BTreeMap<String, Vec<rari_doc::issues::Issue>>,
+                > = std::collections::BTreeMap::new();
+                for (file, issues) in memory_layer.sorted_issues() {
+                    let locale = Path::new(&file).components().find_map(|c| {
+                        c.as_os_str()
+                            .to_str()
+                            .and_then(|s| Locale::from_str(s).ok())
+                    });
+                    if let Some(locale) = locale {
+                        by_locale.entry(locale).or_default().insert(file, issues);
+                    }
+                }
+                let out_root = build_out_root()?;
+                for (locale, issues) in &by_locale {
+                    let dir = out_root.join(locale.as_folder_str());
+                    fs::create_dir_all(&dir).unwrap();
+                    let out_file = dir.join("issues.json");
+                    let file = File::create(&out_file).unwrap();
+                    let mut buffed = BufWriter::new(file);
+                    serde_json::to_writer_pretty(&mut buffed, issues).unwrap();
+                }
             }
         }
         Commands::Serve(args) => {

--- a/crates/rari-cli/main.rs
+++ b/crates/rari-cli/main.rs
@@ -540,6 +540,32 @@ fn main() -> Result<(), Error> {
                     "Found {} issues in {} of {} files",
                     num_issues, num_files, total_files
                 );
+                let mut by_locale: std::collections::BTreeMap<Option<Locale>, (usize, usize)> =
+                    std::collections::BTreeMap::new();
+                for entry in events.iter() {
+                    let locale = Path::new(entry.key()).components().find_map(|c| {
+                        c.as_os_str()
+                            .to_str()
+                            .and_then(|s| Locale::from_str(s).ok())
+                    });
+                    let stats = by_locale.entry(locale).or_default();
+                    stats.0 += 1;
+                    stats.1 += entry.value().len();
+                }
+                let unknown = by_locale.remove(&None);
+                for (locale, (files, issues)) in &by_locale {
+                    if let Some(locale) = locale {
+                        info!(
+                            "  {}: {} issues in {} files",
+                            locale.as_url_str(),
+                            issues,
+                            files
+                        );
+                    }
+                }
+                if let Some((files, issues)) = unknown {
+                    info!("  unknown: {} issues in {} files", issues, files);
+                }
             } else {
                 info!("No issues found in {} files", total_files);
             }

--- a/crates/rari-cli/main.rs
+++ b/crates/rari-cli/main.rs
@@ -553,11 +553,7 @@ fn main() -> Result<(), Error> {
                 let mut by_locale: std::collections::BTreeMap<Option<Locale>, (usize, usize)> =
                     std::collections::BTreeMap::new();
                 for entry in events.iter() {
-                    let locale = Path::new(entry.key()).components().find_map(|c| {
-                        c.as_os_str()
-                            .to_str()
-                            .and_then(|s| Locale::from_str(s).ok())
-                    });
+                    let locale = locale_from_path(entry.key());
                     let stats = by_locale.entry(locale).or_default();
                     stats.0 += 1;
                     stats.1 += entry.value().len();
@@ -597,12 +593,7 @@ fn main() -> Result<(), Error> {
                     std::collections::BTreeMap<String, Vec<rari_doc::issues::Issue>>,
                 > = std::collections::BTreeMap::new();
                 for (file, issues) in memory_layer.sorted_issues() {
-                    let locale = Path::new(&file).components().find_map(|c| {
-                        c.as_os_str()
-                            .to_str()
-                            .and_then(|s| Locale::from_str(s).ok())
-                    });
-                    if let Some(locale) = locale {
+                    if let Some(locale) = locale_from_path(&file) {
                         by_locale.entry(locale).or_default().insert(file, issues);
                     }
                 }
@@ -857,4 +848,12 @@ fn update(version: Option<String>) -> Result<(), Error> {
     let status = update.update()?;
     info!("\n\nrari updated to `{}`", status.version());
     Ok(())
+}
+
+fn locale_from_path(path: &str) -> Option<Locale> {
+    Path::new(path).components().find_map(|c| {
+        c.as_os_str()
+            .to_str()
+            .and_then(|s| Locale::from_str(s).ok())
+    })
 }

--- a/crates/rari-cli/main.rs
+++ b/crates/rari-cli/main.rs
@@ -236,7 +236,12 @@ struct BuildArgs {
     sitemaps: bool,
     #[arg(long, help = "Display template statistics (debugging")]
     templ_stats: bool,
-    #[arg(long, help = "Write all issues to path <ISSUES>")]
+    #[arg(
+        long,
+        num_args = 0..=1,
+        default_missing_value = "",
+        help = "Write all issues to path <ISSUES> (defaults to BUILD_OUT_ROOT/issues.json)"
+    )]
     issues: Option<PathBuf>,
     #[arg(long, help = "Annotate html with 'data-flaw' attributes")]
     data_issues: bool,
@@ -571,6 +576,11 @@ fn main() -> Result<(), Error> {
             }
 
             if let Some(issues_path) = args.issues {
+                let issues_path = if issues_path.as_os_str().is_empty() {
+                    build_out_root()?.join("issues.json")
+                } else {
+                    issues_path
+                };
                 let file = File::create(&issues_path).unwrap();
                 let mut buffed = BufWriter::new(file);
                 serde_json::to_writer_pretty(&mut buffed, &memory_layer.sorted_issues()).unwrap();

--- a/crates/rari-doc/src/utils.rs
+++ b/crates/rari-doc/src/utils.rs
@@ -185,7 +185,7 @@ pub fn root_for_locale(locale: Locale) -> Result<&'static Path, EnvError> {
 ///
 /// This function will return an error if:
 /// - The path does not contain a recognizable locale.
-pub(crate) fn locale_and_typ_from_path(path: &Path) -> Result<(Locale, PageCategory), DocError> {
+pub fn locale_and_typ_from_path(path: &Path) -> Result<(Locale, PageCategory), DocError> {
     if path.starts_with(content_root()) {
         return Ok((Locale::EnUs, PageCategory::Doc));
     }
@@ -325,17 +325,6 @@ mod text {
             "foo bar 20 00"
         );
         assert_eq!(dedup_whitespace("    "), "");
-    }
-
-    #[test]
-    fn test_locale_from_path() {
-        let en_us = content_root();
-
-        let path = en_us.to_path_buf().join("en-us/web/html/index.md");
-        assert_eq!(
-            locale_and_typ_from_path(&path).unwrap(),
-            (Locale::EnUs, PageCategory::Doc)
-        );
     }
 
     #[test]

--- a/crates/rari-doc/src/utils.rs
+++ b/crates/rari-doc/src/utils.rs
@@ -328,6 +328,48 @@ mod text {
     }
 
     #[test]
+    fn test_locale_and_typ_from_path() {
+        let en_us = content_root();
+
+        let path = en_us.to_path_buf().join("en-us/web/html/index.md");
+        assert_eq!(
+            locale_and_typ_from_path(&path).unwrap(),
+            (Locale::EnUs, PageCategory::Doc)
+        );
+    }
+
+    #[test]
+    fn test_locale_and_typ_from_path_translated() {
+        let translated = content_translated_root().expect("translated root configured");
+
+        let path = translated.to_path_buf().join("fr/web/html/index.md");
+        assert_eq!(
+            locale_and_typ_from_path(&path).unwrap(),
+            (Locale::Fr, PageCategory::Doc)
+        );
+    }
+
+    #[test]
+    fn test_locale_and_typ_from_path_blog() {
+        let blog = blog_root().expect("blog root configured");
+
+        let path = blog.to_path_buf().join("posts/some-slug/index.md");
+        assert_eq!(
+            locale_and_typ_from_path(&path).unwrap(),
+            (Locale::EnUs, PageCategory::BlogPost)
+        );
+    }
+
+    #[test]
+    fn test_locale_and_typ_from_path_err() {
+        let path = Path::new("/non/existent/path/index.md");
+        assert!(matches!(
+            locale_and_typ_from_path(path),
+            Err(DocError::LocaleError(LocaleError::NoLocaleInPath))
+        ));
+    }
+
+    #[test]
     fn test_readtime() {
         let s = format!(
             r#"Foo

--- a/crates/rari-types/src/settings.rs
+++ b/crates/rari-types/src/settings.rs
@@ -113,6 +113,7 @@ impl Settings {
                 "CONTENT_TRANSLATED_ROOT",
                 std::env::var("TESTING_CONTENT_TRANSLATED_ROOT").unwrap(),
             );
+            std::env::set_var("BLOG_ROOT", std::env::var("TESTING_BLOG_ROOT").unwrap());
             std::env::set_var(
                 "CACHE_CONTENT",
                 std::env::var("TESTING_CACHE_CONTENT").unwrap(),


### PR DESCRIPTION
### Description

Adds a per-locale breakdown of build issues to the build summary, splits the JSON issue dump by locale via a new `--issues-per-locale` flag, and makes the `--issues` argument optional (defaulting to `BUILD_OUT_ROOT/issues.json`).

### Motivation

The single "Found X issues in Y of Z files" summary makes it hard to see how issues distribute across locales — useful when triaging which translated trees need attention. Splitting the JSON dump per locale also makes downstream tooling (e.g. per-locale dashboards, per-locale fix runs) simpler than slicing one large `issues.json`.

### Additional details

- New summary lines after the totals, in `Locale` enum order with an `unknown` bucket appended if any issue's file path doesn't yield a locale:
  ```
  Found 24506 issues in 7623 of 50748 files
    en-US: 1205 issues in 495 files
    es: 4117 issues in 916 files
    ...
    unknown: 8 issues in 1 files
  ```
- `--issues` now takes 0 or 1 args; bare `--issues` writes to `BUILD_OUT_ROOT/issues.json`.
- `--issues-per-locale` writes `BUILD_OUT_ROOT/{locale}/issues.json` for each locale that has issues. Issues with no extractable locale (empty `file` path) are skipped here.
- Locale extraction is centralized in a small `locale_from_path()` helper that walks path components and returns the first one parseable via `Locale::from_str`.

### Related issues and pull requests

<!-- none -->