### PR TITLE
fix(ci): pin npx fred-ssr and rari to their @mdn packages

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -173,7 +173,7 @@ jobs:
         run: |
           set -eo pipefail
 
-          npx rari git-history
+          npx @mdn/rari git-history
 
           if [ -n "$BLOG_ROOT" ]; then
             BUILD_OPTIONS="--all"
@@ -277,11 +277,11 @@ jobs:
             done
           fi
 
-          npx rari build $BUILD_OPTIONS $FILE_LIST --issues "$BUILD_OUT_ROOT/issues.json" --templ-stats
+          npx @mdn/rari build $BUILD_OPTIONS $FILE_LIST --issues "$BUILD_OUT_ROOT/issues.json" --templ-stats
 
       - name: Render content (fred)
         working-directory: mdn/content
-        run: npx fred-ssr
+        run: npx --package=@mdn/fred fred-ssr
 
       - name: Set artifact name
         id: set-artifact-name


### PR DESCRIPTION
## Description

- `.github/workflows/_build.yml`: `npx fred-ssr` → `npx --package=@mdn/fred fred-ssr`
- `.github/workflows/_build.yml`: `npx rari …` → `npx @mdn/rari …`

## Motivation

Prevent dependency-confusion fallbacks in `npx fred-ssr` and `npx rari`.

## Additional details

`npx <bin>` resolves to the local bin only when present; otherwise npm silently downloads and runs a registry package literally named `<bin>`. In CI, `npx` assumes `--yes`, so this happens with no prompt. `fred-ssr` is a bin of `@mdn/fred` and its bare name is unpublished (squattable); the unscoped `rari` name is owned by an unrelated third party, not MDN (this repo publishes the scoped `@mdn/rari`). Pinning `--package=@mdn/fred` / `@mdn/rari` guarantees the intended bins.

## Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1680.
