### PR TITLE
fix(vscode): run cargo with --locked

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "rust-lang.rust-analyzer"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "rust-analyzer.check.extraArgs": ["--locked"],
+  "rust-analyzer.cargo.extraArgs": ["--locked"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,3 @@
 {
-  "rust-analyzer.check.extraArgs": ["--locked"],
   "rust-analyzer.cargo.extraArgs": ["--locked"]
 }


### PR DESCRIPTION


<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Add VSCode workspace settings for `rust-analyzer`, ensuring that Cargo commands are run with `--locked`.

### Motivation

Prevent rust-analyzer from updating `Cargo.lock` as a side-effect of a newer release being out.

### Additional details

Runnning even just `cargo check` on f6bbec884c907e3ee82c4cf6db27019fcda1198d results in this change:

```diff
diff --git a/Cargo.lock b/Cargo.lock
index 6d785696..eba352ea 100644
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3043,7 +3043,7 @@ version = "2.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0e38781082c53bdde56e6081698c06831f69a27eac2593ed6b6cb2511424ad5"
 dependencies = [
- "quick-xml 0.39.2",
+ "quick-xml 0.39.4",
 ]

 [[package]]
```

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
