### PR TITLE
fix(cssinfo,csssyntax): report links as `templ-*-link`

### DIFF
--- a/crates/rari-doc/src/html/links.rs
+++ b/crates/rari-doc/src/html/links.rs
@@ -1,12 +1,15 @@
 use std::borrow::Cow;
 
+use lol_html::{RewriteStrSettings, element, rewrite_str};
 use rari_md::anchor::anchorize;
 use rari_types::fm_types::FeatureStatus;
 use rari_types::locale::Locale;
 use rari_utils::concat_strs;
 
 use crate::error::DocError;
+use crate::issues::get_issue_counter;
 use crate::pages::page::{Page, PageLike};
+use crate::redirects::resolve_redirect;
 use crate::resolve::locale_from_url;
 use crate::templ::api::RariApi;
 use crate::templ::templs::badges::{write_deprecated, write_experimental, write_non_standard};
@@ -184,4 +187,110 @@ pub fn render_link_via_page(
     }
     out.push_str("</a>");
     Ok(())
+}
+
+/// Validate internal `<a>` links in template-generated HTML.
+///
+/// Some templates (e.g. `csssyntax`, `cssinfo`) emit `<a>` tags by hand
+/// without going through `RariApi::get_page`, so they bypass the
+/// `templ-broken-link` / `templ-redirected-link` reporting that other
+/// link-producing templates get for free. Untagged links also reach
+/// `fix_link` later, which would surface them as plain `broken-link` /
+/// `redirected-link` issues without a markdown sourcepos.
+///
+/// This walks the rendered HTML, and for each internal `<a href="/...">`
+/// that doesn't already carry `data-templ-link`:
+/// - emits `templ-redirected-link` / `templ-ill-cased-link` if the URL
+///   resolves through a redirect,
+/// - emits `templ-broken-link` if the (resolved) URL doesn't exist,
+/// - tags the element with `data-templ-link` so `fix_link` skips it.
+///
+/// Must be called from inside the surrounding `templ` tracing span so
+/// the warnings pick up the macro name and source location.
+pub fn post_process_templ_links(html: &str) -> Result<String, DocError> {
+    let element_content_handlers = vec![element!("a[href]:not([data-templ-link])", |el| {
+        let Some(href) = el.get_attribute("href") else {
+            return Ok(());
+        };
+        if href.starts_with('/') {
+            let href_no_hash = &href[..href.find('#').unwrap_or(href.len())];
+            let resolved = resolve_redirect(href_no_hash);
+            match resolved.as_deref() {
+                Some(redirect) if href_no_hash.eq_ignore_ascii_case(redirect) => {
+                    let ic = get_issue_counter();
+                    tracing::warn!(
+                        source = "templ-ill-cased-link",
+                        ic = ic,
+                        url = href.as_str(),
+                        redirect = redirect,
+                    );
+                }
+                Some(redirect) => {
+                    let ic = get_issue_counter();
+                    tracing::warn!(
+                        source = "templ-redirected-link",
+                        ic = ic,
+                        url = href.as_str(),
+                        redirect = redirect,
+                    );
+                }
+                None => {}
+            }
+            let target = resolved.as_deref().unwrap_or(href_no_hash);
+            if !Page::ignore_link_check(target) && !Page::exists_with_fallback(target) {
+                let ic = get_issue_counter();
+                tracing::warn!(source = "templ-broken-link", ic = ic, url = href.as_str());
+            }
+            el.set_attribute("data-templ-link", "")?;
+        }
+        Ok(())
+    })];
+    Ok(rewrite_str(
+        html,
+        RewriteStrSettings {
+            element_content_handlers,
+            ..Default::default()
+        },
+    )?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::post_process_templ_links;
+
+    #[test]
+    fn tags_internal_links_so_fix_link_skips_them() {
+        // Before this helper existed, formal-syntax `<a>` tags reached
+        // `fix_link` without `data-templ-link` and surfaced as plain
+        // `broken-link`/`redirected-link` issues with no sourcepos. The
+        // post-processor must now tag every untagged internal link.
+        let input = r#"<a href="/en-US/docs/Web/CSS/Reference/Values/foo">foo</a>"#;
+        let output = post_process_templ_links(input).unwrap();
+        assert!(
+            output.contains("data-templ-link"),
+            "expected internal link to be tagged with `data-templ-link`, got: {output}"
+        );
+    }
+
+    #[test]
+    fn leaves_external_links_alone() {
+        let input = r#"<a href="https://drafts.csswg.org/css-conditional-5/">spec</a>"#;
+        let output = post_process_templ_links(input).unwrap();
+        assert!(
+            !output.contains("data-templ-link"),
+            "external link should not be tagged: {output}"
+        );
+    }
+
+    #[test]
+    fn skips_already_tagged_links() {
+        // Links emitted via `RariApi::link` / `render_internal_link` already
+        // carry `data-templ-link` and have already been validated by the
+        // template, so we mustn't re-process and double-warn.
+        let input =
+            r#"<a data-templ-link href="/en-US/docs/Web/CSS/Reference/Properties/color">x</a>"#;
+        let output = post_process_templ_links(input).unwrap();
+        // Still exactly one occurrence (we didn't add another).
+        assert_eq!(output.matches("data-templ-link").count(), 1);
+    }
 }

--- a/crates/rari-doc/src/html/links.rs
+++ b/crates/rari-doc/src/html/links.rs
@@ -213,7 +213,9 @@ pub fn post_process_templ_links(html: &str) -> Result<String, DocError> {
             return Ok(());
         };
         if href.starts_with('/') {
-            let href_no_hash = &href[..href.find('#').unwrap_or(href.len())];
+            let hash_idx = href.find('#').unwrap_or(href.len());
+            let href_no_hash = &href[..hash_idx];
+            let fragment = &href[hash_idx..];
             let resolved = resolve_redirect(href_no_hash);
             match resolved.as_deref() {
                 Some(redirect) if href_no_hash.eq_ignore_ascii_case(redirect) => {
@@ -240,6 +242,12 @@ pub fn post_process_templ_links(html: &str) -> Result<String, DocError> {
             if !Page::ignore_link_check(target) && !Page::exists_with_fallback(target) {
                 let ic = get_issue_counter();
                 tracing::warn!(source = "templ-broken-link", ic = ic, url = href.as_str());
+            }
+            // Tagging with `data-templ-link` below opts this link out of
+            // `fix_link`'s redirect rewrite, so do it here instead — otherwise
+            // the rendered page would keep pointing at the unresolved URL.
+            if let Some(redirect) = resolved.as_deref() {
+                el.set_attribute("href", &format!("{redirect}{fragment}"))?;
             }
             el.set_attribute("data-templ-link", "")?;
         }

--- a/crates/rari-doc/src/templ/templs/cssinfo.rs
+++ b/crates/rari-doc/src/templ/templs/cssinfo.rs
@@ -7,6 +7,7 @@ use crate::error::DocError;
 use crate::helpers::css_info::{
     css_info_properties, mdn_data_files, write_computed_output, write_missing,
 };
+use crate::html::links::post_process_templ_links;
 
 #[rari_f(register = "crate::Templ")]
 pub fn cssinfo() -> Result<String, DocError> {
@@ -49,5 +50,5 @@ pub fn cssinfo() -> Result<String, DocError> {
         write!(&mut out, r#"</td></tr>"#)?;
     }
     out.push_str(r#"</tbody></table>"#);
-    Ok(out)
+    post_process_templ_links(&out)
 }

--- a/crates/rari-doc/src/templ/templs/csssyntax.rs
+++ b/crates/rari-doc/src/templ/templs/csssyntax.rs
@@ -2,15 +2,12 @@ use std::collections::HashMap;
 use std::sync::LazyLock;
 
 use css_syntax::syntax::{CssType, LinkedToken, SyntaxInput, render_formal_syntax};
-use lol_html::{RewriteStrSettings, element, rewrite_str};
 use rari_templ_func::rari_f;
 use tracing::{error, warn};
 
 use crate::error::DocError;
 use crate::helpers::l10n::l10n_json_data;
-use crate::issues::get_issue_counter;
-use crate::pages::page::Page;
-use crate::redirects::resolve_redirect;
+use crate::html::links::post_process_templ_links;
 
 static TOOLTIPS: LazyLock<HashMap<LinkedToken, String>> = LazyLock::new(|| {
     [(LinkedToken::Asterisk, "Asterisk: the entity may occur zero, one or several times".to_string()),
@@ -89,7 +86,7 @@ pub fn csssyntax(name: Option<String>) -> Result<String, DocError> {
         &TOOLTIPS,
         Some(sources_prefix),
     )?;
-    post_process_formal_syntax(&html)
+    post_process_templ_links(&html)
 }
 
 #[rari_f(register = "crate::Templ")]
@@ -106,65 +103,5 @@ pub fn csssyntaxraw(syntax: String) -> Result<String, DocError> {
         &TOOLTIPS,
         Some(sources_prefix),
     )?;
-    post_process_formal_syntax(&html)
-}
-
-/// Post-process formal-syntax HTML to validate generated internal links.
-///
-/// `render_formal_syntax` synthesizes `<a>` tags for CSS Properties/Values pages
-/// from token names without checking they resolve. We tag each generated link
-/// with `data-templ-link` (so `fix_link` skips its own checks) and emit a
-/// `templ-broken-link` warning here for any internal link that doesn't resolve.
-fn post_process_formal_syntax(html: &str) -> Result<String, DocError> {
-    let element_content_handlers = vec![element!("a[href]", |el| {
-        let Some(href) = el.get_attribute("href") else {
-            return Ok(());
-        };
-        if href.starts_with('/') {
-            let href_no_hash = &href[..href.find('#').unwrap_or(href.len())];
-            let resolved = resolve_redirect(href_no_hash);
-            let target = resolved.as_deref().unwrap_or(href_no_hash);
-            if !Page::ignore_link_check(target) && !Page::exists_with_fallback(target) {
-                let ic = get_issue_counter();
-                tracing::warn!(source = "templ-broken-link", ic = ic, url = href.as_str());
-            }
-            el.set_attribute("data-templ-link", "")?;
-        }
-        Ok(())
-    })];
-    Ok(rewrite_str(
-        html,
-        RewriteStrSettings {
-            element_content_handlers,
-            ..Default::default()
-        },
-    )?)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::post_process_formal_syntax;
-
-    #[test]
-    fn tags_internal_links_so_fix_link_skips_them() {
-        // Before the fix, formal-syntax `<a>` tags reached `fix_link` without
-        // `data-templ-link` and surfaced as plain `broken-link` issues with no
-        // sourcepos. The post-processor must now tag every internal link.
-        let input = r#"<a href="/en-US/docs/Web/CSS/Reference/Values/foo">foo</a>"#;
-        let output = post_process_formal_syntax(input).unwrap();
-        assert!(
-            output.contains("data-templ-link"),
-            "expected internal link to be tagged with `data-templ-link`, got: {output}"
-        );
-    }
-
-    #[test]
-    fn leaves_external_links_alone() {
-        let input = r#"<a href="https://drafts.csswg.org/css-conditional-5/">spec</a>"#;
-        let output = post_process_formal_syntax(input).unwrap();
-        assert!(
-            !output.contains("data-templ-link"),
-            "external link should not be tagged: {output}"
-        );
-    }
+    post_process_templ_links(&html)
 }

--- a/crates/rari-doc/src/templ/templs/csssyntax.rs
+++ b/crates/rari-doc/src/templ/templs/csssyntax.rs
@@ -2,11 +2,15 @@ use std::collections::HashMap;
 use std::sync::LazyLock;
 
 use css_syntax::syntax::{CssType, LinkedToken, SyntaxInput, render_formal_syntax};
+use lol_html::{RewriteStrSettings, element, rewrite_str};
 use rari_templ_func::rari_f;
 use tracing::{error, warn};
 
 use crate::error::DocError;
 use crate::helpers::l10n::l10n_json_data;
+use crate::issues::get_issue_counter;
+use crate::pages::page::Page;
+use crate::redirects::resolve_redirect;
 
 static TOOLTIPS: LazyLock<HashMap<LinkedToken, String>> = LazyLock::new(|| {
     [(LinkedToken::Asterisk, "Asterisk: the entity may occur zero, one or several times".to_string()),
@@ -74,7 +78,7 @@ pub fn csssyntax(name: Option<String>) -> Result<String, DocError> {
         );
     }
 
-    Ok(render_formal_syntax(
+    let html = render_formal_syntax(
         SyntaxInput::Css(typ),
         env.browser_compat.first().map(|s| s.as_str()),
         env.locale.as_url_str(),
@@ -84,13 +88,14 @@ pub fn csssyntax(name: Option<String>) -> Result<String, DocError> {
         ),
         &TOOLTIPS,
         Some(sources_prefix),
-    )?)
+    )?;
+    post_process_formal_syntax(&html)
 }
 
 #[rari_f(register = "crate::Templ")]
 pub fn csssyntaxraw(syntax: String) -> Result<String, DocError> {
     let sources_prefix = l10n_json_data("Template", "formal_syntax_footer", env.locale)?;
-    Ok(render_formal_syntax(
+    let html = render_formal_syntax(
         SyntaxInput::SyntaxString(&syntax),
         env.browser_compat.first().map(|s| s.as_str()),
         env.locale.as_url_str(),
@@ -100,5 +105,66 @@ pub fn csssyntaxraw(syntax: String) -> Result<String, DocError> {
         ),
         &TOOLTIPS,
         Some(sources_prefix),
+    )?;
+    post_process_formal_syntax(&html)
+}
+
+/// Post-process formal-syntax HTML to validate generated internal links.
+///
+/// `render_formal_syntax` synthesizes `<a>` tags for CSS Properties/Values pages
+/// from token names without checking they resolve. We tag each generated link
+/// with `data-templ-link` (so `fix_link` skips its own checks) and emit a
+/// `templ-broken-link` warning here for any internal link that doesn't resolve.
+fn post_process_formal_syntax(html: &str) -> Result<String, DocError> {
+    let element_content_handlers = vec![element!("a[href]", |el| {
+        let Some(href) = el.get_attribute("href") else {
+            return Ok(());
+        };
+        if href.starts_with('/') {
+            let href_no_hash = &href[..href.find('#').unwrap_or(href.len())];
+            let resolved = resolve_redirect(href_no_hash);
+            let target = resolved.as_deref().unwrap_or(href_no_hash);
+            if !Page::ignore_link_check(target) && !Page::exists_with_fallback(target) {
+                let ic = get_issue_counter();
+                tracing::warn!(source = "templ-broken-link", ic = ic, url = href.as_str());
+            }
+            el.set_attribute("data-templ-link", "")?;
+        }
+        Ok(())
+    })];
+    Ok(rewrite_str(
+        html,
+        RewriteStrSettings {
+            element_content_handlers,
+            ..Default::default()
+        },
     )?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::post_process_formal_syntax;
+
+    #[test]
+    fn tags_internal_links_so_fix_link_skips_them() {
+        // Before the fix, formal-syntax `<a>` tags reached `fix_link` without
+        // `data-templ-link` and surfaced as plain `broken-link` issues with no
+        // sourcepos. The post-processor must now tag every internal link.
+        let input = r#"<a href="/en-US/docs/Web/CSS/Reference/Values/foo">foo</a>"#;
+        let output = post_process_formal_syntax(input).unwrap();
+        assert!(
+            output.contains("data-templ-link"),
+            "expected internal link to be tagged with `data-templ-link`, got: {output}"
+        );
+    }
+
+    #[test]
+    fn leaves_external_links_alone() {
+        let input = r#"<a href="https://drafts.csswg.org/css-conditional-5/">spec</a>"#;
+        let output = post_process_formal_syntax(input).unwrap();
+        assert!(
+            !output.contains("data-templ-link"),
+            "external link should not be tagged: {output}"
+        );
+    }
 }


### PR DESCRIPTION
### Description

Report broken/ill-cased/redirecting links in "Formal syntax" and "Formal definition" as `templ-broken-link`/`templ-ill-cased-link`/`templ-redirected-link` instead of `broken-link`/`ill-cased-link`/`redirected-link`.

### Motivation

Consistency. Make it easy to distinguish issues with macro-generated links from "authored" links.

### Additional details

Internal `<a>` tags synthesized by "Formal syntax" and "Formal definition" templates were never validated, so links with issues only surfaced as sourcepos-less `broken-link`/`redirected-link`.

We now validate them in `cssinfo`/`csssyntax`/`csssyntaxraw` after rendering and tag them with `data-templ-link` so `fix_link` skips them. Issues are now reported as `templ-broken-link` / `templ-redirected-link` / `templ-ill-cased-link` with macro name and line number.

### Related issues and pull requests

Related to https://github.com/mdn/rari/issues/665.

Part of https://github.com/mdn/fred/issues/1462.