### PR TITLE
fix(doc): fix links with missing trailing slash

### DIFF
--- a/.github/workflows/_test-content-run.yml
+++ b/.github/workflows/_test-content-run.yml
@@ -69,9 +69,9 @@ jobs:
       - name: Diff content
         if: inputs.diff
         working-directory: content
-        run: git diff --color=always --word-diff --word-diff-regex='[[:alnum:]_/]+'
+        run: git diff --color=always --word-diff --word-diff-regex='[[:alnum:]_]+'
 
       - name: Diff translated-content
         if: inputs.diff && inputs.translated-content
         working-directory: translated-content
-        run: git diff --color=always --word-diff --word-diff-regex='[[:alnum:]_/]+'
+        run: git diff --color=always --word-diff --word-diff-regex='[[:alnum:]_]+'

--- a/.github/workflows/_test-content-run.yml
+++ b/.github/workflows/_test-content-run.yml
@@ -69,9 +69,9 @@ jobs:
       - name: Diff content
         if: inputs.diff
         working-directory: content
-        run: git diff --color=always --word-diff --word-diff-regex='[[:alnum:]_]+'
+        run: git diff --color=always --word-diff --word-diff-regex='[[:alnum:]_/]+'
 
       - name: Diff translated-content
         if: inputs.diff && inputs.translated-content
         working-directory: translated-content
-        run: git diff --color=always --word-diff --word-diff-regex='[[:alnum:]_]+'
+        run: git diff --color=always --word-diff --word-diff-regex='[[:alnum:]_/]+'

--- a/crates/rari-doc/src/html/fix_link.rs
+++ b/crates/rari-doc/src/html/fix_link.rs
@@ -12,6 +12,14 @@ use crate::pages::page::{Page, PageLike};
 use crate::redirects::resolve_redirect;
 use crate::resolve::{strip_locale_from_url, url_with_locale};
 
+fn toggle_trailing_slash(url: &str) -> Option<String> {
+    if let Some(stripped) = url.strip_suffix('/') {
+        (!stripped.is_empty()).then(|| stripped.to_string())
+    } else {
+        Some(concat_strs!(url, "/"))
+    }
+}
+
 pub fn check_and_fix_link(
     el: &mut Element,
     page: &impl PageLike,
@@ -110,6 +118,24 @@ pub fn handle_internal_link(
     } else {
         false
     };
+
+    if !Page::exists_with_fallback(resolved_href_no_hash)
+        && !Page::ignore_link_check(href)
+        && let Some(toggled) = toggle_trailing_slash(resolved_href_no_hash)
+    {
+        let toggled_resolved: Cow<'_, str> =
+            resolve_redirect(&toggled).unwrap_or(Cow::Owned(toggled));
+        if Page::exists_with_fallback(&toggled_resolved) {
+            let new_resolved = if let Some(i) = resolved_href.find('#') {
+                concat_strs!(toggled_resolved.as_ref(), &resolved_href[i..])
+            } else {
+                toggled_resolved.into_owned()
+            };
+            resolved_href = Cow::Owned(new_resolved);
+            resolved_href_no_hash =
+                &resolved_href[..resolved_href.find('#').unwrap_or(resolved_href.len())];
+        }
+    }
 
     let remove_href =
         if !Page::exists_with_fallback(resolved_href_no_hash) && !Page::ignore_link_check(href) {


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Updates the `fix_link` logic to try if toggling the trailing slash resolves the issue.

### Motivation

Make links to Blog posts missing trailing slash auto-fixable.

### Additional details

Example:

```diff
-/en-US/blog/how-to-land-your-first-developer-job
+/en-US/blog/how-to-land-your-first-developer-job/
```

Verified by running `fix-flaws` locally.

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1462.

Fixes https://github.com/mdn/rari/issues/687.