### PR TITLE
perf(lefthook): share `--features doctest` across pre-push tests

### DIFF
--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -14,7 +14,7 @@ pre-push:
   parallel: true
   commands:
     test:
-      run: cargo test --verbose --workspace --all-targets --no-fail-fast
+      run: cargo test --verbose --workspace --all-targets --features doctest --no-fail-fast
 
     test-doc:
       run: cargo test --verbose --workspace --doc --features doctest --no-fail-fast


### PR DESCRIPTION
### Description

Add `--features doctest` to the `pre-push` `test` command in `.lefthook.yml` so both `cargo test` invocations share feature resolution.

### Motivation

The two commands previously resolved features differently (only `test-doc` enabled `doctest`, which pulls in `rari-deps` via `css-syntax`). Cargo therefore kept two feature-resolved artifact sets in `target/` and rebuilt back and forth on every pre-push.

### Additional details

Single-run benchmarks (Apple Silicon, cold `CARGO_TARGET_DIR`):

| | Wall | `target/` | User CPU |
|---|---|---|---|
| Cold — before | 67.05s | 3.0G | — |
| Cold — after | 64.29s | 2.6G | — |
| **Warm — before** | **17.56s** | 3.0G → **3.1G** | **26.31s** |
| **Warm — after**  | **14.01s** | 2.6G → 2.6G | **13.44s** |

Warm builds are the typical pre-push case: ~20% faster wall, ~half the user CPU, and `target/` stays stable instead of growing each run.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->