### PR TITLE
fix(css-syntax): apply multipliers to literal tokens

### DIFF
--- a/crates/css-definition-syntax/src/parser.rs
+++ b/crates/css-definition-syntax/src/parser.rs
@@ -745,7 +745,10 @@ fn peek(
             }
         }
 
-        _ => maybe_token(tokenizer),
+        _ => match maybe_token(tokenizer) {
+            Some(node) => Some(maybe_multiplied(tokenizer, node)?),
+            None => None,
+        },
     })
 }
 
@@ -1177,6 +1180,35 @@ mod test {
                 explicit: true
             })
         );
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_token_with_multiplier() -> Result<(), SyntaxDefinitionError> {
+        // Regression test for https://github.com/mdn/rari/issues/668
+        // Literal tokens (e.g. ';') may be followed by multipliers in webref data,
+        // such as the if() syntax `if( [ <if-branch> ; ]* <if-branch> ;? )` and
+        // <init-descriptors>/<pattern-descriptors> using `;*` / `;+`.
+        let result = parse("a ;?")?;
+        assert_eq!(
+            result,
+            Node::Group(Group {
+                terms: vec![
+                    Node::Keyword(Keyword { name: "a".into() }),
+                    Node::Multiplier(Multiplier {
+                        comma: false,
+                        min: 0,
+                        max: 1,
+                        term: Box::new(Node::Token(Token { value: ';' })),
+                    }),
+                ],
+                combinator: CombinatorType::Space,
+                disallow_empty: false,
+                explicit: false,
+            })
+        );
+        // Full if() syntax from webref must round-trip through parse() without error.
+        parse("if( [ <if-branch> ; ]* <if-branch> ;? )")?;
         Ok(())
     }
 

--- a/crates/css-syntax/src/syntax.rs
+++ b/crates/css-syntax/src/syntax.rs
@@ -932,6 +932,26 @@ mod test {
     }
 
     #[test]
+    fn test_render_if_function() -> Result<(), SyntaxError> {
+        // Regression test for https://github.com/mdn/rari/issues/668
+        // The if() syntax contains `;?` (a literal token followed by an optional
+        // multiplier), which previously failed with "Parse error: Unexpected input".
+        let result = render_formal_syntax(
+            SyntaxInput::Css(CssType::Function("if")),
+            Some("css.types.if"),
+            "en-US",
+            "/en-US/docs/Web/CSS/Guides/Values_and_units/Value_definition_syntax",
+            &TOOLTIPS,
+            None,
+        )?;
+        assert!(result.contains("&lt;if()&gt;"));
+        assert!(result.contains("if-branch"));
+        // Question-mark multiplier on `;` must be rendered as a linked token.
+        assert!(result.contains("question_mark"));
+        Ok(())
+    }
+
+    #[test]
     fn test_render_cursor_property() -> Result<(), SyntaxError> {
         // Regression test for https://github.com/mdn/rari/issues/596
         // The cursor-image type syntax uses a stacked multiplier ({2}?) which


### PR DESCRIPTION
### Description

Updates the `css-syntax` parser, applying multipliers to literal tokens.

### Motivation

Avoids parse error on CSS `if()` page.

### Additional details

The webref `if()` syntax `if( [ <if-branch> ; ]* <if-branch> ;? )` contains `;?` (an optional literal `;` token), which the parser's catch-all token branch never wrapped in `maybe_multiplied`, leaving the `?` unconsumed and producing "Parse error: Unexpected input". Same shape also affects `<if-args>`, `<init-descriptors>`, and `<pattern-descriptors>`.

### Related issues and pull requests

Fixes #668.

Part of https://github.com/mdn/fred/issues/1462.