### PR TITLE
feat(templ-stats): report unused, translated-only, and invalid templates

### DIFF
--- a/crates/rari-cli/main.rs
+++ b/crates/rari-cli/main.rs
@@ -392,6 +392,8 @@ fn main() -> Result<(), Error> {
                 TEMPL_RECORDER_SENDER
                     .set(tx.clone())
                     .expect("unable to create templ recorder");
+                // `echo` is a test-only template that never appears in real content;
+                // suppress it from every section so it does not show up as unused.
                 const IGNORED: &[&str] = &["echo"];
                 let recorder_handler = spawn(move || {
                     let mut known: HashMap<String, HashMap<Locale, usize>> = HashMap::new();

--- a/crates/rari-cli/main.rs
+++ b/crates/rari-cli/main.rs
@@ -393,37 +393,69 @@ fn main() -> Result<(), Error> {
                     .set(tx.clone())
                     .expect("unable to create templ recorder");
                 let recorder_handler = spawn(move || {
-                    let mut stats: HashMap<String, HashMap<Locale, usize>> = HashMap::new();
+                    let mut known: HashMap<String, HashMap<Locale, usize>> = HashMap::new();
+                    let mut invalid: HashMap<String, HashMap<Locale, usize>> = HashMap::new();
                     while let Ok(event) = rx.recv() {
                         match event {
                             TemplStatEvent::Stop => break,
-                            TemplStatEvent::Record { name, locale } => {
+                            TemplStatEvent::Record {
+                                name,
+                                locale,
+                                known: is_known,
+                            } => {
                                 let name = name.to_lowercase();
-                                *stats.entry(name).or_default().entry(locale).or_insert(0) += 1;
+                                let bucket = if is_known { &mut known } else { &mut invalid };
+                                *bucket.entry(name).or_default().entry(locale).or_insert(0) += 1;
                             }
                         }
                     }
 
-                    let mut out: Vec<(String, usize, HashMap<Locale, usize>)> = stats
-                        .into_iter()
-                        .map(|(name, per_locale)| {
-                            let total: usize = per_locale.values().sum();
-                            (name, total, per_locale)
-                        })
-                        .collect();
-                    out.sort_by(|(_, a, _), (_, b, _)| b.cmp(a));
+                    fn into_sorted(
+                        stats: HashMap<String, HashMap<Locale, usize>>,
+                    ) -> Vec<(String, usize, HashMap<Locale, usize>)> {
+                        let mut out: Vec<_> = stats
+                            .into_iter()
+                            .map(|(name, per_locale)| {
+                                let total: usize = per_locale.values().sum();
+                                (name, total, per_locale)
+                            })
+                            .collect();
+                        out.sort_by(|(_, a, _), (_, b, _)| b.cmp(a));
+                        out
+                    }
 
-                    info!("--- templ summary ---");
+                    let known_sorted = into_sorted(known);
+                    let invalid_sorted = into_sorted(invalid);
+
+                    info!("--- templ summary ({}) ---", known_sorted.len());
                     let mut tw = TabWriter::new(vec![]);
-                    for (i, (templ, count, _)) in out.iter().enumerate() {
+                    for (i, (templ, count, _)) in known_sorted.iter().enumerate() {
                         writeln!(&mut tw, "{:2}\t{templ}\t{count:4}", i + 1)
                             .expect("unable to write");
                     }
                     info!("{}", String::from_utf8_lossy(&tw.into_inner().unwrap()));
 
+                    info!("--- templ invalid ({}) ---", invalid_sorted.len());
+                    let mut tw = TabWriter::new(vec![]);
+                    for (i, (templ, count, per_locale)) in invalid_sorted.iter().enumerate() {
+                        let mut locales: Vec<String> = per_locale
+                            .keys()
+                            .map(|l| l.as_url_str().to_string())
+                            .collect();
+                        locales.sort();
+                        writeln!(
+                            &mut tw,
+                            "{:2}\t{templ}\t{count:4}\t{}",
+                            i + 1,
+                            locales.join(", ")
+                        )
+                        .expect("unable to write");
+                    }
+                    info!("{}", String::from_utf8_lossy(&tw.into_inner().unwrap()));
+
                     if full_build {
                         let seen: std::collections::HashSet<&str> =
-                            out.iter().map(|(n, _, _)| n.as_str()).collect();
+                            known_sorted.iter().map(|(n, _, _)| n.as_str()).collect();
                         let mut unused: Vec<String> = TEMPL_MAP
                             .iter()
                             .map(|t| t.name.replace('-', "_").to_lowercase())
@@ -440,7 +472,8 @@ fn main() -> Result<(), Error> {
 
                     if multi_locale {
                         let mut translated_only: Vec<(&String, &HashMap<Locale, usize>, usize)> =
-                            out.iter()
+                            known_sorted
+                                .iter()
                                 .filter_map(|(name, total, per_locale)| {
                                     if !per_locale.is_empty()
                                         && !per_locale.contains_key(&Locale::EnUs)

--- a/crates/rari-cli/main.rs
+++ b/crates/rari-cli/main.rs
@@ -1,5 +1,5 @@
 use std::borrow::Cow;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fs::{self, File};
 use std::io::{BufWriter, Write};
@@ -460,7 +460,7 @@ fn main() -> Result<(), Error> {
                     info!("{}", String::from_utf8_lossy(&tw.into_inner().unwrap()));
 
                     if full_build {
-                        let seen: std::collections::HashSet<&str> =
+                        let seen: HashSet<&str> =
                             known_sorted.iter().map(|(n, _, _)| n.as_str()).collect();
                         let mut unused: Vec<String> = TEMPL_MAP
                             .iter()

--- a/crates/rari-cli/main.rs
+++ b/crates/rari-cli/main.rs
@@ -297,6 +297,32 @@ fn clear_dependencies_last_checked(base_path: &Path) {
     }
 }
 
+/// Applies one `TemplStatEvent` to the running `known`/`invalid` aggregates.
+///
+/// Returns `false` for `Stop`, signalling the receive loop to terminate.
+fn ingest_templ_event(
+    event: TemplStatEvent,
+    known: &mut HashMap<String, HashMap<Locale, usize>>,
+    invalid: &mut HashMap<String, HashMap<Locale, usize>>,
+    ignored: &[&str],
+) -> bool {
+    match event {
+        TemplStatEvent::Stop => return false,
+        TemplStatEvent::Record {
+            name,
+            locale,
+            known: is_known,
+        } => {
+            let name = name.to_lowercase();
+            if !ignored.contains(&name.as_str()) {
+                let bucket = if is_known { known } else { invalid };
+                *bucket.entry(name).or_default().entry(locale).or_insert(0) += 1;
+            }
+        }
+    }
+    true
+}
+
 fn into_sorted_templ_stats(
     stats: HashMap<String, HashMap<Locale, usize>>,
 ) -> Vec<(String, usize, HashMap<Locale, usize>)> {
@@ -437,20 +463,8 @@ fn main() -> Result<(), Error> {
                     let mut known: HashMap<String, HashMap<Locale, usize>> = HashMap::new();
                     let mut invalid: HashMap<String, HashMap<Locale, usize>> = HashMap::new();
                     while let Ok(event) = rx.recv() {
-                        match event {
-                            TemplStatEvent::Stop => break,
-                            TemplStatEvent::Record {
-                                name,
-                                locale,
-                                known: is_known,
-                            } => {
-                                let name = name.to_lowercase();
-                                if IGNORED.contains(&name.as_str()) {
-                                    continue;
-                                }
-                                let bucket = if is_known { &mut known } else { &mut invalid };
-                                *bucket.entry(name).or_default().entry(locale).or_insert(0) += 1;
-                            }
+                        if !ingest_templ_event(event, &mut known, &mut invalid, IGNORED) {
+                            break;
                         }
                     }
 

--- a/crates/rari-cli/main.rs
+++ b/crates/rari-cli/main.rs
@@ -483,13 +483,8 @@ fn main() -> Result<(), Error> {
                             known_sorted
                                 .iter()
                                 .filter_map(|(name, total, per_locale)| {
-                                    if !per_locale.is_empty()
-                                        && !per_locale.contains_key(&Locale::EnUs)
-                                    {
-                                        Some((name, per_locale, *total))
-                                    } else {
-                                        None
-                                    }
+                                    (!per_locale.contains_key(&Locale::EnUs))
+                                        .then_some((name, per_locale, *total))
                                 })
                                 .collect();
                         translated_only.sort_by(|(_, _, a), (_, _, b)| b.cmp(a));

--- a/crates/rari-cli/main.rs
+++ b/crates/rari-cli/main.rs
@@ -307,7 +307,9 @@ fn into_sorted_templ_stats(
             (name, total, per_locale)
         })
         .collect();
-    out.sort_by(|(_, a, _), (_, b, _)| b.cmp(a));
+    out.sort_by(|(a_name, a_total, _), (b_name, b_total, _)| {
+        b_total.cmp(a_total).then_with(|| a_name.cmp(b_name))
+    });
     out
 }
 
@@ -487,7 +489,9 @@ fn main() -> Result<(), Error> {
                                         .then_some((name, per_locale, *total))
                                 })
                                 .collect();
-                        translated_only.sort_by(|(_, _, a), (_, _, b)| b.cmp(a));
+                        translated_only.sort_by(|(a_name, _, a_total), (b_name, _, b_total)| {
+                            b_total.cmp(a_total).then_with(|| a_name.cmp(b_name))
+                        });
                         info!("--- templ translated-only ({}) ---", translated_only.len());
                         let mut tw = TabWriter::new(vec![]);
                         for (i, (name, per_locale, total)) in translated_only.iter().enumerate() {

--- a/crates/rari-cli/main.rs
+++ b/crates/rari-cli/main.rs
@@ -392,6 +392,7 @@ fn main() -> Result<(), Error> {
                 TEMPL_RECORDER_SENDER
                     .set(tx.clone())
                     .expect("unable to create templ recorder");
+                const IGNORED: &[&str] = &["echo"];
                 let recorder_handler = spawn(move || {
                     let mut known: HashMap<String, HashMap<Locale, usize>> = HashMap::new();
                     let mut invalid: HashMap<String, HashMap<Locale, usize>> = HashMap::new();
@@ -404,6 +405,9 @@ fn main() -> Result<(), Error> {
                                 known: is_known,
                             } => {
                                 let name = name.to_lowercase();
+                                if IGNORED.contains(&name.as_str()) {
+                                    continue;
+                                }
                                 let bucket = if is_known { &mut known } else { &mut invalid };
                                 *bucket.entry(name).or_default().entry(locale).or_insert(0) += 1;
                             }
@@ -459,7 +463,9 @@ fn main() -> Result<(), Error> {
                         let mut unused: Vec<String> = TEMPL_MAP
                             .iter()
                             .map(|t| t.name.replace('-', "_").to_lowercase())
-                            .filter(|n| !seen.contains(n.as_str()))
+                            .filter(|n| {
+                                !seen.contains(n.as_str()) && !IGNORED.contains(&n.as_str())
+                            })
                             .collect();
                         unused.sort();
                         info!("--- templ unused ({}) ---", unused.len());

--- a/crates/rari-cli/main.rs
+++ b/crates/rari-cli/main.rs
@@ -29,7 +29,8 @@ use rari_doc::pages::page::Page;
 use rari_doc::pages::types::doc::Doc;
 use rari_doc::reader::read_docs_parallel;
 use rari_doc::search_index::build_search_index;
-use rari_doc::utils::{TEMPL_RECORDER_SENDER, locale_and_typ_from_path};
+use rari_doc::templ::templs::TEMPL_MAP;
+use rari_doc::utils::{TEMPL_RECORDER_SENDER, TemplStatEvent, locale_and_typ_from_path};
 use rari_sitemap::Sitemaps;
 use rari_tools::add_redirect::add_redirect;
 use rari_tools::fix::fixer::fix_all;
@@ -382,33 +383,93 @@ fn main() -> Result<(), Error> {
                 );
             }
 
+            let full_build = arg_files.is_empty()
+                && (args.all || args.all_available || !args.no_basic || args.content);
+            let multi_locale = full_build && content_translated_root().is_some();
+
             let templ_stats = if args.templ_stats {
-                let (tx, rx) = channel::<String>();
+                let (tx, rx) = channel::<TemplStatEvent>();
                 TEMPL_RECORDER_SENDER
                     .set(tx.clone())
                     .expect("unable to create templ recorder");
                 let recorder_handler = spawn(move || {
-                    let mut stats = HashMap::new();
-                    while let Ok(t) = rx.recv() {
-                        if t == "∞" {
-                            break;
-                        }
-                        let t = t.to_lowercase();
-                        if let Some(n) = stats.get_mut(&t) {
-                            *n += 1usize;
-                        } else {
-                            stats.insert(t, 1usize);
+                    let mut stats: HashMap<String, HashMap<Locale, usize>> = HashMap::new();
+                    while let Ok(event) = rx.recv() {
+                        match event {
+                            TemplStatEvent::Stop => break,
+                            TemplStatEvent::Record { name, locale } => {
+                                let name = name.to_lowercase();
+                                *stats.entry(name).or_default().entry(locale).or_insert(0) += 1;
+                            }
                         }
                     }
-                    let mut out = stats.into_iter().collect::<Vec<(String, usize)>>();
-                    out.sort_by(|(_, a), (_, b)| b.cmp(a));
+
+                    let mut out: Vec<(String, usize, HashMap<Locale, usize>)> = stats
+                        .into_iter()
+                        .map(|(name, per_locale)| {
+                            let total: usize = per_locale.values().sum();
+                            (name, total, per_locale)
+                        })
+                        .collect();
+                    out.sort_by(|(_, a, _), (_, b, _)| b.cmp(a));
+
                     info!("--- templ summary ---");
                     let mut tw = TabWriter::new(vec![]);
-                    for (i, (templ, count)) in out.iter().enumerate() {
+                    for (i, (templ, count, _)) in out.iter().enumerate() {
                         writeln!(&mut tw, "{:2}\t{templ}\t{count:4}", i + 1)
                             .expect("unable to write");
                     }
                     info!("{}", String::from_utf8_lossy(&tw.into_inner().unwrap()));
+
+                    if full_build {
+                        let seen: std::collections::HashSet<&str> =
+                            out.iter().map(|(n, _, _)| n.as_str()).collect();
+                        let mut unused: Vec<String> = TEMPL_MAP
+                            .iter()
+                            .map(|t| t.name.replace('-', "_").to_lowercase())
+                            .filter(|n| !seen.contains(n.as_str()))
+                            .collect();
+                        unused.sort();
+                        info!("--- templ unused ({}) ---", unused.len());
+                        let mut tw = TabWriter::new(vec![]);
+                        for (i, name) in unused.iter().enumerate() {
+                            writeln!(&mut tw, "{:2}\t{name}", i + 1).expect("unable to write");
+                        }
+                        info!("{}", String::from_utf8_lossy(&tw.into_inner().unwrap()));
+                    }
+
+                    if multi_locale {
+                        let mut translated_only: Vec<(&String, &HashMap<Locale, usize>, usize)> =
+                            out.iter()
+                                .filter_map(|(name, total, per_locale)| {
+                                    if !per_locale.is_empty()
+                                        && !per_locale.contains_key(&Locale::EnUs)
+                                    {
+                                        Some((name, per_locale, *total))
+                                    } else {
+                                        None
+                                    }
+                                })
+                                .collect();
+                        translated_only.sort_by(|(_, _, a), (_, _, b)| b.cmp(a));
+                        info!("--- templ translated-only ({}) ---", translated_only.len());
+                        let mut tw = TabWriter::new(vec![]);
+                        for (i, (name, per_locale, total)) in translated_only.iter().enumerate() {
+                            let mut locales: Vec<String> = per_locale
+                                .keys()
+                                .map(|l| l.as_url_str().to_string())
+                                .collect();
+                            locales.sort();
+                            writeln!(
+                                &mut tw,
+                                "{:2}\t{name}\t{total:4}\t{}",
+                                i + 1,
+                                locales.join(", ")
+                            )
+                            .expect("unable to write");
+                        }
+                        info!("{}", String::from_utf8_lossy(&tw.into_inner().unwrap()));
+                    }
                 });
                 Some((recorder_handler, tx))
             } else {
@@ -535,7 +596,7 @@ fn main() -> Result<(), Error> {
                 );
             }
             if let Some((recorder_handler, tx)) = templ_stats {
-                tx.send("∞".to_string())?;
+                tx.send(TemplStatEvent::Stop)?;
                 recorder_handler
                     .join()
                     .expect("unable to close templ recorder");

--- a/crates/rari-cli/main.rs
+++ b/crates/rari-cli/main.rs
@@ -313,6 +313,28 @@ fn into_sorted_templ_stats(
     out
 }
 
+fn print_templ_locales_section<'a, I>(label: &str, rows: I)
+where
+    I: IntoIterator<Item = (&'a str, usize, &'a HashMap<Locale, usize>)>,
+    I::IntoIter: ExactSizeIterator,
+{
+    let rows = rows.into_iter();
+    info!("--- {label} ({}) ---", rows.len());
+    let mut tw = TabWriter::new(vec![]);
+    for (i, (name, count, per_locale)) in rows.enumerate() {
+        let mut locales: Vec<&str> = per_locale.keys().map(|l| l.as_url_str()).collect();
+        locales.sort();
+        writeln!(
+            &mut tw,
+            "{:2}\t{name}\t{count:4}\t{}",
+            i + 1,
+            locales.join(", ")
+        )
+        .expect("unable to write");
+    }
+    info!("{}", String::from_utf8_lossy(&tw.into_inner().unwrap()));
+}
+
 fn main() -> Result<(), Error> {
     if let Ok(env_file) = dotenvy::from_filename(
         env::var("DOT_FILE")
@@ -443,23 +465,12 @@ fn main() -> Result<(), Error> {
                     }
                     info!("{}", String::from_utf8_lossy(&tw.into_inner().unwrap()));
 
-                    info!("--- templ invalid ({}) ---", invalid_sorted.len());
-                    let mut tw = TabWriter::new(vec![]);
-                    for (i, (templ, count, per_locale)) in invalid_sorted.iter().enumerate() {
-                        let mut locales: Vec<String> = per_locale
-                            .keys()
-                            .map(|l| l.as_url_str().to_string())
-                            .collect();
-                        locales.sort();
-                        writeln!(
-                            &mut tw,
-                            "{:2}\t{templ}\t{count:4}\t{}",
-                            i + 1,
-                            locales.join(", ")
-                        )
-                        .expect("unable to write");
-                    }
-                    info!("{}", String::from_utf8_lossy(&tw.into_inner().unwrap()));
+                    print_templ_locales_section(
+                        "templ invalid",
+                        invalid_sorted
+                            .iter()
+                            .map(|(name, count, per_locale)| (name.as_str(), *count, per_locale)),
+                    );
 
                     if full_build {
                         let seen: HashSet<&str> =
@@ -481,34 +492,24 @@ fn main() -> Result<(), Error> {
                     }
 
                     if multi_locale {
-                        let mut translated_only: Vec<(&String, &HashMap<Locale, usize>, usize)> =
+                        let mut translated_only: Vec<(&str, usize, &HashMap<Locale, usize>)> =
                             known_sorted
                                 .iter()
                                 .filter_map(|(name, total, per_locale)| {
-                                    (!per_locale.contains_key(&Locale::EnUs))
-                                        .then_some((name, per_locale, *total))
+                                    (!per_locale.contains_key(&Locale::EnUs)).then_some((
+                                        name.as_str(),
+                                        *total,
+                                        per_locale,
+                                    ))
                                 })
                                 .collect();
-                        translated_only.sort_by(|(a_name, _, a_total), (b_name, _, b_total)| {
+                        translated_only.sort_by(|(a_name, a_total, _), (b_name, b_total, _)| {
                             b_total.cmp(a_total).then_with(|| a_name.cmp(b_name))
                         });
-                        info!("--- templ translated-only ({}) ---", translated_only.len());
-                        let mut tw = TabWriter::new(vec![]);
-                        for (i, (name, per_locale, total)) in translated_only.iter().enumerate() {
-                            let mut locales: Vec<String> = per_locale
-                                .keys()
-                                .map(|l| l.as_url_str().to_string())
-                                .collect();
-                            locales.sort();
-                            writeln!(
-                                &mut tw,
-                                "{:2}\t{name}\t{total:4}\t{}",
-                                i + 1,
-                                locales.join(", ")
-                            )
-                            .expect("unable to write");
-                        }
-                        info!("{}", String::from_utf8_lossy(&tw.into_inner().unwrap()));
+                        print_templ_locales_section(
+                            "templ translated-only",
+                            translated_only.iter().copied(),
+                        );
                     }
                 });
                 Some((recorder_handler, tx))

--- a/crates/rari-cli/main.rs
+++ b/crates/rari-cli/main.rs
@@ -297,6 +297,20 @@ fn clear_dependencies_last_checked(base_path: &Path) {
     }
 }
 
+fn into_sorted_templ_stats(
+    stats: HashMap<String, HashMap<Locale, usize>>,
+) -> Vec<(String, usize, HashMap<Locale, usize>)> {
+    let mut out: Vec<_> = stats
+        .into_iter()
+        .map(|(name, per_locale)| {
+            let total: usize = per_locale.values().sum();
+            (name, total, per_locale)
+        })
+        .collect();
+    out.sort_by(|(_, a, _), (_, b, _)| b.cmp(a));
+    out
+}
+
 fn main() -> Result<(), Error> {
     if let Ok(env_file) = dotenvy::from_filename(
         env::var("DOT_FILE")
@@ -416,22 +430,8 @@ fn main() -> Result<(), Error> {
                         }
                     }
 
-                    fn into_sorted(
-                        stats: HashMap<String, HashMap<Locale, usize>>,
-                    ) -> Vec<(String, usize, HashMap<Locale, usize>)> {
-                        let mut out: Vec<_> = stats
-                            .into_iter()
-                            .map(|(name, per_locale)| {
-                                let total: usize = per_locale.values().sum();
-                                (name, total, per_locale)
-                            })
-                            .collect();
-                        out.sort_by(|(_, a, _), (_, b, _)| b.cmp(a));
-                        out
-                    }
-
-                    let known_sorted = into_sorted(known);
-                    let invalid_sorted = into_sorted(invalid);
+                    let known_sorted = into_sorted_templ_stats(known);
+                    let invalid_sorted = into_sorted_templ_stats(invalid);
 
                     info!("--- templ summary ({}) ---", known_sorted.len());
                     let mut tw = TabWriter::new(vec![]);

--- a/crates/rari-cli/main.rs
+++ b/crates/rari-cli/main.rs
@@ -967,3 +967,99 @@ fn update(version: Option<String>) -> Result<(), Error> {
     info!("\n\nrari updated to `{}`", status.version());
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn record(name: &str, locale: Locale, known: bool) -> TemplStatEvent {
+        TemplStatEvent::Record {
+            name: name.to_string(),
+            locale,
+            known,
+        }
+    }
+
+    #[test]
+    fn ingest_templ_event_routes_known_and_invalid() {
+        let mut known = HashMap::new();
+        let mut invalid = HashMap::new();
+        assert!(ingest_templ_event(
+            record("Compat", Locale::EnUs, true),
+            &mut known,
+            &mut invalid,
+            &[],
+        ));
+        assert!(ingest_templ_event(
+            record("typo_macro", Locale::Fr, false),
+            &mut known,
+            &mut invalid,
+            &[],
+        ));
+        assert_eq!(known["compat"][&Locale::EnUs], 1);
+        assert_eq!(invalid["typo_macro"][&Locale::Fr], 1);
+        assert!(!known.contains_key("typo_macro"));
+        assert!(!invalid.contains_key("compat"));
+    }
+
+    #[test]
+    fn ingest_templ_event_lowercases_and_accumulates_per_locale() {
+        let mut known = HashMap::new();
+        let mut invalid = HashMap::new();
+        for event in [
+            record("CSSxRef", Locale::EnUs, true),
+            record("cssxref", Locale::EnUs, true),
+            record("CSSXREF", Locale::Fr, true),
+        ] {
+            ingest_templ_event(event, &mut known, &mut invalid, &[]);
+        }
+        assert_eq!(known["cssxref"][&Locale::EnUs], 2);
+        assert_eq!(known["cssxref"][&Locale::Fr], 1);
+        assert!(invalid.is_empty());
+    }
+
+    #[test]
+    fn ingest_templ_event_skips_ignored_names() {
+        let mut known = HashMap::new();
+        let mut invalid = HashMap::new();
+        ingest_templ_event(
+            record("Echo", Locale::EnUs, true),
+            &mut known,
+            &mut invalid,
+            &["echo"],
+        );
+        assert!(known.is_empty());
+        assert!(invalid.is_empty());
+    }
+
+    #[test]
+    fn ingest_templ_event_returns_false_on_stop() {
+        let mut known = HashMap::new();
+        let mut invalid = HashMap::new();
+        assert!(!ingest_templ_event(
+            TemplStatEvent::Stop,
+            &mut known,
+            &mut invalid,
+            &[],
+        ));
+    }
+
+    #[test]
+    fn into_sorted_templ_stats_orders_by_count_then_name() {
+        let mut stats: HashMap<String, HashMap<Locale, usize>> = HashMap::new();
+        stats.insert("zeta".into(), HashMap::from([(Locale::EnUs, 3)]));
+        stats.insert("alpha".into(), HashMap::from([(Locale::EnUs, 5)]));
+        stats.insert("beta".into(), HashMap::from([(Locale::EnUs, 5)]));
+        stats.insert(
+            "gamma".into(),
+            HashMap::from([(Locale::EnUs, 2), (Locale::Fr, 1)]),
+        );
+
+        let sorted = into_sorted_templ_stats(stats);
+        let names: Vec<&str> = sorted.iter().map(|(n, _, _)| n.as_str()).collect();
+        let totals: Vec<usize> = sorted.iter().map(|(_, t, _)| *t).collect();
+
+        assert_eq!(names, ["alpha", "beta", "gamma", "zeta"]);
+        assert_eq!(totals, [5, 5, 3, 3]);
+    }
+}

--- a/crates/rari-doc/src/templ/templs/mod.rs
+++ b/crates/rari-doc/src/templ/templs/mod.rs
@@ -61,12 +61,13 @@ pub fn exists(name: &str) -> bool {
     TEMPL_MAPPING.contains_key(name)
 }
 
-fn record_invocation(name: &str, locale: rari_types::locale::Locale) {
+fn record_invocation(name: &str, locale: rari_types::locale::Locale, known: bool) {
     TEMPL_RECORDER.with(|tx| {
         if let Some(tx) = tx
             && let Err(e) = tx.send(TemplStatEvent::Record {
                 name: name.to_string(),
                 locale,
+                known,
             })
         {
             error!("templ recorder: {e}");
@@ -85,11 +86,11 @@ pub fn invoke(
         None if name == "xulelem" => return Ok((Default::default(), TemplType::None)),
         None if deny_warnings() => return Err(DocError::UnknownMacro(name.to_string())),
         None => {
-            record_invocation(&name, env.locale);
+            record_invocation(&name, env.locale, false);
             return Ok((format!("<s>unsupported templ: {name}</s>"), TemplType::None));
         } //
     };
-    record_invocation(&name, env.locale);
+    record_invocation(&name, env.locale, true);
     f(env, args).map(|s| (s, is_sidebar))
 }
 

--- a/crates/rari-doc/src/templ/templs/mod.rs
+++ b/crates/rari-doc/src/templ/templs/mod.rs
@@ -61,11 +61,11 @@ pub fn exists(name: &str) -> bool {
     TEMPL_MAPPING.contains_key(name)
 }
 
-fn record_invocation(name: &str, locale: rari_types::locale::Locale, known: bool) {
+fn record_invocation(name: String, locale: rari_types::locale::Locale, known: bool) {
     TEMPL_RECORDER.with(|tx| {
         if let Some(tx) = tx
             && let Err(e) = tx.send(TemplStatEvent::Record {
-                name: name.to_string(),
+                name,
                 locale,
                 known,
             })
@@ -86,11 +86,12 @@ pub fn invoke(
         None if name == "xulelem" => return Ok((Default::default(), TemplType::None)),
         None if deny_warnings() => return Err(DocError::UnknownMacro(name.to_string())),
         None => {
-            record_invocation(&name, env.locale, false);
-            return Ok((format!("<s>unsupported templ: {name}</s>"), TemplType::None));
+            let rendered = format!("<s>unsupported templ: {name}</s>");
+            record_invocation(name, env.locale, false);
+            return Ok((rendered, TemplType::None));
         } //
     };
-    record_invocation(&name, env.locale, true);
+    record_invocation(name, env.locale, true);
     f(env, args).map(|s| (s, is_sidebar))
 }
 

--- a/crates/rari-doc/src/templ/templs/mod.rs
+++ b/crates/rari-doc/src/templ/templs/mod.rs
@@ -36,7 +36,7 @@ use rari_types::{Arg, RariEnv};
 use tracing::error;
 
 use crate::error::DocError;
-use crate::utils::TEMPL_RECORDER;
+use crate::utils::{TEMPL_RECORDER, TemplStatEvent};
 
 #[derive(Debug)]
 pub struct Templ {
@@ -61,6 +61,19 @@ pub fn exists(name: &str) -> bool {
     TEMPL_MAPPING.contains_key(name)
 }
 
+fn record_invocation(name: &str, locale: rari_types::locale::Locale) {
+    TEMPL_RECORDER.with(|tx| {
+        if let Some(tx) = tx
+            && let Err(e) = tx.send(TemplStatEvent::Record {
+                name: name.to_string(),
+                locale,
+            })
+        {
+            error!("templ recorder: {e}");
+        }
+    });
+}
+
 pub fn invoke(
     env: &RariEnv,
     name: &str,
@@ -72,16 +85,11 @@ pub fn invoke(
         None if name == "xulelem" => return Ok((Default::default(), TemplType::None)),
         None if deny_warnings() => return Err(DocError::UnknownMacro(name.to_string())),
         None => {
-            TEMPL_RECORDER.with(|tx| {
-                if let Some(tx) = tx
-                    && let Err(e) = tx.send(name.to_string())
-                {
-                    error!("templ recorder: {e}");
-                }
-            });
+            record_invocation(&name, env.locale);
             return Ok((format!("<s>unsupported templ: {name}</s>"), TemplType::None));
         } //
     };
+    record_invocation(&name, env.locale);
     f(env, args).map(|s| (s, is_sidebar))
 }
 

--- a/crates/rari-doc/src/utils.rs
+++ b/crates/rari-doc/src/utils.rs
@@ -393,9 +393,15 @@ thread_local! {
     };
 }
 
-pub static TEMPL_RECORDER_SENDER: OnceLock<Sender<String>> = OnceLock::new();
+#[derive(Debug)]
+pub enum TemplStatEvent {
+    Record { name: String, locale: Locale },
+    Stop,
+}
+
+pub static TEMPL_RECORDER_SENDER: OnceLock<Sender<TemplStatEvent>> = OnceLock::new();
 thread_local! {
-    pub static TEMPL_RECORDER: Option<Sender<String>> = {
+    pub static TEMPL_RECORDER: Option<Sender<TemplStatEvent>> = {
         TEMPL_RECORDER_SENDER.get().cloned()
     };
 }

--- a/crates/rari-doc/src/utils.rs
+++ b/crates/rari-doc/src/utils.rs
@@ -395,7 +395,11 @@ thread_local! {
 
 #[derive(Debug)]
 pub enum TemplStatEvent {
-    Record { name: String, locale: Locale },
+    Record {
+        name: String,
+        locale: Locale,
+        known: bool,
+    },
     Stop,
 }
 


### PR DESCRIPTION
### Description

Extend `--templ-stats` with three new sections on full builds:

- Invalid templates: macro calls whose name is not registered in `TEMPL_MAP` (parser artifacts, typos, removed macros), shown with per-locale counts.
- Unused templates: registered via `inventory` but never invoked.
- Translated-only templates: invoked in translated locales but never in en-US — deprecation candidates in `translated-content`.

### Motivation

Make it easy to identify macros that can be fixed (broken/typoed calls), removed (no longer used), or deprecated (no longer used in en-US).

### Additional details

The recorder now captures every invocation along with the invoking locale and a `known` flag via a new `TemplStatEvent` enum. The unused and invalid sections print when a full build was requested (no per-file filter); the translated-only section additionally requires `content_translated_root` to be configured. The `echo` template is suppressed from every section because it only exists for testing.

Example run:

```
% cargo run build --templ-stats
   Compiling rari-doc v0.2.23 (/Users/claas/github/mdn/rari/crates/rari-doc)
   Compiling rari-tools v0.2.23 (/Users/claas/github/mdn/rari/crates/rari-tools)
   Compiling rari-sitemap v0.2.23 (/Users/claas/github/mdn/rari/crates/rari-sitemap)
   Compiling rari-lsp v0.2.23 (/Users/claas/github/mdn/rari/crates/rari-lsp)
   Compiling rari v0.2.23 (/Users/claas/github/mdn/rari)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 19.58s
     Running `target/debug/rari build --templ-stats`
Building everything 🛠️
Took:     3.578s for reading 50984 docs
Took:  523.444ms to build spas (118)
Took:   221.890s to build content docs (50984)
Took:  285.614ms to build search index
--- templ summary (77) ---
 1  domxref                  178392
 2  cssxref                  87858
 3  jsxref                   72693
 4  htmlelement              47259
 5  compat                   36704
 6  specifications           34892
 7  glossary                 23939
 8  apiref                   20161
 9  embedlivesample          17166
10  readonlyinline           11324
11  httpheader               11046
12  svgelement               9879
13  optional_inline          9656
14  svgattr                  8139
15  webextapiref             7451
16  interactiveexample       6442
17  cssref                   5851
18  jsref                    5091
19  deprecated_inline        4927
20  experimental_inline      4916
21  glossarysidebar          3813
22  availableinworkers       3813
23  seecompattable           3635
24  csssyntax                3347
25  non_standard_inline      2850
26  securecontext_header     2685
27  cssinfo                  2663
28  httpstatus               2522
29  previousmenunext         2384
30  addonsidebar             2255
31  inheritancediagram       2071
32  jssidebar                1971
33  httpmethod               1893
34  learnsidebar             1891
35  webextexamples           1764
36  htmlsidebar              1651
37  deprecated_header        1606
38  defaultapisidebar        1522
39  mathmlelement            1404
40  non_standard_header      1244
41  rfc                      1210
42  embedghlivesample        1157
43  previousnext             1078
44  svgref                   1007
45  csp                       750
46  accessibilitysidebar      573
47  nextmenu                  464
48  webassemblysidebar        445
49  js_property_attributes    406
50  mdnsidebar                387
51  securecontext_inline      368
52  svginfo                   304
53  quicklinkswithsubpages    228
54  previousmenu              212
55  mathmlref                 200
56  pwasidebar                193
57  xsltsidebar               191
58  subpageswithsummaries     181
59  firefox_for_developers    173
60  csssyntaxraw              124
61  jsfiddleembed             103
62  embedyoutube              101
63  next                       78
64  listsubpages               64
65  listsubpagesforsidebar     61
66  livesamplelink             59
67  previous                   55
68  glossarydisambiguation     55
69  landingpagelistsubpages    50
70  listgroups                 10
71  apilistalpha                9
72  webextallexamples           8
73  css_ref                     8
74  experimentalbadge           5
75  addonsidebarmain            5
76  webextallcompattables       5
77  xsltref                     1

--- templ invalid (2) ---
 1  embedinteractiveexample     2  es, zh-CN
 2  jsxref(「reflect.           1  ja

--- templ unused (4) ---
 1  firefoxsidebar
 2  gamessidebar
 3  httpsidebar
 4  non_standardbage

--- templ translated-only (8) ---
 1  quicklinkswithsubpages    228  es, fr, ja, ko, pt-BR, ru, zh-TW
 2  xsltsidebar               191  es, fr, ja, ko, ru
 3  firefox_for_developers    173  es, fr, ja, pt-BR, ru, zh-CN, zh-TW
 4  jsfiddleembed             103  es, ja, ko, ru, zh-CN
 5  listsubpagesforsidebar     61  es, fr, ja, ko, pt-BR
 6  landingpagelistsubpages    50  es, fr, ja, ko, pt-BR, ru, zh-CN, zh-TW
 7  experimentalbadge           5  fr
 8  xsltref                     1  fr

Found 24681 issues in 7793 of 51102 files
  en-US: 1111 issues in 445 files
  es: 4127 issues in 927 files
  fr: 2840 issues in 947 files
  ja: 1917 issues in 791 files
  ko: 2907 issues in 1239 files
  pt-BR: 2656 issues in 713 files
  ru: 3950 issues in 1004 files
  zh-CN: 4508 issues in 1538 files
  zh-TW: 665 issues in 189 files
```

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
