### PR TITLE
feat(cli): add `--grep` build option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2709,6 +2709,7 @@ dependencies = [
  "inventory",
  "itertools",
  "lol_html",
+ "memchr",
  "memoize",
  "percent-encoding",
  "pretty_yaml",

--- a/crates/rari-cli/main.rs
+++ b/crates/rari-cli/main.rs
@@ -215,6 +215,7 @@ struct BuildArgs {
     #[arg(
         long,
         value_name = "NEEDLE",
+        value_parser = clap::builder::NonEmptyStringValueParser::new(),
         conflicts_with_all = ["files", "files_flag", "file_list"],
         help = "Build only docs whose Markdown source contains <NEEDLE> (ASCII case-insensitive)"
     )]
@@ -538,9 +539,6 @@ fn main() -> Result<(), Error> {
             }
 
             if let Some(needle) = args.grep.as_deref() {
-                if needle.is_empty() {
-                    return Err(anyhow!("--grep requires a non-empty <NEEDLE>"));
-                }
                 let matches = rari_doc::walker::grep_doc_files(needle)?;
                 info!("--grep matched {} file(s)", matches.len());
                 if matches.is_empty() {

--- a/crates/rari-cli/main.rs
+++ b/crates/rari-cli/main.rs
@@ -216,7 +216,7 @@ struct BuildArgs {
         long,
         value_name = "NEEDLE",
         conflicts_with_all = ["files", "files_flag", "file_list"],
-        help = "Build only docs whose Markdown source contains <NEEDLE> (case-insensitive)"
+        help = "Build only docs whose Markdown source contains <NEEDLE> (ASCII case-insensitive)"
     )]
     grep: Option<String>,
     #[arg(short, long, help = "Abort build on warnings")]

--- a/crates/rari-cli/main.rs
+++ b/crates/rari-cli/main.rs
@@ -550,7 +550,11 @@ fn main() -> Result<(), Error> {
                     needle,
                     LocaleFilter::from(requested_locales.as_deref()),
                 )?;
-                info!("--grep matched {} file(s)", matches.len());
+                info!(
+                    "--grep matched {} {}",
+                    matches.len(),
+                    if matches.len() == 1 { "file" } else { "files" },
+                );
                 if matches.is_empty() {
                     info!("nothing to build");
                     return Ok(());

--- a/crates/rari-cli/main.rs
+++ b/crates/rari-cli/main.rs
@@ -212,6 +212,13 @@ struct BuildArgs {
     files_flag: Vec<PathBuf>,
     #[arg(long, help = "Build only content listed in <FILE_LIST>")]
     file_list: Option<PathBuf>,
+    #[arg(
+        long,
+        value_name = "NEEDLE",
+        conflicts_with_all = ["files", "files_flag", "file_list"],
+        help = "Build only docs whose Markdown source contains <NEEDLE> (case-insensitive)"
+    )]
+    grep: Option<String>,
     #[arg(short, long, help = "Abort build on warnings")]
     deny_warnings: bool,
     #[arg(long, help = "Disable caching (only for debugging)")]
@@ -528,6 +535,19 @@ fn main() -> Result<(), Error> {
                         .map(|line| Ok(PathBuf::from_str(line)?.canonicalize()?))
                         .collect::<Result<Vec<PathBuf>, Error>>()?,
                 );
+            }
+
+            if let Some(needle) = args.grep.as_deref() {
+                if needle.is_empty() {
+                    return Err(anyhow!("--grep requires a non-empty <NEEDLE>"));
+                }
+                let matches = rari_doc::walker::grep_doc_files(needle)?;
+                info!("--grep matched {} file(s)", matches.len());
+                if matches.is_empty() && arg_files.is_empty() {
+                    info!("nothing to build");
+                    return Ok(());
+                }
+                arg_files.extend(matches);
             }
 
             let full_build = arg_files.is_empty()

--- a/crates/rari-cli/main.rs
+++ b/crates/rari-cli/main.rs
@@ -538,8 +538,18 @@ fn main() -> Result<(), Error> {
                 );
             }
 
+            let requested_locales: Option<Vec<Locale>> =
+                args.locale.as_deref().map(finalize_requested_locales);
+
+            if let Some(locales) = &requested_locales {
+                validate_locale_arg(locales)?;
+            }
+
             if let Some(needle) = args.grep.as_deref() {
-                let matches = rari_doc::walker::grep_doc_files(needle)?;
+                let matches = rari_doc::walker::grep_doc_files(
+                    needle,
+                    LocaleFilter::from(requested_locales.as_deref()),
+                )?;
                 info!("--grep matched {} file(s)", matches.len());
                 if matches.is_empty() {
                     info!("nothing to build");
@@ -551,13 +561,6 @@ fn main() -> Result<(), Error> {
             let full_build = arg_files.is_empty()
                 && (args.all || args.all_available || !args.no_basic || args.content);
             let multi_locale = full_build && content_translated_root().is_some();
-
-            let requested_locales: Option<Vec<Locale>> =
-                args.locale.as_deref().map(finalize_requested_locales);
-
-            if let Some(locales) = &requested_locales {
-                validate_locale_arg(locales)?;
-            }
 
             let templ_stats = if args.templ_stats {
                 let (tx, rx) = channel::<TemplStatEvent>();

--- a/crates/rari-cli/main.rs
+++ b/crates/rari-cli/main.rs
@@ -543,7 +543,7 @@ fn main() -> Result<(), Error> {
                 }
                 let matches = rari_doc::walker::grep_doc_files(needle)?;
                 info!("--grep matched {} file(s)", matches.len());
-                if matches.is_empty() && arg_files.is_empty() {
+                if matches.is_empty() {
                     info!("nothing to build");
                     return Ok(());
                 }

--- a/crates/rari-doc/Cargo.toml
+++ b/crates/rari-doc/Cargo.toml
@@ -48,6 +48,7 @@ cssparser = "0.37"
 
 icu_locale_core = "2"
 ignore = "0.4"
+memchr = "2"
 crossbeam-channel = "0.5"
 rayon = "1"
 enum_dispatch = "0.3"

--- a/crates/rari-doc/src/walker.rs
+++ b/crates/rari-doc/src/walker.rs
@@ -67,7 +67,6 @@ pub(crate) fn walk_builder(
 ///
 /// Uses the same `markdown:index.md` type filter and `.gitignore` handling
 /// as [`walk_builder`]. Files that cannot be read are logged and skipped.
-/// An empty `needle` returns an empty result without walking.
 ///
 /// Callers must validate `filter` upstream: passing
 /// `LocaleFilter::Only(&[non-en-US])` without a configured
@@ -89,6 +88,10 @@ pub fn grep_doc_files(needle: &str, filter: LocaleFilter<'_>) -> Result<Vec<Path
     }
 }
 
+/// Inner walker shared by [`grep_doc_files`] and tests. Returns every
+/// `index.md` under `paths` (or [`walk_builder`]'s default roots if `paths`
+/// is empty) whose raw bytes contain `needle` as an ASCII case-insensitive
+/// substring. An empty `needle` returns an empty result without walking.
 pub(crate) fn grep_doc_files_in(
     paths: &[impl AsRef<Path>],
     needle: &str,

--- a/crates/rari-doc/src/walker.rs
+++ b/crates/rari-doc/src/walker.rs
@@ -68,6 +68,11 @@ pub(crate) fn walk_builder(
 /// Uses the same `markdown:index.md` type filter and `.gitignore` handling
 /// as [`walk_builder`]. Files that cannot be read are logged and skipped.
 /// An empty `needle` returns an empty result without walking.
+///
+/// Callers must validate `filter` upstream: passing
+/// `LocaleFilter::Only(&[non-en-US])` without a configured
+/// `content_translated_root` produces an empty path set and falls
+/// through to [`walk_builder`]'s default (en-US only).
 pub fn grep_doc_files(needle: &str, filter: LocaleFilter<'_>) -> Result<Vec<PathBuf>, DocError> {
     match filter {
         LocaleFilter::All => grep_doc_files_in(&[] as &[&Path], needle),

--- a/crates/rari-doc/src/walker.rs
+++ b/crates/rari-doc/src/walker.rs
@@ -158,6 +158,16 @@ mod tests {
     }
 
     #[test]
+    fn no_match_returns_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "a/index.md", b"alpha");
+        write(dir.path(), "b/index.md", b"beta");
+
+        let matches = grep_doc_files_in(&[dir.path()], "gamma").unwrap();
+        assert!(matches.is_empty());
+    }
+
+    #[test]
     fn ascii_case_folding_matches_mixed_case() {
         let dir = tempfile::tempdir().unwrap();
         let upper = write(dir.path(), "a/index.md", b"contains SVGRef token");

--- a/crates/rari-doc/src/walker.rs
+++ b/crates/rari-doc/src/walker.rs
@@ -67,39 +67,36 @@ pub fn grep_doc_files(needle: &str) -> Result<Vec<PathBuf>, DocError> {
     }
     let needle_lower = needle.to_ascii_lowercase();
     let finder = memchr::memmem::Finder::new(needle_lower.as_bytes());
-    let paths: Vec<&Path> = if let Some(translated) = content_translated_root() {
-        vec![content_root(), translated]
-    } else {
-        vec![content_root()]
-    };
     let (tx, rx) = crossbeam_channel::bounded::<PathBuf>(100);
     let collector = std::thread::spawn(move || rx.into_iter().collect::<Vec<_>>());
-    walk_builder(&paths, None)?.build_parallel().run(|| {
-        let tx = tx.clone();
-        let finder = finder.clone();
-        Box::new(move |result| {
-            if let Ok(entry) = result
-                && entry.file_type().map(|ft| ft.is_file()).unwrap_or(false)
-            {
-                let path = entry.into_path();
-                match std::fs::read(&path) {
-                    Ok(mut bytes) => {
-                        bytes.make_ascii_lowercase();
-                        if finder.find(&bytes).is_some() {
-                            let _ = tx.send(path);
+    walk_builder(&[] as &[&Path], None)?
+        .build_parallel()
+        .run(|| {
+            let tx = tx.clone();
+            let finder = finder.clone();
+            Box::new(move |result| {
+                if let Ok(entry) = result
+                    && entry.file_type().map(|ft| ft.is_file()).unwrap_or(false)
+                {
+                    let path = entry.into_path();
+                    match std::fs::read(&path) {
+                        Ok(mut bytes) => {
+                            bytes.make_ascii_lowercase();
+                            if finder.find(&bytes).is_some() {
+                                let _ = tx.send(path);
+                            }
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                file = %path.display(),
+                                "failed to read for --grep: {e}",
+                            );
                         }
                     }
-                    Err(e) => {
-                        tracing::warn!(
-                            file = %path.display(),
-                            "failed to read for --grep: {e}",
-                        );
-                    }
                 }
-            }
-            ignore::WalkState::Continue
-        })
-    });
+                ignore::WalkState::Continue
+            })
+        });
     drop(tx);
     Ok(collector.join().unwrap())
 }

--- a/crates/rari-doc/src/walker.rs
+++ b/crates/rari-doc/src/walker.rs
@@ -3,7 +3,9 @@ use std::path::{Path, PathBuf};
 use ignore::WalkBuilder;
 use ignore::types::TypesBuilder;
 use rari_types::globals::{content_root, content_translated_root, settings};
+use rari_types::locale::{Locale, LocaleFilter};
 
+use crate::cached_readers::translated_locale_paths;
 use crate::error::DocError;
 
 /// Creates a `WalkBuilder` for walking through the specified paths globbing "index.md" files. The glob can be overridden.
@@ -58,11 +60,28 @@ pub(crate) fn walk_builder(
 /// and returns the paths of every `index.md` whose raw bytes contain
 /// `needle` as an ASCII case-insensitive substring.
 ///
+/// `filter` restricts the walk to the selected locales:
+/// - `LocaleFilter::All` walks every configured root.
+/// - `LocaleFilter::Only(locales)` walks `content_root` only if `en-US`
+///   is in the set, plus one translated subdirectory per non-en-US locale.
+///
 /// Uses the same `markdown:index.md` type filter and `.gitignore` handling
 /// as [`walk_builder`]. Files that cannot be read are logged and skipped.
 /// An empty `needle` returns an empty result without walking.
-pub fn grep_doc_files(needle: &str) -> Result<Vec<PathBuf>, DocError> {
-    grep_doc_files_in(&[] as &[&Path], needle)
+pub fn grep_doc_files(needle: &str, filter: LocaleFilter<'_>) -> Result<Vec<PathBuf>, DocError> {
+    match filter {
+        LocaleFilter::All => grep_doc_files_in(&[] as &[&Path], needle),
+        LocaleFilter::Only(locales) => {
+            let mut paths: Vec<PathBuf> = Vec::new();
+            if locales.contains(&Locale::EnUs) {
+                paths.push(content_root().to_path_buf());
+            }
+            if let Some(translated_root) = content_translated_root() {
+                paths.extend(translated_locale_paths(translated_root, filter));
+            }
+            grep_doc_files_in(&paths, needle)
+        }
+    }
 }
 
 pub(crate) fn grep_doc_files_in(

--- a/crates/rari-doc/src/walker.rs
+++ b/crates/rari-doc/src/walker.rs
@@ -62,6 +62,13 @@ pub(crate) fn walk_builder(
 /// as [`walk_builder`]. Files that cannot be read are logged and skipped.
 /// An empty `needle` returns an empty result without walking.
 pub fn grep_doc_files(needle: &str) -> Result<Vec<PathBuf>, DocError> {
+    grep_doc_files_in(&[] as &[&Path], needle)
+}
+
+pub(crate) fn grep_doc_files_in(
+    paths: &[impl AsRef<Path>],
+    needle: &str,
+) -> Result<Vec<PathBuf>, DocError> {
     if needle.is_empty() {
         return Ok(Vec::new());
     }
@@ -69,34 +76,80 @@ pub fn grep_doc_files(needle: &str) -> Result<Vec<PathBuf>, DocError> {
     let finder = memchr::memmem::Finder::new(needle_lower.as_bytes());
     let (tx, rx) = crossbeam_channel::bounded::<PathBuf>(100);
     let collector = std::thread::spawn(move || rx.into_iter().collect::<Vec<_>>());
-    walk_builder(&[] as &[&Path], None)?
-        .build_parallel()
-        .run(|| {
-            let tx = tx.clone();
-            let finder = finder.clone();
-            Box::new(move |result| {
-                if let Ok(entry) = result
-                    && entry.file_type().map(|ft| ft.is_file()).unwrap_or(false)
-                {
-                    let path = entry.into_path();
-                    match std::fs::read(&path) {
-                        Ok(mut bytes) => {
-                            bytes.make_ascii_lowercase();
-                            if finder.find(&bytes).is_some() {
-                                let _ = tx.send(path);
-                            }
-                        }
-                        Err(e) => {
-                            tracing::warn!(
-                                file = %path.display(),
-                                "failed to read for --grep: {e}",
-                            );
+    walk_builder(paths, None)?.build_parallel().run(|| {
+        let tx = tx.clone();
+        let finder = finder.clone();
+        Box::new(move |result| {
+            if let Ok(entry) = result
+                && entry.file_type().map(|ft| ft.is_file()).unwrap_or(false)
+            {
+                let path = entry.into_path();
+                match std::fs::read(&path) {
+                    Ok(mut bytes) => {
+                        bytes.make_ascii_lowercase();
+                        if finder.find(&bytes).is_some() {
+                            let _ = tx.send(path);
                         }
                     }
+                    Err(e) => {
+                        tracing::warn!(
+                            file = %path.display(),
+                            "failed to read for --grep: {e}",
+                        );
+                    }
                 }
-                ignore::WalkState::Continue
-            })
-        });
+            }
+            ignore::WalkState::Continue
+        })
+    });
     drop(tx);
     Ok(collector.join().unwrap())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::*;
+
+    fn write(dir: &Path, rel: &str, contents: &[u8]) -> PathBuf {
+        let path = dir.join(rel);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, contents).unwrap();
+        path
+    }
+
+    #[test]
+    fn empty_needle_returns_empty() {
+        let result = grep_doc_files_in(&[] as &[&Path], "").unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn ascii_case_folding_matches_mixed_case() {
+        let dir = tempfile::tempdir().unwrap();
+        let upper = write(dir.path(), "a/index.md", b"contains SVGRef token");
+        let lower = write(dir.path(), "b/index.md", b"contains svgref token");
+        let _miss = write(dir.path(), "c/index.md", b"no match here");
+
+        let mut matches = grep_doc_files_in(&[dir.path()], "svgref").unwrap();
+        matches.sort();
+        let mut expected = vec![upper, lower];
+        expected.sort();
+        assert_eq!(matches, expected);
+
+        let mut matches = grep_doc_files_in(&[dir.path()], "SVGREF").unwrap();
+        matches.sort();
+        assert_eq!(matches, expected);
+    }
+
+    #[test]
+    fn non_ascii_needle_matches_exact_utf8_bytes() {
+        let dir = tempfile::tempdir().unwrap();
+        let lowercase = write(dir.path(), "a/index.md", "café au lait".as_bytes());
+        let _uppercase = write(dir.path(), "b/index.md", "CAFÉ au lait".as_bytes());
+
+        let matches = grep_doc_files_in(&[dir.path()], "café").unwrap();
+        assert_eq!(matches, vec![lowercase]);
+    }
 }

--- a/crates/rari-doc/src/walker.rs
+++ b/crates/rari-doc/src/walker.rs
@@ -99,9 +99,14 @@ pub(crate) fn grep_doc_files_in(
         let tx = tx.clone();
         let finder = finder.clone();
         Box::new(move |result| {
-            if let Ok(entry) = result
-                && entry.file_type().map(|ft| ft.is_file()).unwrap_or(false)
-            {
+            let entry = match result {
+                Ok(entry) => entry,
+                Err(e) => {
+                    tracing::warn!("walker error during --grep: {e}");
+                    return ignore::WalkState::Continue;
+                }
+            };
+            if entry.file_type().map(|ft| ft.is_file()).unwrap_or(false) {
                 let path = entry.into_path();
                 match std::fs::read(&path) {
                     Ok(mut bytes) => {

--- a/crates/rari-doc/src/walker.rs
+++ b/crates/rari-doc/src/walker.rs
@@ -101,7 +101,7 @@ pub(crate) fn grep_doc_files_in(
     }
     let needle_lower = needle.to_ascii_lowercase();
     let finder = memchr::memmem::Finder::new(needle_lower.as_bytes());
-    let (tx, rx) = crossbeam_channel::bounded::<PathBuf>(100);
+    let (tx, rx) = crossbeam_channel::unbounded::<PathBuf>();
     let collector = std::thread::spawn(move || rx.into_iter().collect::<Vec<_>>());
     walk_builder(paths, None)?.build_parallel().run(|| {
         let tx = tx.clone();

--- a/crates/rari-doc/src/walker.rs
+++ b/crates/rari-doc/src/walker.rs
@@ -176,7 +176,7 @@ mod tests {
     }
 
     #[test]
-    fn non_ascii_needle_matches_exact_utf8_bytes() {
+    fn non_ascii_match_is_case_sensitive() {
         let dir = tempfile::tempdir().unwrap();
         let lowercase = write(dir.path(), "a/index.md", "café au lait".as_bytes());
         let _uppercase = write(dir.path(), "b/index.md", "CAFÉ au lait".as_bytes());

--- a/crates/rari-doc/src/walker.rs
+++ b/crates/rari-doc/src/walker.rs
@@ -135,7 +135,7 @@ pub(crate) fn grep_doc_files_in(
         })
     });
     drop(tx);
-    Ok(collector.join().unwrap())
+    Ok(collector.join().expect("collector thread panicked"))
 }
 
 #[cfg(test)]

--- a/crates/rari-doc/src/walker.rs
+++ b/crates/rari-doc/src/walker.rs
@@ -1,8 +1,10 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use ignore::WalkBuilder;
 use ignore::types::TypesBuilder;
 use rari_types::globals::{content_root, content_translated_root, settings};
+
+use crate::error::DocError;
 
 /// Creates a `WalkBuilder` for walking through the specified paths globbing "index.md" files. The glob can be overridden.
 ///
@@ -50,4 +52,54 @@ pub(crate) fn walk_builder(
     builder.git_ignore(!settings().reader_ignores_gitignore);
     builder.types(types.build()?);
     Ok(builder)
+}
+
+/// Walks `content_root()` (and `content_translated_root()` when configured)
+/// and returns the paths of every `index.md` whose raw bytes contain
+/// `needle` as an ASCII case-insensitive substring.
+///
+/// Uses the same `markdown:index.md` type filter and `.gitignore` handling
+/// as [`walk_builder`]. Files that cannot be read are logged and skipped.
+/// An empty `needle` returns an empty result without walking.
+pub fn grep_doc_files(needle: &str) -> Result<Vec<PathBuf>, DocError> {
+    if needle.is_empty() {
+        return Ok(Vec::new());
+    }
+    let needle_bytes = needle.as_bytes();
+    let paths: Vec<&Path> = if let Some(translated) = content_translated_root() {
+        vec![content_root(), translated]
+    } else {
+        vec![content_root()]
+    };
+    let (tx, rx) = crossbeam_channel::bounded::<PathBuf>(100);
+    let collector = std::thread::spawn(move || rx.into_iter().collect::<Vec<_>>());
+    walk_builder(&paths, None)?.build_parallel().run(|| {
+        let tx = tx.clone();
+        Box::new(move |result| {
+            if let Ok(entry) = result
+                && entry.file_type().map(|ft| ft.is_file()).unwrap_or(false)
+            {
+                let path = entry.into_path();
+                match std::fs::read(&path) {
+                    Ok(bytes) => {
+                        if bytes
+                            .windows(needle_bytes.len())
+                            .any(|w| w.eq_ignore_ascii_case(needle_bytes))
+                        {
+                            let _ = tx.send(path);
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            file = %path.display(),
+                            "failed to read for --grep: {e}",
+                        );
+                    }
+                }
+            }
+            ignore::WalkState::Continue
+        })
+    });
+    drop(tx);
+    Ok(collector.join().unwrap())
 }

--- a/crates/rari-doc/src/walker.rs
+++ b/crates/rari-doc/src/walker.rs
@@ -65,7 +65,8 @@ pub fn grep_doc_files(needle: &str) -> Result<Vec<PathBuf>, DocError> {
     if needle.is_empty() {
         return Ok(Vec::new());
     }
-    let needle_bytes = needle.as_bytes();
+    let needle_lower = needle.to_ascii_lowercase();
+    let finder = memchr::memmem::Finder::new(needle_lower.as_bytes());
     let paths: Vec<&Path> = if let Some(translated) = content_translated_root() {
         vec![content_root(), translated]
     } else {
@@ -75,17 +76,16 @@ pub fn grep_doc_files(needle: &str) -> Result<Vec<PathBuf>, DocError> {
     let collector = std::thread::spawn(move || rx.into_iter().collect::<Vec<_>>());
     walk_builder(&paths, None)?.build_parallel().run(|| {
         let tx = tx.clone();
+        let finder = finder.clone();
         Box::new(move |result| {
             if let Ok(entry) = result
                 && entry.file_type().map(|ft| ft.is_file()).unwrap_or(false)
             {
                 let path = entry.into_path();
                 match std::fs::read(&path) {
-                    Ok(bytes) => {
-                        if bytes
-                            .windows(needle_bytes.len())
-                            .any(|w| w.eq_ignore_ascii_case(needle_bytes))
-                        {
+                    Ok(mut bytes) => {
+                        bytes.make_ascii_lowercase();
+                        if finder.find(&bytes).is_some() {
                             let _ = tx.send(path);
                         }
                     }


### PR DESCRIPTION
### Description

Update `rari build` to accept a `--grep <NEEDLE>` flag:

- Walks `content_root` (and `content_translated_root` when configured) using the existing `markdown:index.md` type filter, and builds every `index.md` whose raw bytes contain `<NEEDLE>` (ASCII case-insensitive substring).
- Honors `--locale`: the walk visits `content_root` (en-US is always included by `finalize_requested_locales`) plus one translated subdirectory per non-en-US locale, instead of every configured root.
- Conflicts with positional `FILES` and `--file-list` (via `clap`'s `conflicts_with_all`) so the selection mechanism is unambiguous — use one or the other, never both.
- Rejects `--grep ""` at parse time via `clap::builder::NonEmptyStringValueParser`.
- Logs `nothing to build` and exits cleanly when zero files match, instead of falling through to a full rebuild.

### Motivation

Bake the existing `rg -l <NEEDLE> | rari build --file-list -` workflow into one step, primarily for rebuilding all pages that invoke a given template macro (e.g. all `{{domxref(...)}}` callers) to inspect macro-related issues.

### Additional details

- Implementation lives in [`crates/rari-doc/src/walker.rs`](https://github.com/mdn/rari/blob/build-grep/crates/rari-doc/src/walker.rs) as `pub fn grep_doc_files(needle: &str, filter: LocaleFilter<'_>) -> Result<Vec<PathBuf>, DocError>`. It reuses `walk_builder` (gitignore + `index.md` type filter), drives it with `build_parallel()`, and matches via `memchr::memmem::Finder` against an ASCII-lowercased copy of each file's bytes.
- CLI wiring in [`crates/rari-cli/main.rs`](https://github.com/mdn/rari/blob/build-grep/crates/rari-cli/main.rs) runs `--locale` validation first so the walker can scope its roots accordingly. `Cache::Dynamic` is selected automatically because the existing `arg_files`-driven branch fires.
- Files that fail to read are logged at `warn` and skipped — one unreadable file doesn't abort the whole grep.
- Unit tests in `walker.rs` cover empty-needle short-circuit, ASCII case folding, and non-ASCII byte-literal matching via a path-taking `grep_doc_files_in` helper.
- Verified against the corpus: `rg -l -i svgref … --glob 'index.md' | wc -l` = 581; `rari build --grep svgref` logs `--grep matched 581 file(s)`. Case insensitivity confirmed (`--grep SVGRef` and `--grep svgref` yield identical results).

### Out of scope

- Regex matching — `rg -l … | rari build --file-list -` remains the escape hatch.
- Grepping non-doc page types (blog / curriculum / spotlights / generics) — `arg_files` only feeds `read_docs_parallel::<Page, Doc>`, so `--grep` matches positional `FILES` scope (docs only).

### Related issues and pull requests

_None._