### PR TITLE
chore(jsref): change `Proxy/handler` group to `Proxy/Proxy`

### DIFF
--- a/crates/rari-doc/src/sidebars/jsref.rs
+++ b/crates/rari-doc/src/sidebars/jsref.rs
@@ -315,7 +315,6 @@ pub fn get_group(main_obj: &str, inheritance: &[Cow<'_, str>]) -> Vec<Cow<'stati
                 Cow::Borrowed("Intl.Segmenter"),
             ],
             TYPED_ARRAY,
-            &[Cow::Borrowed("Proxy"), Cow::Borrowed("Proxy/Proxy")],
         ]
     });
     for g in GROUP_DATA.iter() {

--- a/crates/rari-doc/src/sidebars/jsref.rs
+++ b/crates/rari-doc/src/sidebars/jsref.rs
@@ -315,7 +315,7 @@ pub fn get_group(main_obj: &str, inheritance: &[Cow<'_, str>]) -> Vec<Cow<'stati
                 Cow::Borrowed("Intl.Segmenter"),
             ],
             TYPED_ARRAY,
-            &[Cow::Borrowed("Proxy"), Cow::Borrowed("Proxy/handler")],
+            &[Cow::Borrowed("Proxy"), Cow::Borrowed("Proxy/Proxy")],
         ]
     });
     for g in GROUP_DATA.iter() {
@@ -372,7 +372,7 @@ fn slug_to_object_name(slug: &str) -> Cow<'_, str> {
         return "Intl/Segmenter/segment/Segments".into();
     }
     if sub_path.starts_with("Proxy/Proxy") {
-        return "Proxy/handler".into();
+        return "Proxy/Proxy".into();
     }
     for namespace in &["Intl/", "Temporal/"] {
         if let Some(sub_sub_path) = sub_path.strip_prefix(namespace) {


### PR DESCRIPTION
### Description

Drop the `Proxy/Proxy` entry from the JS reference sidebar's `Proxy` related-pages group (it is already listed as the constructor), and remove the now-dead `Proxy/Proxy` → `Proxy/handler` remap in `slug_to_object_name`.

### Motivation

The `Proxy/handler` page never existed — only a redirect to `Proxy/Proxy`. The sidebar was emitting a "Related pages" link to `/Proxy/Proxy` labelled `Proxy/handler`, producing 16 `templ-redirected-link` flaws across the `Proxy` reference pages. `Proxy/Proxy` is already shown on the `Proxy` sidebar as the constructor, so listing it again under "Related pages" is redundant.

### Additional details

Before (rendered `Proxy` sidebar tail):

```html
…<li class="section"><span>Related pages</span></li><li class="section"><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy"><code>Proxy/handler</code></a></li>
```

After: the "Related pages" entry is gone; the constructor link to `Proxy/Proxy` remains. Local build of `Proxy/index.md` drops from 1 issue to 0.

#### Screenshots


| Before | After |
|--------|--------|
| <img width="1118" height="892" alt="image" src="https://github.com/user-attachments/assets/b7a0e95c-3afd-4c6e-997f-15a542a83274" /> | <img width="1118" height="892" alt="image" src="https://github.com/user-attachments/assets/dcc1b645-89a1-4ac1-af3f-fb96b2498ec8" /> |
| <img width="1118" height="523" alt="image" src="https://github.com/user-attachments/assets/0f001168-bcf0-4329-a8ad-3eeb927e1f23" /> | <img width="1118" height="523" alt="image" src="https://github.com/user-attachments/assets/99881f40-4232-40f2-b554-2afa8dd388b9" /> |

### Related issues and pull requests

Fixes #706