### PR TITLE
feat(templ): support `_<xref>()` to mark intentionally missing pages

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -51,6 +51,11 @@ jobs:
           path: mdn/rari
           persist-credentials: false
 
+      # TODO: remove once tree-sitter-mdn with expect-missing support is released
+      - name: Checkout tree-sitter-mdn PR #103
+        if: inputs.rari-binary-artifact-id == ''
+        run: git clone --depth 1 --branch expect-missing https://github.com/mdn/tree-sitter-mdn.git mdn/tree-sitter-mdn
+
       - name: Checkout (content)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/build-content-and-diff.yml
+++ b/.github/workflows/build-content-and-diff.yml
@@ -66,6 +66,10 @@ jobs:
           path: rari-pr
           persist-credentials: false
 
+      # TODO: remove once tree-sitter-mdn with expect-missing support is released
+      - name: Checkout tree-sitter-mdn PR #103
+        run: git clone --depth 1 --branch expect-missing https://github.com/mdn/tree-sitter-mdn.git tree-sitter-mdn
+
       - name: Build with base
         working-directory: rari-base
         env:

--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -36,6 +36,10 @@ jobs:
         with:
           persist-credentials: false
 
+      # TODO: remove once tree-sitter-mdn with expect-missing support is released
+      - name: Checkout tree-sitter-mdn PR #103
+        run: git clone --depth 1 --branch expect-missing https://github.com/mdn/tree-sitter-mdn.git ../tree-sitter-mdn
+
       - uses: dtolnay/rust-toolchain@9a1d20035bdbcbc899baabe1e402e85bc33639bc # 1.90
 
       - name: Setup sccache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,10 @@ jobs:
         with:
           persist-credentials: false
 
+      # TODO: remove once tree-sitter-mdn with expect-missing support is released
+      - name: Checkout tree-sitter-mdn PR #103
+        run: git clone --depth 1 --branch expect-missing https://github.com/mdn/tree-sitter-mdn.git ../tree-sitter-mdn
+
       - uses: dtolnay/rust-toolchain@9a1d20035bdbcbc899baabe1e402e85bc33639bc # 1.90
 
       - name: sccache-cache
@@ -76,6 +80,10 @@ jobs:
         with:
           persist-credentials: false
 
+      # TODO: remove once tree-sitter-mdn with expect-missing support is released
+      - name: Checkout tree-sitter-mdn PR #103
+        run: git clone --depth 1 --branch expect-missing https://github.com/mdn/tree-sitter-mdn.git ../tree-sitter-mdn
+
       - uses: dtolnay/rust-toolchain@9a1d20035bdbcbc899baabe1e402e85bc33639bc # 1.90
 
       - name: sccache-cache
@@ -94,6 +102,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
+      # TODO: remove once tree-sitter-mdn with expect-missing support is released
+      - name: Checkout tree-sitter-mdn PR #103
+        run: git clone --depth 1 --branch expect-missing https://github.com/mdn/tree-sitter-mdn.git ../tree-sitter-mdn
 
       - uses: dtolnay/rust-toolchain@9a1d20035bdbcbc899baabe1e402e85bc33639bc # 1.90
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,10 @@ jobs:
         with:
           persist-credentials: false
 
+      # TODO: remove once tree-sitter-mdn with expect-missing support is released
+      - name: Checkout tree-sitter-mdn PR #103
+        run: git clone --depth 1 --branch expect-missing https://github.com/mdn/tree-sitter-mdn.git ../tree-sitter-mdn
+
       - uses: dtolnay/rust-toolchain@9a1d20035bdbcbc899baabe1e402e85bc33639bc # 1.90
         with:
           components: rustfmt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,9 +292,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.49"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90583009037521a116abf44494efecd645ba48b6622457080f080b85544e2215"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -1148,9 +1148,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.5"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "finl_unicode"
@@ -3043,7 +3043,7 @@ version = "2.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0e38781082c53bdde56e6081698c06831f69a27eac2593ed6b6cb2511424ad5"
 dependencies = [
- "quick-xml 0.39.2",
+ "quick-xml 0.39.4",
 ]
 
 [[package]]
@@ -4069,8 +4069,6 @@ dependencies = [
 [[package]]
 name = "tree-sitter-mdn"
 version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af8a0e7886eb722d1f7fc676e89b3c55b0e2df3c0c3677bd0ded11066eec1821"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ semver = { version = "1", features = ["serde"] }
 strum = { version = "0.28", features = ["derive"] }
 tokio = "1"
 inventory = "0.3"
-tree-sitter-mdn = "0.1"
+tree-sitter-mdn = { path = "../tree-sitter-mdn" }
 tree-sitter = "0.23"
 darling = "0.23"
 quote = "1"

--- a/crates/rari-doc/src/error.rs
+++ b/crates/rari-doc/src/error.rs
@@ -72,6 +72,8 @@ pub enum DocError {
     RedirectedLink { from: String, to: String },
     #[error("Unknown macro: {0}")]
     UnknownMacro(String),
+    #[error("Macro `{0}` does not support the `_` (expect-missing) flag")]
+    ExpectMissingNotSupported(String),
     #[error("CSS Page type required")]
     CssPageTypeRequired,
     #[error(transparent)]

--- a/crates/rari-doc/src/html/banner.rs
+++ b/crates/rari-doc/src/html/banner.rs
@@ -20,7 +20,7 @@ pub fn build_banner<T: PageLike>(banner: &FmTempl, page: &T) -> Result<String, D
     };
     let span = span!(Level::ERROR, "banner", banner = name,);
     let _enter = span.enter();
-    let rendered_banner = match invoke(&rari_env, name, args) {
+    let rendered_banner = match invoke(&rari_env, name, args, false) {
         Ok((rendered_banner, TemplType::Banner)) => rendered_banner,
         Ok((_, typ)) => {
             let span = span!(Level::ERROR, "banner", banner = name,);

--- a/crates/rari-doc/src/html/sidebar.rs
+++ b/crates/rari-doc/src/html/sidebar.rs
@@ -157,7 +157,7 @@ pub fn build_sidebar(sidebar: &FmTempl, doc: &Doc) -> Result<String, DocError> {
         let span = span!(Level::ERROR, "sidebar", sidebar = name,);
         let _enter = span.enter();
 
-        match invoke(&rari_env, name, args) {
+        match invoke(&rari_env, name, args, false) {
             Ok((rendered_sidebar, TemplType::Sidebar)) => rendered_sidebar,
             Ok((_, typ)) => {
                 let span = span!(Level::ERROR, "sidebar", sidebar = name,);

--- a/crates/rari-doc/src/issues.rs
+++ b/crates/rari-doc/src/issues.rs
@@ -555,6 +555,9 @@ impl DIssue {
                     let source = issue_source(&mut additional);
                     di.fixed = false;
                     di.fixable = Some(true);
+                    // Used by the fixer as a marker; the actual transformation is
+                    // determined by the issue type, not the suggestion text.
+                    di.suggestion = source.name.clone();
                     di.explanation = Some(format!(
                         "{} is flagged with `_` as expecting a missing page, but {} resolves — remove the leading underscore",
                         source.label,

--- a/crates/rari-doc/src/issues.rs
+++ b/crates/rari-doc/src/issues.rs
@@ -299,6 +299,7 @@ pub enum IssueType {
     TemplBrokenLink,
     TemplIllCasedLink,
     TemplInvalidArg,
+    TemplExpectMissingExists,
     RedirectedLink,
     BrokenLink,
     IllCasedLink,
@@ -315,6 +316,7 @@ impl FromStr for IssueType {
             "templ-broken-link" => Self::TemplBrokenLink,
             "templ-ill-cased-link" => Self::TemplIllCasedLink,
             "templ-invalid-arg" => Self::TemplInvalidArg,
+            "templ-expect-missing-exists" => Self::TemplExpectMissingExists,
             "redirected-link" => Self::RedirectedLink,
             "broken-link" => Self::BrokenLink,
             "ill-cased-link" => Self::IllCasedLink,
@@ -547,6 +549,21 @@ impl DIssue {
                         display_issue: di,
                         macro_name: source.name,
                         href: None,
+                    }
+                }
+                IssueType::TemplExpectMissingExists => {
+                    let source = issue_source(&mut additional);
+                    di.fixed = false;
+                    di.fixable = Some(true);
+                    di.explanation = Some(format!(
+                        "{} is flagged with `_` as expecting a missing page, but {} resolves — remove the leading underscore",
+                        source.label,
+                        additional.get("url").map(|s| s.as_str()).unwrap_or("?")
+                    ));
+                    DIssue::Macros {
+                        display_issue: di,
+                        macro_name: source.name,
+                        href: additional.remove("url"),
                     }
                 }
                 _ => {

--- a/crates/rari-doc/src/templ/api.rs
+++ b/crates/rari-doc/src/templ/api.rs
@@ -11,6 +11,7 @@ use crate::issues::get_issue_counter;
 use crate::pages::page::Page;
 use crate::percent::PATH_SEGMENT;
 use crate::redirects::resolve_redirect;
+use crate::templ::templs::expect_missing;
 
 enum LinkWarn {
     No,
@@ -78,15 +79,24 @@ impl RariApi {
             }
             None => url,
         };
-        Page::from_url_with_fallback(url).inspect_err(|e| {
-            if let DocError::PageNotFound(_, category) = &e
-                && !matches!(warn, LinkWarn::No)
-                && Page::is_category_available(*category)
-            {
-                let ic = get_issue_counter();
-                tracing::warn!(source = "templ-broken-link", ic = ic, url = url);
-            }
-        })
+        let expect_missing = expect_missing();
+        Page::from_url_with_fallback(url)
+            .inspect(|_| {
+                if expect_missing && !matches!(warn, LinkWarn::No) {
+                    let ic = get_issue_counter();
+                    tracing::warn!(source = "templ-expect-missing-exists", ic = ic, url = url);
+                }
+            })
+            .inspect_err(|e| {
+                if let DocError::PageNotFound(_, category) = &e
+                    && !matches!(warn, LinkWarn::No)
+                    && Page::is_category_available(*category)
+                    && !expect_missing
+                {
+                    let ic = get_issue_counter();
+                    tracing::warn!(source = "templ-broken-link", ic = ic, url = url);
+                }
+            })
     }
 
     pub fn decode_uri_component(component: &str) -> String {

--- a/crates/rari-doc/src/templ/parser.rs
+++ b/crates/rari-doc/src/templ/parser.rs
@@ -16,6 +16,7 @@ pub struct MacroToken {
     pub ident: String,
     pub pos: (usize, usize),
     pub args: Vec<Option<Arg>>,
+    pub expect_missing: bool,
 }
 
 fn from_node<'a>(
@@ -23,16 +24,27 @@ fn from_node<'a>(
     content: &str,
     cursor: &mut TreeCursor<'a>,
 ) -> Option<MacroToken> {
-    let ident_node = value.named_child(0).unwrap();
-    let ident = content[ident_node.start_byte()..ident_node.end_byte()].to_string();
-    let args = if let Some(args_node) = value.named_child(1) {
-        args_node
-            .named_children(cursor)
-            .map(|arg| ts_to_arg(arg, content))
-            .collect()
-    } else {
-        vec![]
-    };
+    let mut ident = String::new();
+    let mut args = vec![];
+    let mut expect_missing = false;
+    let mut walker = value.walk();
+    for child in value.named_children(&mut walker) {
+        match child.kind() {
+            "ident" => {
+                ident = content[child.start_byte()..child.end_byte()].to_string();
+            }
+            "expect_missing" => {
+                expect_missing = true;
+            }
+            "args" => {
+                args = child
+                    .named_children(cursor)
+                    .map(|arg| ts_to_arg(arg, content))
+                    .collect();
+            }
+            _ => {}
+        }
+    }
     let start = value.start_byte();
     let end = value.end_byte();
     let start_position = value.start_position();
@@ -43,6 +55,7 @@ fn from_node<'a>(
         pos,
         ident,
         args,
+        expect_missing,
     })
 }
 
@@ -153,6 +166,24 @@ mod test {
         for node in tree.root_node().children(&mut cursor) {
             println!("{}", node.grammar_name());
             println!("{node:?}");
+        }
+    }
+
+    #[test]
+    fn expect_missing_flag() {
+        let p = parse(r#"{{_cssxref("foo")}}"#).unwrap();
+        match p.first() {
+            Some(Token::Macro(m)) => {
+                assert_eq!(m.ident, "cssxref");
+                assert!(m.expect_missing);
+                assert_eq!(m.args.len(), 1);
+            }
+            _ => panic!("expected macro token"),
+        }
+        let p = parse(r#"{{cssxref("foo")}}"#).unwrap();
+        match p.first() {
+            Some(Token::Macro(m)) => assert!(!m.expect_missing),
+            _ => panic!("expected macro token"),
         }
     }
 

--- a/crates/rari-doc/src/templ/render.rs
+++ b/crates/rari-doc/src/templ/render.rs
@@ -87,7 +87,7 @@ pub(crate) fn render(env: &RariEnv, input: &str, offset: usize) -> Result<Render
                     end_col = end_col
                 );
                 let _enter = span.enter();
-                match invoke(env, &name, mac.args) {
+                match invoke(env, &name, mac.args, mac.expect_missing) {
                     Ok((rendered, TemplType::Sidebar)) => {
                         encode_ref(templs.len(), &mut out, mac.end - mac.start)?;
                         templs.push(String::default());

--- a/crates/rari-doc/src/templ/templs/glossary.rs
+++ b/crates/rari-doc/src/templ/templs/glossary.rs
@@ -4,7 +4,7 @@ use crate::error::DocError;
 use crate::templ::api::RariApi;
 use crate::utils::dedup_whitespace;
 
-#[rari_f(register = "crate::Templ")]
+#[rari_f(register = "crate::Templ", accepts_expect_missing = true)]
 pub fn glossary(term_name: String, display_name: Option<String>) -> Result<String, DocError> {
     let url = format!(
         "/Glossary/{}",

--- a/crates/rari-doc/src/templ/templs/links/csp.rs
+++ b/crates/rari-doc/src/templ/templs/links/csp.rs
@@ -24,7 +24,7 @@ use crate::templ::api::RariApi;
 /// - Applies code formatting (`<code>` tags) by default
 /// - Links to `/Web/HTTP/Reference/Headers/Content-Security-Policy/{directive}` path structure
 /// - Works for directives, keywords, and source expressions within CSP
-#[rari_f(register = "crate::Templ")]
+#[rari_f(register = "crate::Templ", accepts_expect_missing = true)]
 pub fn csp(directive: String) -> Result<String, DocError> {
     let url = format!(
         "/{}/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/{directive}",

--- a/crates/rari-doc/src/templ/templs/links/cssxref.rs
+++ b/crates/rari-doc/src/templ/templs/links/cssxref.rs
@@ -42,7 +42,7 @@ use crate::templ::api::RariApi;
 /// - Handles HTML entity encoding (`&lt;` and `&gt;`)
 /// - Maps special cases like `<color>` to `color_value`, `:host()` to `:host_function`
 /// - Checks if pages exist at expected URLs and falls back to legacy structure if needed
-#[rari_f(register = "crate::Templ")]
+#[rari_f(register = "crate::Templ", accepts_expect_missing = true)]
 pub fn cssxref(
     name: String,
     display: Option<String>,

--- a/crates/rari-doc/src/templ/templs/links/domxref.rs
+++ b/crates/rari-doc/src/templ/templs/links/domxref.rs
@@ -31,7 +31,7 @@ use crate::templ::api::RariApi;
 /// - Automatically capitalizes first letter of interface names in URLs
 /// - Appends method/property names to display text when using anchors
 /// - Formats links with `<code>` tags unless `no_code` is true
-#[rari_f(register = "crate::Templ")]
+#[rari_f(register = "crate::Templ", accepts_expect_missing = true)]
 pub fn domxref(
     api_name: String,
     display: Option<String>,

--- a/crates/rari-doc/src/templ/templs/links/htmlxref.rs
+++ b/crates/rari-doc/src/templ/templs/links/htmlxref.rs
@@ -25,7 +25,7 @@ use crate::templ::api::RariApi;
 /// - Automatically wraps element name in `&lt;` and `&gt;` for display
 /// - Uses code formatting (`<code>` tags) by default unless custom display text provided
 /// - Links to `/Web/HTML/Reference/Elements/{element_name}` path structure
-#[rari_f(register = "crate::Templ")]
+#[rari_f(register = "crate::Templ", accepts_expect_missing = true)]
 pub fn htmlelement(
     element_name: String,
     display: Option<String>,

--- a/crates/rari-doc/src/templ/templs/links/http.rs
+++ b/crates/rari-doc/src/templ/templs/links/http.rs
@@ -22,7 +22,7 @@ use crate::templ::api::RariApi;
 /// * `{{HTTPStatus("200", "OK")}}` -> custom display text
 /// * `{{HTTPStatus("500", "", "#syntax")}}` -> with anchor
 /// * `{{HTTPStatus("403", "", "", true)}}` -> disables code formatting
-#[rari_f(register = "crate::Templ")]
+#[rari_f(register = "crate::Templ", accepts_expect_missing = true)]
 pub fn httpstatus(
     status: AnyArg,
     display: Option<String>,
@@ -54,7 +54,7 @@ pub fn httpstatus(
 /// * `{{HTTPHeader("Authorization", "Auth header")}}` -> custom display text
 /// * `{{HTTPHeader("Cache-Control", "", "#syntax")}}` -> with anchor
 /// * `{{HTTPHeader("Accept", "", "", true)}}` -> disables code formatting
-#[rari_f(register = "crate::Templ")]
+#[rari_f(register = "crate::Templ", accepts_expect_missing = true)]
 pub fn httpheader(
     status: AnyArg,
     display: Option<String>,
@@ -86,7 +86,7 @@ pub fn httpheader(
 /// * `{{HTTPMethod("GET", "GET request")}}` -> custom display text
 /// * `{{HTTPMethod("PUT", "", "#syntax")}}` -> with anchor
 /// * `{{HTTPMethod("DELETE", "", "", true)}}` -> disables code formatting
-#[rari_f(register = "crate::Templ")]
+#[rari_f(register = "crate::Templ", accepts_expect_missing = true)]
 pub fn httpmethod(
     status: AnyArg,
     display: Option<String>,

--- a/crates/rari-doc/src/templ/templs/links/jsxref.rs
+++ b/crates/rari-doc/src/templ/templs/links/jsxref.rs
@@ -31,7 +31,7 @@ use crate::templ::api::RariApi;
 /// - Handles special cases like `try...catch` statements
 /// - Falls back to URI component decoding if no page found
 /// - Formats links with `<code>` tags unless `no_code` is true
-#[rari_f(register = "crate::Templ")]
+#[rari_f(register = "crate::Templ", accepts_expect_missing = true)]
 pub fn jsxref(
     api_name: String,
     display: Option<String>,

--- a/crates/rari-doc/src/templ/templs/links/mathmlxref.rs
+++ b/crates/rari-doc/src/templ/templs/links/mathmlxref.rs
@@ -26,7 +26,7 @@ use crate::templ::api::RariApi;
 /// - Sets title attribute with unescaped angle brackets for accessibility
 /// - Uses code formatting (`<code>` tags) by default
 /// - Links to `/Web/MathML/Reference/Element/{element_name}` path structure
-#[rari_f(register = "crate::Templ")]
+#[rari_f(register = "crate::Templ", accepts_expect_missing = true)]
 pub fn mathmlelement(element_name: String) -> Result<String, DocError> {
     let element_name = element_name.to_lowercase();
     let display = concat_strs!("&lt;", element_name.as_str(), "&gt;");

--- a/crates/rari-doc/src/templ/templs/links/svgattr.rs
+++ b/crates/rari-doc/src/templ/templs/links/svgattr.rs
@@ -21,7 +21,7 @@ use crate::templ::api::RariApi;
 /// - Uses the attribute name as both the URL path and display text
 /// - Applies code formatting (`<code>` tags) by default
 /// - Links to `/Web/SVG/Reference/Attribute/{name}` path structure
-#[rari_f(register = "crate::Templ")]
+#[rari_f(register = "crate::Templ", accepts_expect_missing = true)]
 pub fn svgattr(name: String) -> Result<String, DocError> {
     let url = format!(
         "/{}/docs/Web/SVG/Reference/Attribute/{}",

--- a/crates/rari-doc/src/templ/templs/links/svgxref.rs
+++ b/crates/rari-doc/src/templ/templs/links/svgxref.rs
@@ -24,7 +24,7 @@ use crate::templ::api::RariApi;
 /// - Automatically wraps element name in `&lt;` and `&gt;` for display
 /// - Uses code formatting (`<code>` tags) by default
 /// - Links to `/Web/SVG/Reference/Element/{element_name}` path structure
-#[rari_f(register = "crate::Templ")]
+#[rari_f(register = "crate::Templ", accepts_expect_missing = true)]
 pub fn svgelement(element_name: String, _: Option<AnyArg>) -> Result<String, DocError> {
     svgxref_internal(&element_name, env.locale)
 }

--- a/crates/rari-doc/src/templ/templs/links/webextapixref.rs
+++ b/crates/rari-doc/src/templ/templs/links/webextapixref.rs
@@ -31,7 +31,7 @@ use crate::templ::api::RariApi;
 /// - Appends anchor information to display text when anchors are used
 /// - Formats links with `<code>` tags unless `no_code` is true
 /// - Links to `/Mozilla/Add-ons/WebExtensions/API/{api}` path structure
-#[rari_f(register = "crate::Templ")]
+#[rari_f(register = "crate::Templ", accepts_expect_missing = true)]
 pub fn webextapiref(
     api: String,
     display: Option<String>,

--- a/crates/rari-doc/src/templ/templs/mod.rs
+++ b/crates/rari-doc/src/templ/templs/mod.rs
@@ -27,6 +27,7 @@ pub mod web_ext_examples;
 pub mod webext_all_examples;
 pub mod xsltref;
 
+use std::cell::Cell;
 use std::collections::HashMap;
 use std::sync::LazyLock;
 
@@ -37,6 +38,34 @@ use tracing::error;
 
 use crate::error::DocError;
 use crate::utils::TEMPL_RECORDER;
+
+thread_local! {
+    static EXPECT_MISSING: Cell<bool> = const { Cell::new(false) };
+}
+
+/// Whether the macro currently being expanded was prefixed with `_`
+/// (e.g. `{{_cssxref("foo")}}`), asserting that the target page is
+/// expected to be missing.
+///
+/// Only meaningful inside a template function invoked via [`invoke`].
+pub fn expect_missing() -> bool {
+    EXPECT_MISSING.with(|c| c.get())
+}
+
+struct ExpectMissingGuard(bool);
+
+impl ExpectMissingGuard {
+    fn new(value: bool) -> Self {
+        let previous = EXPECT_MISSING.with(|c| c.replace(value));
+        Self(previous)
+    }
+}
+
+impl Drop for ExpectMissingGuard {
+    fn drop(&mut self) {
+        EXPECT_MISSING.with(|c| c.set(self.0));
+    }
+}
 
 #[derive(Debug)]
 pub struct Templ {
@@ -65,6 +94,7 @@ pub fn invoke(
     env: &RariEnv,
     name: &str,
     args: Vec<Option<Arg>>,
+    expect_missing: bool,
 ) -> Result<(String, TemplType), DocError> {
     let name = name.replace('-', "_");
     let (f, is_sidebar) = match TEMPL_MAPPING.get(name.as_str()) {
@@ -82,6 +112,7 @@ pub fn invoke(
             return Ok((format!("<s>unsupported templ: {name}</s>"), TemplType::None));
         } //
     };
+    let _guard = ExpectMissingGuard::new(expect_missing);
     f(env, args).map(|s| (s, is_sidebar))
 }
 

--- a/crates/rari-doc/src/templ/templs/mod.rs
+++ b/crates/rari-doc/src/templ/templs/mod.rs
@@ -76,6 +76,10 @@ pub struct Templ {
     pub doc: &'static str,
     pub function: RariFn<Result<String, DocError>>,
     pub typ: TemplType,
+    /// Whether this template understands the `_name(...)` "expect-missing"
+    /// flag. When `false`, `invoke` rejects `expect_missing=true` for this
+    /// template with [`DocError::ExpectMissingNotSupported`].
+    pub accepts_expect_missing: bool,
 }
 
 inventory::collect!(Templ);
@@ -97,8 +101,8 @@ pub fn invoke(
     expect_missing: bool,
 ) -> Result<(String, TemplType), DocError> {
     let name = name.replace('-', "_");
-    let (f, is_sidebar) = match TEMPL_MAPPING.get(name.as_str()) {
-        Some(t) => (t.function, t.typ),
+    let (f, is_sidebar, accepts_expect_missing) = match TEMPL_MAPPING.get(name.as_str()) {
+        Some(t) => (t.function, t.typ, t.accepts_expect_missing),
         None if name == "xulelem" => return Ok((Default::default(), TemplType::None)),
         None if deny_warnings() => return Err(DocError::UnknownMacro(name.to_string())),
         None => {
@@ -112,6 +116,9 @@ pub fn invoke(
             return Ok((format!("<s>unsupported templ: {name}</s>"), TemplType::None));
         } //
     };
+    if expect_missing && !accepts_expect_missing {
+        return Err(DocError::ExpectMissingNotSupported(name));
+    }
     let _guard = ExpectMissingGuard::new(expect_missing);
     f(env, args).map(|s| (s, is_sidebar))
 }
@@ -123,5 +130,16 @@ mod test {
     #[test]
     fn test_kw() {
         println!("{:?}", *TEMPL_MAP);
+    }
+
+    #[test]
+    fn expect_missing_rejected_for_non_xref_template() {
+        let env = RariEnv::default();
+        // `echo` is a plain template that does not opt into expect-missing.
+        let result = invoke(&env, "echo", vec![], true);
+        assert!(matches!(
+            result,
+            Err(DocError::ExpectMissingNotSupported(ref n)) if n == "echo"
+        ));
     }
 }

--- a/crates/rari-templ-func/src/lib.rs
+++ b/crates/rari-templ-func/src/lib.rs
@@ -70,6 +70,11 @@ struct RariFargs {
     register: Option<syn::TypePath>,
     #[darling(default)]
     typ: Option<syn::TypePath>,
+    /// Opt the template into accepting the `_name(...)` "expect-missing"
+    /// flag. Only meaningful for link-emitting templates whose target
+    /// page may or may not exist (xref-family).
+    #[darling(default)]
+    accepts_expect_missing: bool,
 }
 
 /// Define rari templ functions.
@@ -190,6 +195,7 @@ pub fn rari_f(attr: TokenStream, input: TokenStream) -> TokenStream {
         .typ
         .map(|typ| quote! { #typ })
         .unwrap_or(quote! { TemplType::None });
+    let accepts_expect_missing = attr_args.accepts_expect_missing;
 
     let collect = if let Some(inventory_type) = attr_args.register {
         quote! {
@@ -202,6 +208,7 @@ pub fn rari_f(attr: TokenStream, input: TokenStream) -> TokenStream {
                         doc: #doc_string,
                         function: #dup_ident,
                         typ: rari_types::templ::#typ,
+                        accepts_expect_missing: #accepts_expect_missing,
                     }
                 }
         }

--- a/crates/rari-tools/src/fix/issues.rs
+++ b/crates/rari-tools/src/fix/issues.rs
@@ -1,7 +1,7 @@
 use std::fs::File;
 use std::io::{BufWriter, Write};
 
-use rari_doc::issues::{DIssue, IN_MEMORY};
+use rari_doc::issues::{DIssue, IN_MEMORY, IssueType};
 use rari_doc::pages::page::{Page, PageBuilder, PageLike};
 use rari_doc::position_utils::{Direction, adjust_to_char_boundary, calculate_line_start_offset};
 use tracing::{Level, span};
@@ -106,6 +106,58 @@ pub struct SearchReplaceWithOffset {
 }
 
 /// Converts issues into offset-based search/replace suggestions
+/// Builds a search/replace suggestion that removes the leading `_` from a
+/// macro invocation like `{{_cssxref("foo")}}` → `{{cssxref("foo")}}`.
+///
+/// Locates `{{` (optionally followed by whitespace) immediately before a
+/// case-insensitive `_<macro_name>` on the issue's line.
+fn strip_underscore_suggestion(
+    raw: &str,
+    line: i64,
+    macro_name: &str,
+) -> Option<SearchReplaceWithOffset> {
+    let line_idx = (line as usize).saturating_sub(1);
+    let line_start = calculate_line_start_offset(raw, line_idx);
+    let line_end = raw[line_start..]
+        .find('\n')
+        .map(|i| line_start + i)
+        .unwrap_or(raw.len());
+    let line_text = &raw[line_start..line_end];
+
+    let lowered = line_text.to_ascii_lowercase();
+    let needle_macro = macro_name.to_ascii_lowercase();
+    let mut search_from = 0;
+    while let Some(rel_open) = lowered[search_from..].find("{{") {
+        let open = search_from + rel_open;
+        let after_braces = open + 2;
+        let after_ws = after_braces
+            + lowered[after_braces..]
+                .find(|c: char| !c.is_ascii_whitespace())
+                .unwrap_or(lowered.len() - after_braces);
+        if lowered[after_ws..].starts_with('_')
+            && lowered[after_ws + 1..].starts_with(&needle_macro)
+        {
+            let search_end = after_ws + 1 + needle_macro.len();
+            // Make sure we matched the whole identifier, not a prefix.
+            if lowered[search_end..]
+                .chars()
+                .next()
+                .is_none_or(|c| !(c.is_ascii_alphanumeric() || c == '_' || c == '-'))
+            {
+                let search_text = line_text[after_ws..search_end].to_string();
+                let replace_text = line_text[after_ws + 1..search_end].to_string();
+                return Some(SearchReplaceWithOffset {
+                    offset: line_start + after_ws,
+                    search: search_text,
+                    replace: replace_text,
+                });
+            }
+        }
+        search_from = after_braces;
+    }
+    None
+}
+
 pub fn collect_suggestions(raw: &str, issues: &[DIssue]) -> Vec<SearchReplaceWithOffset> {
     // Track the byte offset past the last found occurrence for each (line, decoded_href) pair.
     // This lets us find the correct occurrence when the same href appears multiple times on
@@ -116,6 +168,17 @@ pub fn collect_suggestions(raw: &str, issues: &[DIssue]) -> Vec<SearchReplaceWit
     let mut suggestions = issues
         .iter()
         .filter_map(|dissue| {
+            // The expect-missing-exists fix strips a leading `_` from the macro
+            // name in the markdown source. It does not search for the href.
+            if let DIssue::Macros {
+                display_issue,
+                macro_name: Some(macro_name),
+                ..
+            } = dissue
+                && matches!(display_issue.name, IssueType::TemplExpectMissingExists)
+            {
+                return strip_underscore_suggestion(raw, display_issue.line?, macro_name);
+            }
             let (display_issue, href) = match dissue {
                 DIssue::BrokenLink {
                     display_issue,
@@ -419,6 +482,36 @@ fn find_non_prefix_match(raw: &str, line_start_offset: usize, search_text: &str)
 mod tests {
     use super::*;
     use rari_doc::issues::{DisplayIssue, IssueType};
+
+    #[test]
+    fn test_strip_underscore_suggestion_basic() {
+        let raw = "intro\nsee {{_cssxref(\"color\")}} for details\n";
+        let sug = strip_underscore_suggestion(raw, 2, "cssxref").unwrap();
+        assert_eq!(sug.search, "_cssxref");
+        assert_eq!(sug.replace, "cssxref");
+        let fixed = apply_suggestions(raw, &[sug]).unwrap();
+        assert_eq!(fixed, "intro\nsee {{cssxref(\"color\")}} for details\n");
+    }
+
+    #[test]
+    fn test_strip_underscore_suggestion_case_insensitive() {
+        let raw = "{{_CSSxRef(\"color\")}}\n";
+        let sug = strip_underscore_suggestion(raw, 1, "cssxref").unwrap();
+        assert_eq!(sug.search, "_CSSxRef");
+        assert_eq!(sug.replace, "CSSxRef");
+    }
+
+    #[test]
+    fn test_strip_underscore_suggestion_no_match_without_underscore() {
+        let raw = "{{cssxref(\"color\")}}\n";
+        assert!(strip_underscore_suggestion(raw, 1, "cssxref").is_none());
+    }
+
+    #[test]
+    fn test_strip_underscore_suggestion_other_macro_unaffected() {
+        let raw = "{{_domxref(\"Element\")}}\n";
+        assert!(strip_underscore_suggestion(raw, 1, "cssxref").is_none());
+    }
 
     #[test]
     fn test_apply_suggestions_with_duplicate_offsets() {

--- a/crates/rari-tools/src/fix/issues.rs
+++ b/crates/rari-tools/src/fix/issues.rs
@@ -109,14 +109,35 @@ pub struct SearchReplaceWithOffset {
 /// Builds a search/replace suggestion that removes the leading `_` from a
 /// macro invocation like `{{_cssxref("foo")}}` → `{{cssxref("foo")}}`.
 ///
-/// Locates `{{` (optionally followed by whitespace) immediately before a
-/// case-insensitive `_<macro_name>` on the issue's line.
+/// Issue line numbers refer to rendered HTML positions and can drift by a
+/// line or two from the markdown source, so we scan a small window of
+/// nearby lines for `{{` (optionally followed by whitespace) immediately
+/// before a case-insensitive `_<macro_name>`.
 fn strip_underscore_suggestion(
     raw: &str,
     line: i64,
     macro_name: &str,
 ) -> Option<SearchReplaceWithOffset> {
-    let line_idx = (line as usize).saturating_sub(1);
+    const SEARCH_WINDOW: i64 = 5;
+    for delta in 0..=SEARCH_WINDOW {
+        for candidate in [line + delta, line - delta] {
+            if candidate < 1 {
+                continue;
+            }
+            if let Some(s) = strip_underscore_on_line(raw, candidate as usize, macro_name) {
+                return Some(s);
+            }
+        }
+    }
+    None
+}
+
+fn strip_underscore_on_line(
+    raw: &str,
+    line: usize,
+    macro_name: &str,
+) -> Option<SearchReplaceWithOffset> {
+    let line_idx = line.saturating_sub(1);
     let line_start = calculate_line_start_offset(raw, line_idx);
     let line_end = raw[line_start..]
         .find('\n')


### PR DESCRIPTION
### Description

Adds a leading-underscore syntax (`{{_cssxref("foo")}}`) for xref macros to mark links whose target page is intentionally not-yet-created. Missing pages flagged this way no longer emit `templ-broken-link`; if the target later starts resolving, a new `templ-expect-missing-exists` flaw fires and is auto-fixable via `content fix-flaws`.

### Motivation

Authors today have no way to distinguish "this xref is broken" from "this xref points at a page I'm about to add". The first case is a real flaw; the second is noise. Marking the latter explicitly keeps the broken-link signal clean and gives us a way to detect when the placeholder is no longer needed.

### Additional details

- Grammar change in mdn/tree-sitter-mdn#103 (temporary path-dep workaround in 145b5128, to be reverted on release).
- Opt-in per template via `#[rari_f(accepts_expect_missing = true)]`; only `cssxref` is opted in here — follow-ups can extend to the other xref-family templates (`domxref`, `jsxref`, `htmlxref`, …).
- Flaw resolution lives in `RariApi::get_page_internal`, driven by a thread-local set around each template invocation (mirrors the existing `TEMPL_RECORDER` pattern).
- Verified end-to-end against `mdn/content`: existing-page invocations flag and auto-fix, missing-page invocations correctly suppress the broken-link warn.

### Related issues and pull requests

**Depends on:** mdn/tree-sitter-mdn#103