### PR TITLE
build(cargo): disable debuginfo for dev-profile deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ rust-version = "1.90"
 path = "crates/rari-cli/main.rs"
 name = "rari"
 
+[profile.dev.package."*"]
+debug = false
+
 [profile.release-lto]
 inherits = "release"
 opt-level = 3


### PR DESCRIPTION
### Description

Set `debug = false` for `[profile.dev.package."*"]` so third-party dependencies are built without debug info under the dev profile.

### Motivation

Shrinks `target/debug/deps/` (currently the bulk of multi-tens-of-GB `target/` directories) without affecting day-to-day debugging.

### Additional details

- `package."*"` matches third-party crates only — workspace members still build with `debuginfo=2` (verified via `cargo build -v`).
- Backtraces and panic messages are unaffected (function names come from symbol tables, not debug info).
- To step into a dep on demand: `cargo build --config 'profile.dev.package."*".debug=2'`.

See: [GitHub search](https://github.com/search?q=%2F%5C%5Bprofile%5C.dev%5C.package%5C.%22%5C*%22%5C%5D%5Cndebug+%3D+false%2F&type=code).