### PR TITLE
chore(deps): remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2595,7 +2595,6 @@ dependencies = [
 name = "rari-data"
 version = "0.2.21"
 dependencies = [
- "chrono",
  "indexmap",
  "rari-utils",
  "schemars",
@@ -2667,7 +2666,6 @@ dependencies = [
  "serde_json",
  "serde_yaml_ng",
  "sha2",
- "strum",
  "svg_metadata",
  "tempfile",
  "thiserror 2.0.18",
@@ -2757,7 +2755,6 @@ dependencies = [
  "assert-json-diff",
  "chrono",
  "const_format",
- "csv",
  "dialoguer",
  "fake",
  "html-escape",
@@ -2768,7 +2765,6 @@ dependencies = [
  "rari-types",
  "rari-utils",
  "rayon",
- "reqwest",
  "serde",
  "serde_json",
  "serde_yaml_ng",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -570,14 +570,11 @@ dependencies = [
  "css-definition-syntax",
  "css-syntax-types",
  "html-escape",
- "itertools",
  "rari-deps",
  "rari-types",
- "regress",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "url",
 ]
 
 [[package]]
@@ -843,7 +840,6 @@ version = "0.2.21"
 dependencies = [
  "ansi-to-html",
  "anyhow",
- "base64",
  "clap",
  "html-minifier",
  "ignore",
@@ -2128,12 +2124,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
-name = "normalize-path"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5438dd2b2ff4c6df6e1ce22d825ed2fa93ee2922235cc45186991717f0a892d"
-
-[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2683,9 +2673,6 @@ dependencies = [
 [[package]]
 name = "rari-linter"
 version = "0.2.21"
-dependencies = [
- "thiserror 2.0.18",
-]
 
 [[package]]
 name = "rari-lsp"
@@ -2698,13 +2685,9 @@ dependencies = [
  "rari-doc",
  "rari-tools",
  "rari-types",
- "serde",
  "serde_json",
- "streaming-iterator",
  "tokio",
  "tower-lsp-server",
- "tracing",
- "tracing-subscriber",
  "tree-sitter",
  "tree-sitter-md",
  "tree-sitter-mdn",
@@ -2741,7 +2724,6 @@ dependencies = [
 name = "rari-templ-func"
 version = "0.2.21"
 dependencies = [
- "anyhow",
  "darling 0.23.0",
  "quote",
  "rari-types",
@@ -2785,7 +2767,6 @@ dependencies = [
  "darling 0.23.0",
  "dirs",
  "indexmap",
- "normalize-path",
  "proc-macro2",
  "quote",
  "schemars",
@@ -2802,10 +2783,7 @@ dependencies = [
 name = "rari-utils"
 version = "0.2.21"
 dependencies = [
- "serde",
- "serde_json",
  "thiserror 2.0.18",
- "tracing",
 ]
 
 [[package]]
@@ -3493,12 +3471,6 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
-name = "streaming-iterator"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
 name = "string_cache"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -850,7 +850,6 @@ dependencies = [
  "quick-xml 0.39.2",
  "rayon",
  "regex",
- "serde",
  "serde_json",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -856,7 +856,6 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "similar",
 ]
 
 [[package]]
@@ -3444,12 +3443,6 @@ name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
-
-[[package]]
-name = "similar"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "siphasher"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2723,6 +2723,7 @@ dependencies = [
 name = "rari-templ-func"
 version = "0.2.21"
 dependencies = [
+ "anyhow",
  "darling 0.23.0",
  "quote",
  "rari-types",

--- a/crates/css-syntax/Cargo.toml
+++ b/crates/css-syntax/Cargo.toml
@@ -8,12 +8,9 @@ rust-version.workspace = true
 
 [dependencies]
 thiserror.workspace = true
-regress.workspace = true
 serde_json.workspace = true
 serde.workspace = true
-url.workspace = true
 html-escape.workspace = true
-itertools.workspace = true
 rari-types = { workspace = true, optional = true }
 rari-deps = { workspace = true, optional = true }
 

--- a/crates/diff-test/Cargo.toml
+++ b/crates/diff-test/Cargo.toml
@@ -14,7 +14,6 @@ itertools.workspace = true
 regex.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-base64.workspace = true
 
 jsonpath_lib = "0.3"
 prettydiff = "0.9"

--- a/crates/diff-test/Cargo.toml
+++ b/crates/diff-test/Cargo.toml
@@ -12,7 +12,6 @@ anyhow.workspace = true
 ignore.workspace = true
 itertools.workspace = true
 regex.workspace = true
-serde.workspace = true
 serde_json.workspace = true
 
 jsonpath_lib = "0.3"

--- a/crates/diff-test/Cargo.toml
+++ b/crates/diff-test/Cargo.toml
@@ -20,7 +20,6 @@ jsonpath_lib = "0.3"
 prettydiff = "0.9"
 html-minifier = "5"
 ansi-to-html = "0.2"
-similar = "2"
 quick-xml = "0.39"
 clap = { version = "4", features = ["derive"] }
 lol_html = "2"

--- a/crates/rari-data/Cargo.toml
+++ b/crates/rari-data/Cargo.toml
@@ -12,7 +12,6 @@ thiserror.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 url.workspace = true
-chrono.workspace = true
 indexmap.workspace = true
 schemars.workspace = true
 tracing.workspace = true

--- a/crates/rari-doc/Cargo.toml
+++ b/crates/rari-doc/Cargo.toml
@@ -29,7 +29,6 @@ pretty_yaml.workspace = true
 serde_yaml_ng.workspace = true
 yaml_parser.workspace = true
 schemars.workspace = true
-strum.workspace = true
 inventory.workspace = true
 tree-sitter.workspace = true
 tree-sitter-mdn.workspace = true

--- a/crates/rari-linter/Cargo.toml
+++ b/crates/rari-linter/Cargo.toml
@@ -5,6 +5,3 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 rust-version.workspace = true
-
-[dependencies]
-thiserror.workspace = true

--- a/crates/rari-lsp/Cargo.toml
+++ b/crates/rari-lsp/Cargo.toml
@@ -10,12 +10,8 @@ rust-version.workspace = true
 rari-doc.workspace = true
 rari-tools.workspace = true
 rari-types.workspace = true
-
-serde.workspace = true
 serde_json.workspace = true
 tokio = { workspace = true, features = ["io-std"] }
-tracing.workspace = true
-tracing-subscriber.workspace = true
 anyhow.workspace = true
 tree-sitter.workspace = true
 tree-sitter-mdn.workspace = true
@@ -24,5 +20,4 @@ tree-sitter-md = { version = "0.3", features = ["parser"] }
 lsp-textdocument = "0.5"
 lsp-types = "0.97"
 tower-lsp-server = "0.23"
-streaming-iterator = "0.1"
 dashmap = "6"

--- a/crates/rari-templ-func/Cargo.toml
+++ b/crates/rari-templ-func/Cargo.toml
@@ -15,3 +15,6 @@ darling.workspace = true
 quote.workspace = true
 
 syn = { version = "2", features = ["full"] }
+
+[dev-dependencies]
+anyhow.workspace = true

--- a/crates/rari-templ-func/Cargo.toml
+++ b/crates/rari-templ-func/Cargo.toml
@@ -15,6 +15,3 @@ darling.workspace = true
 quote.workspace = true
 
 syn = { version = "2", features = ["full"] }
-
-[dev-dependencies]
-anyhow.workspace = true

--- a/crates/rari-tools/Cargo.toml
+++ b/crates/rari-tools/Cargo.toml
@@ -18,7 +18,6 @@ serde.workspace = true
 serde_json.workspace = true
 chrono.workspace = true
 tracing.workspace = true
-reqwest.workspace = true
 url.workspace = true
 indoc.workspace = true
 rayon.workspace = true
@@ -29,8 +28,6 @@ yaml_parser.workspace = true
 const_format.workspace = true
 dialoguer.workspace = true
 html-escape.workspace = true
-
-csv = "1"
 
 [dev-dependencies]
 serial_test = { version = "3", features = ["file_locks"] }

--- a/crates/rari-types/Cargo.toml
+++ b/crates/rari-types/Cargo.toml
@@ -24,7 +24,6 @@ darling.workspace = true
 quote.workspace = true
 
 serde_variant = "0.1"
-normalize-path = "0.2"
 dirs = "6"
 config = { version = "0.15", default-features = false, features = ["toml"] }
 proc-macro2 = "1"

--- a/crates/rari-utils/Cargo.toml
+++ b/crates/rari-utils/Cargo.toml
@@ -8,6 +8,3 @@ rust-version.workspace = true
 
 [dependencies]
 thiserror.workspace = true
-serde.workspace = true
-serde_json.workspace = true
-tracing.workspace = true


### PR DESCRIPTION
### Description

Remove unused dependencies across the workspace, identified via `cargo machete`.

### Motivation

These crates were declared in `Cargo.toml` but are no longer referenced in source. Dropping them shrinks the dependency graph, cuts compile time, and silences pointless update PRs.

### Additional details

Removed across four commits:

- **`rari-data`**: `chrono`
- **`rari-doc`**: `strum`
- **`rari-tools`**: `csv`, `reqwest`
- **`rari-types`**: `normalize-path`
- **`css-syntax`**: `itertools`, `regress`, `url`
- **`rari-linter`**: `thiserror`
- **`diff-test`**: `base64`, `serde` (only `serde_json` is used), `similar`
- **`rari-lsp`**: `serde`, `tracing`, `streaming-iterator`, `tracing-subscriber`
- **`rari-utils`**: `serde`, `serde_json`, `tracing`

One machete-flagged item left in place: `anyhow` in `crates/css-syntax/Cargo.toml` — false positive, it's a `[build-dependencies]` entry actually used in `build.rs`.

Verified with `cargo build --workspace --all-targets` and `cargo test --doc` (the doctest pass caught a needed `anyhow` dev-dep on `rari-templ-func`, restored in the final commit).

### Related issues and pull requests

Triggered by https://github.com/mdn/rari/pull/664.
