### PR TITLE
feat(cli): accept positional FILES on build, deprecate -f/--files

### DIFF
--- a/crates/rari-cli/main.rs
+++ b/crates/rari-cli/main.rs
@@ -198,8 +198,16 @@ struct ServeArgs {
 
 #[derive(Args)]
 struct BuildArgs {
-    #[arg(short, long, help = "Build only content <FILES>")]
+    #[arg(value_name = "FILES", help = "Build only these content files")]
     files: Vec<PathBuf>,
+    #[arg(
+        short = 'f',
+        long = "files",
+        value_name = "FILES",
+        hide = true,
+        help = "[deprecated] pass file paths as positional arguments instead"
+    )]
+    files_flag: Vec<PathBuf>,
     #[arg(long, help = "Build only content listed in <FILE_LIST>")]
     file_list: Option<PathBuf>,
     #[arg(short, long, help = "Abort build on warnings")]
@@ -366,9 +374,15 @@ fn main() -> Result<(), Error> {
             settings.json_live_samples = args.json_live_samples;
             let _ = SETTINGS.set(settings);
 
+            if !args.files_flag.is_empty() {
+                tracing::warn!(
+                    "`-f`/`--files` is deprecated; pass file paths as positional arguments instead"
+                );
+            }
             let mut arg_files = args
                 .files
                 .iter()
+                .chain(args.files_flag.iter())
                 .map(|path| path.canonicalize())
                 .collect::<Result<Vec<PathBuf>, _>>()?;
 

--- a/crates/rari-cli/main.rs
+++ b/crates/rari-cli/main.rs
@@ -205,6 +205,7 @@ struct BuildArgs {
         long = "files",
         value_name = "FILES",
         hide = true,
+        conflicts_with = "files",
         help = "DEPRECATED: pass file paths as positional arguments instead"
     )]
     files_flag: Vec<PathBuf>,

--- a/crates/rari-cli/main.rs
+++ b/crates/rari-cli/main.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use std::sync::mpsc::channel;
 use std::thread::spawn;
 
-use anyhow::{Context, Error, anyhow};
+use anyhow::{Error, anyhow};
 use clap::{Args, Parser, Subcommand};
 use clap_verbosity_flag::Verbosity;
 use dashmap::DashMap;
@@ -386,17 +386,25 @@ fn main() -> Result<(), Error> {
                 .iter()
                 .chain(args.files_flag.iter())
                 .map(|path| {
-                    path.canonicalize()
-                        .with_context(|| path.display().to_string())
+                    path.canonicalize().map_err(|e| {
+                        let msg = e.to_string();
+                        let trimmed = msg.split(" (os error").next().unwrap_or(&msg);
+                        anyhow!("{}: {}", path.display(), trimmed)
+                    })
                 })
                 .partition(Result::is_ok);
             if !errs.is_empty() {
+                let header = if errs.len() == 1 {
+                    "<FILES> contains an invalid value"
+                } else {
+                    "<FILES> contains invalid values"
+                };
                 let details = errs
                     .into_iter()
-                    .map(|r| format!("{:#}", r.unwrap_err()))
+                    .map(|r| format!("  - {}", r.unwrap_err()))
                     .collect::<Vec<_>>()
-                    .join("\n  ");
-                return Err(anyhow!("invalid <FILES> arguments:\n  {details}"));
+                    .join("\n");
+                return Err(anyhow!("{header}:\n{details}"));
             }
             let mut arg_files: Vec<PathBuf> = oks.into_iter().map(Result::unwrap).collect();
 

--- a/crates/rari-cli/main.rs
+++ b/crates/rari-cli/main.rs
@@ -198,7 +198,7 @@ struct ServeArgs {
 
 #[derive(Args)]
 struct BuildArgs {
-    #[arg(value_name = "FILES", help = "Build only these content files")]
+    #[arg(value_name = "FILES", help = "Build only content <FILES>")]
     files: Vec<PathBuf>,
     #[arg(
         short = 'f',

--- a/crates/rari-cli/main.rs
+++ b/crates/rari-cli/main.rs
@@ -375,8 +375,8 @@ fn main() -> Result<(), Error> {
             let _ = SETTINGS.set(settings);
 
             if !args.files_flag.is_empty() {
-                tracing::warn!(
-                    "`-f`/`--files` is deprecated; pass file paths as positional arguments instead"
+                eprintln!(
+                    "warning: `-f`/`--files` is deprecated; pass file paths as positional arguments instead"
                 );
             }
             let mut arg_files = args

--- a/crates/rari-cli/main.rs
+++ b/crates/rari-cli/main.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use std::sync::mpsc::channel;
 use std::thread::spawn;
 
-use anyhow::{Error, anyhow};
+use anyhow::{Context, Error, anyhow};
 use clap::{Args, Parser, Subcommand};
 use clap_verbosity_flag::Verbosity;
 use dashmap::DashMap;
@@ -385,7 +385,10 @@ fn main() -> Result<(), Error> {
                 .files
                 .iter()
                 .chain(args.files_flag.iter())
-                .map(|path| path.canonicalize())
+                .map(|path| {
+                    path.canonicalize()
+                        .with_context(|| format!("invalid <FILES> argument: {}", path.display()))
+                })
                 .collect::<Result<Vec<PathBuf>, _>>()?;
 
             if let Some(file_list) = args.file_list {

--- a/crates/rari-cli/main.rs
+++ b/crates/rari-cli/main.rs
@@ -376,7 +376,7 @@ fn main() -> Result<(), Error> {
 
             if !args.files_flag.is_empty() {
                 eprintln!(
-                    "warning: `-f`/`--files` is deprecated; pass file paths as positional arguments instead"
+                    "warning: `-f`/`--files` is deprecated and will be removed in a future release; pass file paths as positional arguments instead"
                 );
             }
             let mut arg_files = args

--- a/crates/rari-cli/main.rs
+++ b/crates/rari-cli/main.rs
@@ -205,7 +205,7 @@ struct BuildArgs {
         long = "files",
         value_name = "FILES",
         hide = true,
-        help = "[deprecated] pass file paths as positional arguments instead"
+        help = "DEPRECATED: pass file paths as positional arguments instead"
     )]
     files_flag: Vec<PathBuf>,
     #[arg(long, help = "Build only content listed in <FILE_LIST>")]

--- a/crates/rari-cli/main.rs
+++ b/crates/rari-cli/main.rs
@@ -376,8 +376,9 @@ fn main() -> Result<(), Error> {
             let _ = SETTINGS.set(settings);
 
             if !args.files_flag.is_empty() {
-                eprintln!(
-                    "warning: `-f`/`--files` is deprecated and will be removed in a future release; pass file paths as positional arguments instead"
+                tracing::warn!(
+                    ignore = true,
+                    "`-f`/`--files` is deprecated and will be removed in a future release; pass file paths as positional arguments instead",
                 );
             }
             let mut arg_files = args

--- a/crates/rari-cli/main.rs
+++ b/crates/rari-cli/main.rs
@@ -381,15 +381,24 @@ fn main() -> Result<(), Error> {
                     "`-f`/`--files` is deprecated and will be removed in a future release; pass file paths as positional arguments instead",
                 );
             }
-            let mut arg_files = args
+            let (oks, errs): (Vec<_>, Vec<_>) = args
                 .files
                 .iter()
                 .chain(args.files_flag.iter())
                 .map(|path| {
                     path.canonicalize()
-                        .with_context(|| format!("invalid <FILES> argument: {}", path.display()))
+                        .with_context(|| path.display().to_string())
                 })
-                .collect::<Result<Vec<PathBuf>, _>>()?;
+                .partition(Result::is_ok);
+            if !errs.is_empty() {
+                let details = errs
+                    .into_iter()
+                    .map(|r| format!("{:#}", r.unwrap_err()))
+                    .collect::<Vec<_>>()
+                    .join("\n  ");
+                return Err(anyhow!("invalid <FILES> arguments:\n  {details}"));
+            }
+            let mut arg_files: Vec<PathBuf> = oks.into_iter().map(Result::unwrap).collect();
 
             if let Some(file_list) = args.file_list {
                 arg_files.extend(


### PR DESCRIPTION
### Description

Updates `rari build` to accept file paths as positional arguments. Also hides the existing `-f`/`--files` flag from `--help` and emits a deprecation warning when used on its own, while rejecting it when mixed with positional `FILES`.

### Motivation

Enables natural shell composition with tools like `xargs`, e.g.:

```sh
git ls-files -m '*.md' | xargs cargo run -- build
```

Previously each path had to be prefixed with `-f`, which doesn't compose with `xargs` without extra plumbing.

### Additional details

- Positional `FILES` has identical semantics to `-f` today: triggers `Cache::Dynamic` and skips the full content traversal.
- `--file-list` is unchanged.
- `-f`/`--files` will be removed in a future release once downstream scripts have migrated.
- Invalid positional paths now report all offending entries at once (previously only the first failure surfaced).