### PR TITLE
ci(build-content-and-diff): pass `--quiet` to `cargo run`

### DIFF
--- a/.github/workflows/build-content-and-diff.yml
+++ b/.github/workflows/build-content-and-diff.yml
@@ -71,18 +71,18 @@ jobs:
         env:
           BUILD_OUT_ROOT: ${{ env.BUILD_BASE }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: cargo run --release build --json-issues
+        run: cargo run --quiet --release build --json-issues
 
       - name: Build with PR
         working-directory: rari-pr
         env:
           BUILD_OUT_ROOT: ${{ env.BUILD_PR }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: cargo run --release build --json-issues
+        run: cargo run --quiet --release build --json-issues
 
       - name: Generate diff
         working-directory: rari-pr
-        run: cargo run -p diff-test diff --fast --flaws --html --value --out "$DIFF" --verbose "$BUILD_BASE" "$BUILD_PR"
+        run: cargo run --quiet -p diff-test diff --fast --flaws --html --value --out "$DIFF" --verbose "$BUILD_BASE" "$BUILD_PR"
 
       - name: Upload diff
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
### Description

Update the `build-content-and-diff` workflow to pass `--quiet` to all three `cargo run` invocations (`build with base`, `build with PR`, `generate diff`).

### Motivation

Make it easier to see the actual build output directly in CI logs by suppressing Cargo's compilation progress noise.

### Additional details


See: https://github.com/mdn/rari/actions/runs/26463066110/job/77915899121?pr=730#step:10:20

`cargo run --quiet` suppresses Cargo's own status output (`Compiling …`, `Finished …`, `Running …`) without affecting the compiled binary's stdout/stderr, so the build/diff output remains intact while the surrounding noise is removed.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->