### PR TITLE
ci(build-content-and-diff): include issues in diff

### DIFF
--- a/.github/workflows/build-content-and-diff.yml
+++ b/.github/workflows/build-content-and-diff.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Generate diff
         working-directory: rari-pr
-        run: cargo run -p diff-test diff --fast --html --value --out "$DIFF" --verbose "$BUILD_BASE" "$BUILD_PR"
+        run: cargo run -p diff-test diff --fast --flaws --html --value --out "$DIFF" --verbose "$BUILD_BASE" "$BUILD_PR"
 
       - name: Upload diff
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/build-content-and-diff.yml
+++ b/.github/workflows/build-content-and-diff.yml
@@ -71,14 +71,14 @@ jobs:
         env:
           BUILD_OUT_ROOT: ${{ env.BUILD_BASE }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: cargo run --release build
+        run: cargo run --release build --json-issues
 
       - name: Build with PR
         working-directory: rari-pr
         env:
           BUILD_OUT_ROOT: ${{ env.BUILD_PR }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: cargo run --release build
+        run: cargo run --release build --json-issues
 
       - name: Generate diff
         working-directory: rari-pr


### PR DESCRIPTION
### Description

Extends the `build-content-and-diff` workflow to also diff the issues.

### Motivation

Make it easier to identify impact of changes on issue/flaw reporting, especially when Rari-responsible issues are fixed.

### Additional details

Example:

<img width="1372" height="585" alt="image" src="https://github.com/user-attachments/assets/473a48ed-ae48-4447-a78e-1ebd0a2b8aae" />

### Related issues and pull requests

Blocked by https://github.com/mdn/rari/pull/693.
