### PR TITLE
fix(specs): make `filename` optional

### DIFF
--- a/crates/css-syntax-types/src/specs.rs
+++ b/crates/css-syntax-types/src/specs.rs
@@ -50,7 +50,7 @@ pub struct NightlySpec {
     #[serde(rename = "alternateUrls", default)]
     pub alternate_urls: Vec<String>,
     pub repository: Option<String>,
-    pub filename: String,
+    pub filename: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -58,7 +58,7 @@ pub struct ReleaseSpec {
     pub url: String,
     pub status: String,
     pub pages: Option<Vec<String>>,
-    pub filename: String,
+    pub filename: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/crates/rari-data/src/specs.rs
+++ b/crates/rari-data/src/specs.rs
@@ -24,7 +24,7 @@ pub struct Nightly {
     pub source_path: Option<String>,
     pub alternate_urls: Vec<String>,
     pub repository: Option<String>,
-    pub filename: String,
+    pub filename: Option<String>,
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]


### PR DESCRIPTION
web-specs v4.0.0 drops `filename` from RFC spec nightly objects, breaking deserialization of index.json, which means `rari` won't run.

https://github.com/mdn/dex/actions/runs/26729292623
https://github.com/mdn/dex/actions/runs/26729932043