### PR TITLE
fix(templ): accept slug for subpage macros

### DIFF
--- a/crates/rari-doc/src/templ/legacy.rs
+++ b/crates/rari-doc/src/templ/legacy.rs
@@ -1,104 +1,83 @@
-use std::borrow::Cow;
-use std::str::FromStr;
-
 use rari_types::locale::Locale;
-use tracing::warn;
 
-pub fn fix_broken_legacy_url(url: &str, locale: Locale) -> Cow<'_, str> {
-    let first_non_slash = url.find(|c| c != '/').unwrap_or(url.len());
-    let trimmed = &url[first_non_slash..];
-    let maybe_locale = &trimmed[..trimmed.find('/').unwrap_or(trimmed.len())];
-    let parsed_locale = Locale::from_str(maybe_locale);
-    let has_locale = parsed_locale.is_ok();
-    let (has_docs, maybe_without_docs) = if has_locale {
-        let without_locale = trimmed.strip_prefix(maybe_locale).unwrap_or(trimmed);
-        (
-            without_locale.starts_with("/docs/"),
-            without_locale.strip_prefix('/').unwrap_or(without_locale),
-        )
-    } else {
-        (trimmed.starts_with("docs/"), trimmed)
-    };
+use crate::issues::get_issue_counter;
+use crate::pages::page::Page;
 
-    let fixed_url = match (first_non_slash > 0, has_locale, has_docs) {
-        (true, true, true) => Cow::Borrowed(&url[first_non_slash - 1..]),
-        (true, true, false) => Cow::Owned(["", maybe_locale, "docs", maybe_without_docs].join("/")),
-        (false, true, true) => Cow::Owned(["", url].join("/")),
-        (false, true, false) => {
-            Cow::Owned(["", maybe_locale, "docs", maybe_without_docs].join("/"))
-        }
-        (_, false, true) => Cow::Owned(["", locale.as_url_str(), trimmed].join("/")),
-        (_, false, false) => {
-            Cow::Owned(["", locale.as_url_str(), "docs", maybe_without_docs].join("/"))
-        }
-    };
-    if fixed_url != url {
-        warn!("fixed legacy url: {url} -> {fixed_url}");
+/// Normalize a slug or URL argument to `/{locale}/docs/...`. If `input`
+/// already starts with the locale+docs prefix it is returned as-is.
+fn normalize_url(input: &str, locale: Locale) -> String {
+    if input.is_empty() {
+        return String::new();
     }
-    fixed_url
+    let prefix = format!("/{}/docs", locale.as_url_str());
+    if input.starts_with(&prefix) {
+        input.to_string()
+    } else {
+        format!("{prefix}/{}", input.trim_start_matches('/'))
+    }
+}
+
+/// Normalize a slug or URL argument to `/{locale}/docs/...` and verify the
+/// page exists. Returns `None` and emits a `templ-invalid-arg` issue if the
+/// resolved URL does not point to an existing page.
+pub fn normalize_and_check_url_arg(input: &str, locale: Locale) -> Option<String> {
+    let url = normalize_url(input, locale);
+    if Page::from_url_with_fallback(&url).is_err() {
+        let ic = get_issue_counter();
+        tracing::warn!(source = "templ-invalid-arg", ic = ic, arg = url);
+        return None;
+    }
+    Some(url)
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
 
     #[test]
-    fn test_fix_broken_legacy_url() {
+    fn bare_slug_gets_locale_and_docs_prefix() {
         assert_eq!(
-            fix_broken_legacy_url("/en-US/docs/Web", Locale::EnUs),
-            "/en-US/docs/Web"
+            normalize_url("Web/Performance", Locale::EnUs),
+            "/en-US/docs/Web/Performance"
         );
         assert_eq!(
-            fix_broken_legacy_url("/docs/Web", Locale::EnUs),
-            "/en-US/docs/Web"
-        );
-        assert_eq!(
-            fix_broken_legacy_url("/en-US/Web", Locale::EnUs),
-            "/en-US/docs/Web"
-        );
-        assert_eq!(
-            fix_broken_legacy_url("//Web", Locale::EnUs),
-            "/en-US/docs/Web"
-        );
-        assert_eq!(
-            fix_broken_legacy_url("//en-US/Web", Locale::EnUs),
-            "/en-US/docs/Web"
-        );
-        assert_eq!(
-            fix_broken_legacy_url("/Web", Locale::EnUs),
-            "/en-US/docs/Web"
+            normalize_url("Web/Performance", Locale::Fr),
+            "/fr/docs/Web/Performance"
         );
     }
-}
 
-/*
-function repairURL(url) {
-  // Returns a lowercase URI with common irregularities repaired.
-  url = url.trim().toLowerCase();
-  if (!url.startsWith("/")) {
-    // Ensure the URI starts with a "/".
-    url = `/${url}`;
-  }
-  // Remove redundant forward slashes, like "//".
-  url = url.replace(/\/{2,}/g, "/");
-  // Ensure the URI starts with a valid locale.
-  const maybeLocale = url.split("/")[1];
-  if (!isValidLocale(maybeLocale)) {
-    if (maybeLocale === "en") {
-      // Converts URI's like "/en/..." to "/en-us/...".
-      url = url.replace(`/${maybeLocale}`, "/en-us");
-    } else {
-      // Converts URI's like "/web/..." to "/en-us/web/...", or
-      // URI's like "/docs/..." to "/en-us/docs/...".
-      url = `/en-us${url}`;
+    #[test]
+    fn leading_slash_is_stripped_before_prefixing() {
+        assert_eq!(
+            normalize_url("/Web/Performance", Locale::Fr),
+            "/fr/docs/Web/Performance"
+        );
     }
-  }
-  // Ensure the locale is followed by "/docs".
-  const [locale, maybeDocs] = url.split("/").slice(1, 3);
-  if (maybeDocs !== "docs") {
-    // Converts URI's like "/en-us/web/..." to "/en-us/docs/web/...".
-    url = url.replace(`/${locale}`, `/${locale}/docs`);
-  }
-  return url;
+
+    #[test]
+    fn already_prefixed_url_is_returned_as_is() {
+        assert_eq!(
+            normalize_url("/fr/docs/Web/Performance", Locale::Fr),
+            "/fr/docs/Web/Performance"
+        );
+        assert_eq!(
+            normalize_url("/fr/docs/Web/Performance/", Locale::Fr),
+            "/fr/docs/Web/Performance/"
+        );
+    }
+
+    #[test]
+    fn prefix_check_is_locale_specific() {
+        // A `/fr/docs/...` URL processed under en-US is treated as a slug
+        // and gets re-prefixed.
+        assert_eq!(
+            normalize_url("/fr/docs/Web", Locale::EnUs),
+            "/en-US/docs/fr/docs/Web"
+        );
+    }
+
+    #[test]
+    fn empty_input_yields_empty_string() {
+        assert_eq!(normalize_url("", Locale::EnUs), "");
+    }
 }
-*/

--- a/crates/rari-doc/src/templ/templs/list_subpages_for_sidebar.rs
+++ b/crates/rari-doc/src/templ/templs/list_subpages_for_sidebar.rs
@@ -4,8 +4,8 @@ use rari_types::AnyArg;
 use crate::error::DocError;
 use crate::helpers::subpages::{SubPagesSorter, get_sub_pages};
 use crate::html::links::{LinkModifier, render_internal_link};
-use crate::issues::get_issue_counter;
 use crate::pages::page::{Page, PageLike};
+use crate::templ::legacy::normalize_and_check_url_arg;
 use crate::utils::{trim_after, trim_before};
 
 /// List sub pages for sidebar
@@ -18,17 +18,10 @@ pub fn listsubpagesforsidebar(
     title_only_before: Option<String>,
 ) -> Result<String, DocError> {
     let mut out = String::new();
-    let prefix = format!("/{}/docs", env.locale.as_url_str());
-    let url = if url.starts_with(&prefix) {
-        url
-    } else {
-        format!("{prefix}/{}", url.trim_start_matches('/'))
+    let url = match normalize_and_check_url_arg(&url, env.locale) {
+        Some(url) => url,
+        None => return Ok(out),
     };
-    if Page::from_url_with_fallback(&url).is_err() {
-        let ic = get_issue_counter();
-        tracing::warn!(source = "templ-invalid-arg", ic = ic, arg = url);
-        return Ok(out);
-    }
     let include_parent = include_parent.map(|i| i.as_bool()).unwrap_or_default();
     let mut sub_pages = get_sub_pages(&url, Some(1), SubPagesSorter::Title)?;
     if sub_pages.is_empty() && !include_parent {

--- a/crates/rari-doc/src/templ/templs/list_subpages_for_sidebar.rs
+++ b/crates/rari-doc/src/templ/templs/list_subpages_for_sidebar.rs
@@ -4,6 +4,7 @@ use rari_types::AnyArg;
 use crate::error::DocError;
 use crate::helpers::subpages::{SubPagesSorter, get_sub_pages};
 use crate::html::links::{LinkModifier, render_internal_link};
+use crate::issues::get_issue_counter;
 use crate::pages::page::{Page, PageLike};
 use crate::utils::{trim_after, trim_before};
 
@@ -17,6 +18,17 @@ pub fn listsubpagesforsidebar(
     title_only_before: Option<String>,
 ) -> Result<String, DocError> {
     let mut out = String::new();
+    let prefix = format!("/{}/docs", env.locale.as_url_str());
+    let url = if url.starts_with(&prefix) {
+        url
+    } else {
+        format!("{prefix}/{}", url.trim_start_matches('/'))
+    };
+    if Page::from_url_with_fallback(&url).is_err() {
+        let ic = get_issue_counter();
+        tracing::warn!(source = "templ-invalid-arg", ic = ic, arg = url);
+        return Ok(out);
+    }
     let include_parent = include_parent.map(|i| i.as_bool()).unwrap_or_default();
     let mut sub_pages = get_sub_pages(&url, Some(1), SubPagesSorter::Title)?;
     if sub_pages.is_empty() && !include_parent {

--- a/crates/rari-doc/src/templ/templs/quick_links_with_subpages.rs
+++ b/crates/rari-doc/src/templ/templs/quick_links_with_subpages.rs
@@ -3,12 +3,18 @@ use rari_types::{AnyArg, Arg};
 
 use super::listsubpages::listsubpages;
 use crate::error::DocError;
-use crate::templ::legacy::fix_broken_legacy_url;
 
 /// List sub pages
 #[rari_f(register = "crate::Templ")]
 pub fn quicklinkswithsubpages(url: Option<String>) -> Result<String, DocError> {
-    let url = url.map(|s| fix_broken_legacy_url(&s, env.locale).to_string());
+    let prefix = format!("/{}/docs", env.locale.as_url_str());
+    let url = url.map(|s| {
+        if s.starts_with(&prefix) {
+            s
+        } else {
+            format!("{prefix}/{}", s.trim_start_matches('/'))
+        }
+    });
     listsubpages(
         env,
         url,

--- a/crates/rari-doc/src/templ/templs/quick_links_with_subpages.rs
+++ b/crates/rari-doc/src/templ/templs/quick_links_with_subpages.rs
@@ -3,28 +3,18 @@ use rari_types::{AnyArg, Arg};
 
 use super::listsubpages::listsubpages;
 use crate::error::DocError;
-use crate::issues::get_issue_counter;
-use crate::pages::page::Page;
+use crate::templ::legacy::normalize_and_check_url_arg;
 
 /// List sub pages
 #[rari_f(register = "crate::Templ")]
 pub fn quicklinkswithsubpages(url: Option<String>) -> Result<String, DocError> {
-    let prefix = format!("/{}/docs", env.locale.as_url_str());
-    let url = url.map(|s| {
-        if s.starts_with(&prefix) {
-            s
-        } else {
-            format!("{prefix}/{}", s.trim_start_matches('/'))
-        }
-    });
-
-    if let Some(url) = url.as_deref()
-        && Page::from_url_with_fallback(url).is_err()
-    {
-        let ic = get_issue_counter();
-        tracing::warn!(source = "templ-invalid-arg", ic = ic, arg = url);
-        return Ok(String::new());
-    }
+    let url = match url {
+        Some(s) => match normalize_and_check_url_arg(&s, env.locale) {
+            Some(url) => Some(url),
+            None => return Ok(String::new()),
+        },
+        None => None,
+    };
 
     listsubpages(
         env,

--- a/crates/rari-doc/src/templ/templs/quick_links_with_subpages.rs
+++ b/crates/rari-doc/src/templ/templs/quick_links_with_subpages.rs
@@ -3,6 +3,8 @@ use rari_types::{AnyArg, Arg};
 
 use super::listsubpages::listsubpages;
 use crate::error::DocError;
+use crate::issues::get_issue_counter;
+use crate::pages::page::Page;
 
 /// List sub pages
 #[rari_f(register = "crate::Templ")]
@@ -15,6 +17,15 @@ pub fn quicklinkswithsubpages(url: Option<String>) -> Result<String, DocError> {
             format!("{prefix}/{}", s.trim_start_matches('/'))
         }
     });
+
+    if let Some(url) = url.as_deref()
+        && Page::from_url_with_fallback(url).is_err()
+    {
+        let ic = get_issue_counter();
+        tracing::warn!(source = "templ-invalid-arg", ic = ic, arg = url);
+        return Ok(String::new());
+    }
+
     listsubpages(
         env,
         url,


### PR DESCRIPTION


### Description

Updates the `{{QuickLinksWithSubpages}}` and `{{ListSubpagesForSidebar}}` macros to accept a slug (without `/{locale}/docs/` prefix), without triggering a flaw.

### Motivation

Avoid unnecessary flaws (the slug in the context of a locale is not ambiguous).

### Additional details

Previously, this triggered flaws like this:

```
fixed legacy url: Learn/Common_questions -> /es/docs/Learn/Common_questions
```

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1462.

Related to https://github.com/mdn/translated-content/pull/36029.