### PR TITLE
fix(doc): fallback blog posts to en-US

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,6 @@
 [env]
 TESTING_CONTENT_ROOT = { value = "tests/data/content/files", relative = true }
 TESTING_CONTENT_TRANSLATED_ROOT = { value = "tests/data/translated_content/files", relative = true }
+TESTING_BLOG_ROOT = { value = "tests/data/blog/posts", relative = true }
 TESTING_CACHE_CONTENT = "0"
 TESTING_READER_IGNORES_GITIGNORE = "1"

--- a/crates/rari-doc/src/pages/page.rs
+++ b/crates/rari-doc/src/pages/page.rs
@@ -114,7 +114,7 @@ impl Page {
                 .ok_or(DocError::PageNotFound(url.to_string(), PageCategory::SPA)),
             PageCategory::Doc => Doc::page_from_slug_path(&folder_path, locale, fallback)
                 .map_err(|_| DocError::PageNotFound(url.to_string(), PageCategory::Doc)),
-            PageCategory::BlogPost if locale != Locale::EnUs => {
+            PageCategory::BlogPost if locale != Locale::EnUs && !fallback => {
                 // Blog is en-US only.
                 Err(DocError::PageNotFound(
                     url.to_string(),

--- a/crates/rari-tools/src/tests/blog_fallback.rs
+++ b/crates/rari-tools/src/tests/blog_fallback.rs
@@ -8,8 +8,6 @@ use super::fixtures::blog::BlogFixtures;
 const SLUG: &str = "test-post";
 const URL: &str = "/en-US/blog/test-post/";
 
-/// Without fallback, looking up an `/en-US/blog/...` URL with a non-en-US
-/// locale must return `PageNotFound` — this guards the `!fallback` branch.
 #[test]
 #[file_serial(blog_fixtures)]
 fn blog_post_no_fallback_returns_page_not_found_for_non_en_us() {
@@ -24,8 +22,6 @@ fn blog_post_no_fallback_returns_page_not_found_for_non_en_us() {
     }
 }
 
-/// With fallback, an `/en-US/blog/...` URL should resolve even when the
-/// caller-supplied locale isn't en-US — covers the new behavior.
 #[test]
 #[file_serial(blog_fixtures)]
 fn blog_post_falls_back_to_en_us_for_non_en_us_locale() {
@@ -37,7 +33,6 @@ fn blog_post_falls_back_to_en_us_for_non_en_us_locale() {
     assert!(matches!(page, Page::BlogPost(_)));
 }
 
-/// Sanity check: the en-US lookup path is unaffected.
 #[test]
 #[file_serial(blog_fixtures)]
 fn blog_post_en_us_still_resolves() {

--- a/crates/rari-tools/src/tests/blog_fallback.rs
+++ b/crates/rari-tools/src/tests/blog_fallback.rs
@@ -1,0 +1,49 @@
+use rari_doc::error::DocError;
+use rari_doc::pages::page::{Page, PageCategory};
+use rari_types::locale::Locale;
+use serial_test::file_serial;
+
+use super::fixtures::blog::BlogFixtures;
+
+const SLUG: &str = "test-post";
+const URL: &str = "/en-US/blog/test-post/";
+
+/// Without fallback, looking up an `/en-US/blog/...` URL with a non-en-US
+/// locale must return `PageNotFound` — this guards the `!fallback` branch.
+#[test]
+#[file_serial(blog_fixtures)]
+fn blog_post_no_fallback_returns_page_not_found_for_non_en_us() {
+    let _blog = BlogFixtures::new(&[SLUG.to_string()]);
+
+    let err = Page::internal_from_url(URL, Some(Locale::Fr), false)
+        .expect_err("non-en-US locale without fallback should fail");
+
+    match err {
+        DocError::PageNotFound(_, PageCategory::BlogPost) => {}
+        other => panic!("expected PageNotFound(_, BlogPost), got {other:?}"),
+    }
+}
+
+/// With fallback, an `/en-US/blog/...` URL should resolve even when the
+/// caller-supplied locale isn't en-US — covers the new behavior.
+#[test]
+#[file_serial(blog_fixtures)]
+fn blog_post_falls_back_to_en_us_for_non_en_us_locale() {
+    let _blog = BlogFixtures::new(&[SLUG.to_string()]);
+
+    let page = Page::from_url_with_locale_and_fallback(URL, Locale::Fr)
+        .expect("fallback should locate the en-US blog post");
+
+    assert!(matches!(page, Page::BlogPost(_)));
+}
+
+/// Sanity check: the en-US lookup path is unaffected.
+#[test]
+#[file_serial(blog_fixtures)]
+fn blog_post_en_us_still_resolves() {
+    let _blog = BlogFixtures::new(&[SLUG.to_string()]);
+
+    let page = Page::from_url(URL).expect("en-US lookup should succeed");
+
+    assert!(matches!(page, Page::BlogPost(_)));
+}

--- a/crates/rari-tools/src/tests/fixtures/blog.rs
+++ b/crates/rari-tools/src/tests/fixtures/blog.rs
@@ -1,0 +1,70 @@
+use std::fs;
+use std::path::PathBuf;
+
+use indoc::formatdoc;
+use rari_types::globals::blog_root;
+
+pub(crate) struct BlogFixtures {
+    slugs: Vec<String>,
+    do_not_remove: bool,
+}
+
+impl BlogFixtures {
+    pub fn new(slugs: &[String]) -> Self {
+        Self::new_internal(slugs, false)
+    }
+
+    #[allow(dead_code)]
+    pub fn debug_new(slugs: &[String]) -> Self {
+        Self::new_internal(slugs, true)
+    }
+
+    fn new_internal(slugs: &[String], do_not_remove: bool) -> Self {
+        for slug in slugs {
+            Self::create_post_file(slug);
+        }
+        BlogFixtures {
+            slugs: slugs.to_vec(),
+            do_not_remove,
+        }
+    }
+
+    fn posts_root() -> PathBuf {
+        blog_root()
+            .expect("BLOG_ROOT must be set for blog fixtures")
+            .join("posts")
+    }
+
+    fn create_post_file(slug: &str) {
+        let folder = Self::posts_root().join(slug);
+        fs::create_dir_all(&folder).unwrap();
+        let content = formatdoc! {
+            r#"---
+            title: {slug}
+            slug: {slug}
+            date: 2024-01-01
+            author: test-author
+            ---
+
+            Test content for {slug}.
+            "#,
+            slug = slug,
+        };
+        fs::write(folder.join("index.md"), content).unwrap();
+    }
+}
+
+impl Drop for BlogFixtures {
+    fn drop(&mut self) {
+        if self.do_not_remove {
+            tracing::info!("Leaving blog fixtures in place for debugging");
+            return;
+        }
+        for slug in &self.slugs {
+            let folder = Self::posts_root().join(slug);
+            if folder.exists() {
+                fs::remove_dir_all(&folder).unwrap();
+            }
+        }
+    }
+}

--- a/crates/rari-tools/src/tests/fixtures/mod.rs
+++ b/crates/rari-tools/src/tests/fixtures/mod.rs
@@ -1,3 +1,4 @@
+pub mod blog;
 pub mod docs;
 pub mod redirects;
 pub mod sidebars;

--- a/crates/rari-tools/src/tests/mod.rs
+++ b/crates/rari-tools/src/tests/mod.rs
@@ -1,2 +1,3 @@
+mod blog_fallback;
 pub mod fixtures;
 mod image_fallback;

--- a/crates/rari-types/src/settings.rs
+++ b/crates/rari-types/src/settings.rs
@@ -113,6 +113,7 @@ impl Settings {
                 "CONTENT_TRANSLATED_ROOT",
                 std::env::var("TESTING_CONTENT_TRANSLATED_ROOT").unwrap(),
             );
+            std::env::set_var("BLOG_ROOT", std::env::var("TESTING_BLOG_ROOT").unwrap());
             std::env::set_var(
                 "CACHE_CONTENT",
                 std::env::var("TESTING_CACHE_CONTENT").unwrap(),


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Update blog post URL resolution to fall back to the en-US post when a non-en-US locale is requested with `fallback = true` (default).

### Motivation

Avoids "unknown" issues for en-US blog posts referenced on the homapage in other locales.

### Additional details

Previously the `PageCategory::BlogPost` guard rejected any non-en-US lookup unconditionally, so callers using the fallback path got `PageNotFound` for every blog URL in a non-en-US locale — even though the en-US post exists and the API contract promises a fallback.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
