### PR TITLE
Revert "ci(dependabot): always update Cargo.toml (#799)"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,6 @@ version: 2
 updates:
   - package-ecosystem: cargo
     directory: /
-    versioning-strategy: increase
     schedule:
       interval: weekly
     commit-message:


### PR DESCRIPTION
This reverts commit f33b013ca1e9e04634d4f8aa3c8f598e8d27783f.

`increase` is listed as supported in the docs, but the dependabot schema validator doesn't support it, breaking our entire dependabot config:

https://github.com/mdn/rari/network/updates:
> The property '#/updates/0/versioning-strategy' value "increase" did not match one of the following values: lockfile-only, auto