### PR TITLE
chore(deps): bump MSRV from 1.90 to 1.97

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -128,7 +128,7 @@ jobs:
 
       - name: Setup Rust
         if: inputs.rari-binary-artifact-id == ''
-        uses: dtolnay/rust-toolchain@9a1d20035bdbcbc899baabe1e402e85bc33639bc # 1.90
+        uses: dtolnay/rust-toolchain@1a3a6d54512beeaffd394f8d516ca16f2c506a20 # 1.97
 
       - name: Setup sccache
         if: inputs.rari-binary-artifact-id == ''

--- a/.github/workflows/build-content-and-diff.yml
+++ b/.github/workflows/build-content-and-diff.yml
@@ -3,10 +3,10 @@ name: Build Content and Diff
 on:
   pull_request:
     paths:
-      - '**/*.rs'
-      - '**/Cargo.lock'
-      - '**/Cargo.toml'
-      - '.github/workflows/build-content-and-diff.yml'
+      - "**/*.rs"
+      - "**/Cargo.lock"
+      - "**/Cargo.toml"
+      - ".github/workflows/build-content-and-diff.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
@@ -37,7 +37,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@9a1d20035bdbcbc899baabe1e402e85bc33639bc # 1.90
+        uses: dtolnay/rust-toolchain@1a3a6d54512beeaffd394f8d516ca16f2c506a20 # 1.97
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10

--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@9a1d20035bdbcbc899baabe1e402e85bc33639bc # 1.90
+      - uses: dtolnay/rust-toolchain@1a3a6d54512beeaffd394f8d516ca16f2c506a20 # 1.97
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10

--- a/.github/workflows/sync-cargo-lock.yml
+++ b/.github/workflows/sync-cargo-lock.yml
@@ -24,7 +24,7 @@ jobs:
           persist-credentials: false
           ref: ${{ github.event.repository.default_branch }}
 
-      - uses: dtolnay/rust-toolchain@9a1d20035bdbcbc899baabe1e402e85bc33639bc # 1.90
+      - uses: dtolnay/rust-toolchain@1a3a6d54512beeaffd394f8d516ca16f2c506a20 # 1.97
 
       - name: Run cargo metadata
         run: cargo metadata

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@9a1d20035bdbcbc899baabe1e402e85bc33639bc # 1.90
+      - uses: dtolnay/rust-toolchain@1a3a6d54512beeaffd394f8d516ca16f2c506a20 # 1.97
 
       - name: sccache-cache
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
@@ -56,7 +56,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@9a1d20035bdbcbc899baabe1e402e85bc33639bc # 1.90
+      - uses: dtolnay/rust-toolchain@1a3a6d54512beeaffd394f8d516ca16f2c506a20 # 1.97
         with:
           components: rustfmt
 
@@ -76,7 +76,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@9a1d20035bdbcbc899baabe1e402e85bc33639bc # 1.90
+      - uses: dtolnay/rust-toolchain@1a3a6d54512beeaffd394f8d516ca16f2c506a20 # 1.97
 
       - name: sccache-cache
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
@@ -95,7 +95,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@9a1d20035bdbcbc899baabe1e402e85bc33639bc # 1.90
+      - uses: dtolnay/rust-toolchain@1a3a6d54512beeaffd394f8d516ca16f2c506a20 # 1.97
         with:
           components: clippy
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MPL-2.0"
 authors = ["MDN Engineering Team <mdn-dev@mozilla.com>"]
 homepage = "https://github.com/mdn/rari"
 repository = "https://github.com/mdn/rari"
-rust-version = "1.90"
+rust-version = "1.97"
 
 [[bin]]
 path = "crates/rari-cli/main.rs"
@@ -51,7 +51,7 @@ members = [
 edition = "2024"
 license = "MPL-2.0"
 authors = ["MDN Engineering Team <mdn-dev@mozilla.com>"]
-rust-version = "1.90"
+rust-version = "1.97"
 
 [workspace.dependencies]
 rari-doc = { path = "crates/rari-doc" }

--- a/crates/rari-doc/src/html/sections.rs
+++ b/crates/rari-doc/src/html/sections.rs
@@ -44,13 +44,10 @@ pub fn split_sections(html: &Html) -> Result<Split<'_>, DocError> {
             match current.value() {
                 scraper::Node::Comment(comment) => {
                     let comment = format!("<!-- {} -->", comment.deref());
-                    if let Some(ref mut section) = maybe_section.as_mut().and_then(|section| {
-                        if !matches!(section.typ, BuildSectionType::Compat) {
-                            Some(section)
-                        } else {
-                            None
-                        }
-                    }) {
+                    if let Some(section) = maybe_section
+                        .as_mut()
+                        .filter(|section| !matches!(section.typ, BuildSectionType::Compat))
+                    {
                         section.body.push(comment);
                     } else {
                         if let Some(compat_section) = maybe_section.take() {
@@ -197,19 +194,12 @@ pub fn split_sections(html: &Html) -> Result<Split<'_>, DocError> {
                             }
                             _ => {
                                 let html = ElementRef::wrap(current).unwrap().html();
-                                if let Some(ref mut section) =
-                                    maybe_section.as_mut().and_then(|section| {
-                                        if !matches!(
-                                            section.typ,
-                                            BuildSectionType::Compat
-                                                | BuildSectionType::Specification
-                                        ) {
-                                            Some(section)
-                                        } else {
-                                            None
-                                        }
-                                    })
-                                {
+                                if let Some(section) = maybe_section.as_mut().filter(|section| {
+                                    !matches!(
+                                        section.typ,
+                                        BuildSectionType::Compat | BuildSectionType::Specification
+                                    )
+                                }) {
                                     section.body.push(html)
                                 } else {
                                     if let Some(compat_section) = maybe_section.take() {

--- a/crates/rari-doc/src/issues.rs
+++ b/crates/rari-doc/src/issues.rs
@@ -436,7 +436,7 @@ impl DIssue {
             di.filepath = Some(page.full_path().to_string_lossy().into_owned());
 
             let mut additional = HashMap::new();
-            for (key, value) in issue.spans.into_iter().chain(issue.fields.into_iter()) {
+            for (key, value) in issue.spans.into_iter().chain(issue.fields) {
                 match key {
                     "source" => {
                         di.name = IssueType::from_str(&value).unwrap();

--- a/crates/rari-doc/src/pages/types/spa_homepage.rs
+++ b/crates/rari-doc/src/pages/types/spa_homepage.rs
@@ -85,7 +85,7 @@ pub fn recent_contributions() -> Result<Vec<HomePageRecentContribution>, DocErro
             "mdn/translated-content",
         )?);
     };
-    content.sort_by(|a, b| a.updated_at.cmp(&b.updated_at));
+    content.sort_by_key(|a| a.updated_at);
     Ok(content)
 }
 

--- a/crates/rari-doc/src/templ/templs/links/cssxref.rs
+++ b/crates/rari-doc/src/templ/templs/links/cssxref.rs
@@ -136,7 +136,7 @@ pub fn cssxref_internal(
         .map(|a| format!("#{a}"))
         .or_else(|| anchor.map(str::to_string))
         .unwrap_or_default();
-    let url = format!("{}{}{}", &base_url, &url_path, &fragment);
+    let url = format!("{}{}{}", base_url, url_path, fragment);
 
     let display_name = if display_name.is_some() {
         encoded_maybe_display_name.to_string()

--- a/crates/rari-doc/src/templ/templs/links/jsxref.rs
+++ b/crates/rari-doc/src/templ/templs/links/jsxref.rs
@@ -41,7 +41,7 @@ pub fn jsxref(
     let display = display.as_deref().filter(|s| !s.is_empty());
     let global_objects = "Global_Objects";
     let display = display.unwrap_or(api_name.as_str());
-    let mut url = format!("/{}/docs/Web/JavaScript/Reference/", &env.locale);
+    let mut url = format!("/{}/docs/Web/JavaScript/Reference/", env.locale);
     let mut base_path = url.clone();
 
     let mut slug = api_name.replace("()", "").replace(".prototype.", ".");

--- a/crates/rari-doc/src/templ/templs/links/webextapixref.rs
+++ b/crates/rari-doc/src/templ/templs/links/webextapixref.rs
@@ -43,7 +43,7 @@ pub fn webextapiref(
     let mut url = format!(
         "/{}/docs/Mozilla/Add-ons/WebExtensions/API/{}",
         env.locale.as_url_str(),
-        &api.replace(' ', "_").replace("()", "").replace('.', "/"),
+        api.replace(' ', "_").replace("()", "").replace('.', "/"),
     );
     if let Some(anchor) = anchor {
         if !anchor.starts_with('#') {

--- a/crates/rari-doc/src/templ/templs/webext_all_examples.rs
+++ b/crates/rari-doc/src/templ/templs/webext_all_examples.rs
@@ -29,7 +29,7 @@ pub fn webextallexamples() -> Result<String, DocError> {
             let url = format!(
                 "/{}/docs/Mozilla/Add-ons/WebExtensions/API/{}",
                 env.locale.as_url_str(),
-                &api.replace(' ', "_").replace("()", "").replace('.', "/"),
+                api.replace(' ', "_").replace("()", "").replace('.', "/"),
             );
             let link = RariApi::link(&url, Some(env.locale), None, true, None, false)?;
             out.push_str(&link);

--- a/crates/rari-tools/src/fix/issues.rs
+++ b/crates/rari-tools/src/fix/issues.rs
@@ -213,7 +213,7 @@ pub fn collect_suggestions(raw: &str, issues: &[DIssue]) -> Vec<SearchReplaceWit
         })
         .collect::<Vec<_>>();
 
-    suggestions.sort_by(|a, b| a.offset.cmp(&b.offset));
+    suggestions.sort_by_key(|a| a.offset);
     suggestions.dedup();
 
     suggestions

--- a/crates/rari-tools/src/redirects.rs
+++ b/crates/rari-tools/src/redirects.rs
@@ -506,7 +506,7 @@ fn compare_sorted_redirects(
     old_sorted_map: BTreeMap<&String, &String>,
     new_sorted_map: BTreeMap<String, String>,
 ) -> Result<(), ToolError> {
-    for (old, new) in old_sorted_map.into_iter().zip(new_sorted_map.into_iter()) {
+    for (old, new) in old_sorted_map.into_iter().zip(new_sorted_map) {
         if old.0 != &new.0 || old.1 != &new.1 {
             return Err(ToolError::InvalidRedirect(
                 old.0.clone(),


### PR DESCRIPTION
### Description

Bumps the Minimal Supported Rust Version (MSRV) from 1.90 to 1.97:

- Updates `rust-version` in `Cargo.toml`
- Updates the `dtolnay/rust-toolchain` pin in `.github/workflows/_build.yml`
- Updates the `dtolnay/rust-toolchain` pin in `.github/workflows/build-content-and-diff.yml`
- Updates the `dtolnay/rust-toolchain` pin in `.github/workflows/pr-review-companion.yml`
- Updates the `dtolnay/rust-toolchain` pin in `.github/workflows/sync-cargo-lock.yml`
- Updates the `dtolnay/rust-toolchain` pin in `.github/workflows/test.yml`

### Motivation

Consistency across repositories in the MDN organization.

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1684.