### PR TITLE
ci(dependabot): always update Cargo.toml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: cargo
     directory: /
+    versioning-strategy: increase
     schedule:
       interval: weekly
     commit-message:


### PR DESCRIPTION
Fixes: https://github.com/mdn/rari/issues/759

Relates to: https://github.com/mdn/rari/pull/758

This should ensure we never get a silent downgrade loop again by always updating both Cargo.toml and Cargo.lock.