### PR TITLE
feat(diff-test): add --flaws option

### DIFF
--- a/crates/diff-test/src/main.rs
+++ b/crates/diff-test/src/main.rs
@@ -161,6 +161,8 @@ struct BuildArgs {
     verbose: bool,
     #[arg(long)]
     sidebars: bool,
+    #[arg(long)]
+    flaws: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -183,7 +185,6 @@ fn is_html(s: &str) -> bool {
 }
 
 const IGNORED_KEYS: &[&str] = &[
-    "doc.flaws",
     "doc.modified",
     "doc.popularity",
     "doc.source.github_url",
@@ -245,6 +246,7 @@ fn full_diff(
     if lhs != rhs {
         if IGNORED_KEYS.iter().any(|i| key.starts_with(i))
             || key == "doc.sidebarHTML" && !args.sidebars
+            || key.starts_with("doc.flaws") && (key.ends_with(".id") || !args.flaws)
         {
             return;
         }


### PR DESCRIPTION
### Description

Extends the `diff-test` command to accept the `--flaws` option to compare the `doc.flaws` field.

### Motivation

Allows identifying flaw-related difference, especially useful for Rari PRs that touch flaw-related code.

### Additional details

Note: We ignore the `doc.flaws.*.id` fields, as they are non-deterministic.

### Related issues and pull requests

Extracted from https://github.com/mdn/rari/pull/690.