### PR TITLE
feat(baseline): add discouraged icons to sidebars, expose single status key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .DS_Store
 tests/data/content/files/*
 !tests/data/content/files/.keep
+!tests/data/content/files/jsondata
 tests/data/translated_content/files/*
 !tests/data/translated_content/files/.keep
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2610,6 +2610,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "strum",
  "thiserror 2.0.18",
  "tracing",
  "url",

--- a/crates/rari-data/Cargo.toml
+++ b/crates/rari-data/Cargo.toml
@@ -14,4 +14,5 @@ serde_json.workspace = true
 url.workspace = true
 indexmap.workspace = true
 schemars.workspace = true
+strum.workspace = true
 tracing.workspace = true

--- a/crates/rari-data/src/baseline.rs
+++ b/crates/rari-data/src/baseline.rs
@@ -24,6 +24,23 @@ pub struct Baseline<'a> {
     pub feature: &'a FeatureData,
 }
 
+#[derive(Serialize, JsonSchema, Debug, Clone, Copy, PartialEq, Eq, strum::Display)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum BaselineStatus {
+    High,
+    Low,
+    Limited,
+    Discouraged,
+    Removing,
+}
+
+impl BaselineStatus {
+    pub fn is_discouraged(self) -> bool {
+        matches!(self, Self::Discouraged | Self::Removing)
+    }
+}
+
 #[derive(Deserialize, Serialize, Debug, Clone, JsonSchema)]
 pub struct DeveloperSignals {
     pub url: String,
@@ -492,6 +509,40 @@ mod test {
 
     fn discouraged_fixture() -> WebFeatures {
         fixture("web-features.json")
+    }
+
+    const ALL_STATUSES: [(BaselineStatus, &str); 5] = [
+        (BaselineStatus::High, "high"),
+        (BaselineStatus::Low, "low"),
+        (BaselineStatus::Limited, "limited"),
+        (BaselineStatus::Discouraged, "discouraged"),
+        (BaselineStatus::Removing, "removing"),
+    ];
+
+    #[test]
+    fn baseline_status_serializes_as_its_name() {
+        for (status, name) in ALL_STATUSES {
+            assert_eq!(
+                serde_json::to_string(&status).unwrap(),
+                format!(r#""{name}""#)
+            );
+        }
+    }
+
+    #[test]
+    fn baseline_status_displays_as_it_serializes() {
+        for (status, name) in ALL_STATUSES {
+            assert_eq!(status.to_string(), name);
+        }
+    }
+
+    #[test]
+    fn only_discouraged_statuses_are_discouraged() {
+        assert!(BaselineStatus::Discouraged.is_discouraged());
+        assert!(BaselineStatus::Removing.is_discouraged());
+        assert!(!BaselineStatus::High.is_discouraged());
+        assert!(!BaselineStatus::Low.is_discouraged());
+        assert!(!BaselineStatus::Limited.is_discouraged());
     }
 
     #[test]

--- a/crates/rari-data/src/baseline.rs
+++ b/crates/rari-data/src/baseline.rs
@@ -24,6 +24,24 @@ pub struct Baseline<'a> {
     pub feature: &'a FeatureData,
 }
 
+impl Baseline<'_> {
+    pub fn status(&self) -> BaselineStatus {
+        baseline_status(self.feature, self.support)
+    }
+}
+
+fn baseline_status(feature: &FeatureData, support: &SupportStatus) -> BaselineStatus {
+    match feature.discouraged.as_ref() {
+        Some(discouraged) if discouraged.removal_date.is_some() => BaselineStatus::Removing,
+        Some(_) => BaselineStatus::Discouraged,
+        None => match support.baseline {
+            BaselineHighLow::High => BaselineStatus::High,
+            BaselineHighLow::Low => BaselineStatus::Low,
+            BaselineHighLow::False => BaselineStatus::Limited,
+        },
+    }
+}
+
 #[derive(Serialize, JsonSchema, Debug, Clone, Copy, PartialEq, Eq, strum::Display)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
@@ -192,9 +210,10 @@ impl WebFeatures {
                 })
                 .collect::<Vec<_>>();
 
-            let asterisk = if sub_status
-                .iter()
-                .all(|baseline| baseline == &Some(status_for_key.baseline))
+            let asterisk = if baseline_status(feature, status_for_key).is_discouraged()
+                || sub_status
+                    .iter()
+                    .all(|baseline| baseline == &Some(status_for_key.baseline))
             {
                 false
             } else {
@@ -518,6 +537,80 @@ mod test {
         (BaselineStatus::Discouraged, "discouraged"),
         (BaselineStatus::Removing, "removing"),
     ];
+
+    #[test]
+    fn baseline_high_is_high() {
+        let wf = discouraged_fixture();
+        let baseline = wf.baseline_by_bcd_key("svg.elements").unwrap();
+        assert_eq!(baseline.support.baseline, BaselineHighLow::High);
+        assert_eq!(baseline.status(), BaselineStatus::High);
+    }
+
+    #[test]
+    fn baseline_low_is_low() {
+        let wf = discouraged_fixture();
+        let baseline = wf.baseline_by_bcd_key("api.NoUrlThing").unwrap();
+        assert_eq!(baseline.support.baseline, BaselineHighLow::Low);
+        assert_eq!(baseline.status(), BaselineStatus::Low);
+    }
+
+    #[test]
+    fn baseline_false_is_limited() {
+        let wf = discouraged_fixture();
+        let baseline = wf.baseline_by_bcd_key("api.LimitedThing").unwrap();
+        assert_eq!(baseline.support.baseline, BaselineHighLow::False);
+        assert_eq!(baseline.status(), BaselineStatus::Limited);
+    }
+
+    #[test]
+    fn discouraged_without_a_removal_date_is_discouraged() {
+        let wf = discouraged_fixture();
+        let baseline = wf.baseline_by_bcd_key("api.LegacyThing").unwrap();
+        let discouraged = baseline.feature.discouraged.as_ref().unwrap();
+        assert!(discouraged.removal_date.is_none());
+        assert_eq!(baseline.status(), BaselineStatus::Discouraged);
+    }
+
+    #[test]
+    fn discouraged_with_a_removal_date_is_removing() {
+        let wf = discouraged_fixture();
+        let baseline = wf.baseline_by_bcd_key("api.OldThing").unwrap();
+        let discouraged = baseline.feature.discouraged.as_ref().unwrap();
+        assert!(discouraged.removal_date.is_some());
+        assert_eq!(baseline.status(), BaselineStatus::Removing);
+    }
+
+    #[test]
+    fn discouraged_outranks_the_baseline_level() {
+        let wf = discouraged_fixture();
+        let baseline = wf.baseline_by_bcd_key("api.LegacyThing").unwrap();
+        assert_eq!(baseline.support.baseline, BaselineHighLow::Low);
+        assert_eq!(baseline.status(), BaselineStatus::Discouraged);
+    }
+
+    #[test]
+    fn discouraged_feature_has_no_asterisk_when_sub_keys_differ() {
+        let wf = discouraged_fixture();
+        let parent = wf.baseline_by_bcd_key("api.MixedDiscouraged").unwrap();
+        let sub = wf.baseline_by_bcd_key("api.MixedDiscouraged.sub").unwrap();
+        assert_ne!(sub.support.baseline, parent.support.baseline);
+        assert!(!parent.asterisk);
+    }
+
+    #[test]
+    fn removing_feature_has_no_asterisk_when_sub_keys_differ() {
+        let wf = discouraged_fixture();
+        let parent = wf.baseline_by_bcd_key("api.MixedRemoving").unwrap();
+        let sub = wf.baseline_by_bcd_key("api.MixedRemoving.sub").unwrap();
+        assert_ne!(sub.support.baseline, parent.support.baseline);
+        assert!(!parent.asterisk);
+    }
+
+    #[test]
+    fn unknown_bcd_key_has_no_baseline() {
+        let wf = discouraged_fixture();
+        assert!(wf.baseline_by_bcd_key("api.NotAFeature").is_none());
+    }
 
     #[test]
     fn baseline_status_serializes_as_its_name() {

--- a/crates/rari-data/src/baseline.rs
+++ b/crates/rari-data/src/baseline.rs
@@ -210,10 +210,9 @@ impl WebFeatures {
                 })
                 .collect::<Vec<_>>();
 
-            let asterisk = if baseline_status(feature, status_for_key).is_discouraged()
-                || sub_status
-                    .iter()
-                    .all(|baseline| baseline == &Some(status_for_key.baseline))
+            let asterisk = if sub_status
+                .iter()
+                .all(|baseline| baseline == &Some(status_for_key.baseline))
             {
                 false
             } else {
@@ -589,21 +588,21 @@ mod test {
     }
 
     #[test]
-    fn discouraged_feature_has_no_asterisk_when_sub_keys_differ() {
+    fn discouraged_feature_has_asterisk_when_sub_keys_differ() {
         let wf = discouraged_fixture();
         let parent = wf.baseline_by_bcd_key("api.MixedDiscouraged").unwrap();
         let sub = wf.baseline_by_bcd_key("api.MixedDiscouraged.sub").unwrap();
         assert_ne!(sub.support.baseline, parent.support.baseline);
-        assert!(!parent.asterisk);
+        assert!(parent.asterisk);
     }
 
     #[test]
-    fn removing_feature_has_no_asterisk_when_sub_keys_differ() {
+    fn removing_feature_has_asterisk_when_sub_keys_differ() {
         let wf = discouraged_fixture();
         let parent = wf.baseline_by_bcd_key("api.MixedRemoving").unwrap();
         let sub = wf.baseline_by_bcd_key("api.MixedRemoving.sub").unwrap();
         assert_ne!(sub.support.baseline, parent.support.baseline);
-        assert!(!parent.asterisk);
+        assert!(parent.asterisk);
     }
 
     #[test]

--- a/crates/rari-data/src/baseline.rs
+++ b/crates/rari-data/src/baseline.rs
@@ -353,7 +353,7 @@ pub struct FeatureData {
 #[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
 pub struct Discouraged {
     reason_html: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing)]
     removal_date: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     according_to: Vec<String>,

--- a/crates/rari-data/tests/fixtures/web-features.json
+++ b/crates/rari-data/tests/fixtures/web-features.json
@@ -56,6 +56,55 @@
         "by_compat_key": { "svg.elements": { "baseline": "high", "support": {} } }
       },
       "compat_features": ["svg.elements"]
+    },
+    "limited-thing": {
+      "kind": "feature",
+      "name": "Limited Thing",
+      "description": "Limited availability",
+      "description_html": "Limited availability",
+      "status": {
+        "baseline": false,
+        "support": {},
+        "by_compat_key": { "api.LimitedThing": { "baseline": false, "support": {} } }
+      },
+      "compat_features": ["api.LimitedThing"]
+    },
+    "mixed-discouraged": {
+      "kind": "feature",
+      "name": "Mixed Discouraged",
+      "description": "A discouraged feature whose sub-key would otherwise earn an asterisk",
+      "description_html": "",
+      "status": {
+        "baseline": "high",
+        "support": {},
+        "by_compat_key": {
+          "api.MixedDiscouraged": { "baseline": "high", "support": {} },
+          "api.MixedDiscouraged.sub": { "baseline": "low", "support": {} }
+        }
+      },
+      "compat_features": ["api.MixedDiscouraged", "api.MixedDiscouraged.sub"],
+      "discouraged": {
+        "reason_html": "Use something else."
+      }
+    },
+    "mixed-removing": {
+      "kind": "feature",
+      "name": "Mixed Removing",
+      "description": "A removing feature whose sub-key would otherwise earn an asterisk",
+      "description_html": "",
+      "status": {
+        "baseline": "high",
+        "support": {},
+        "by_compat_key": {
+          "api.MixedRemoving": { "baseline": "high", "support": {} },
+          "api.MixedRemoving.sub": { "baseline": "low", "support": {} }
+        }
+      },
+      "compat_features": ["api.MixedRemoving", "api.MixedRemoving.sub"],
+      "discouraged": {
+        "reason_html": "Use something else.",
+        "removal_date": "2025-01-01"
+      }
     }
   }
 }

--- a/crates/rari-doc/src/baseline.rs
+++ b/crates/rari-doc/src/baseline.rs
@@ -5,9 +5,11 @@
 //! support status for specific browser compatibility keys.
 use std::sync::LazyLock;
 
-use rari_data::baseline::{Baseline, WebFeatures};
+use rari_data::baseline::{Baseline, BaselineStatus, WebFeatures};
 use rari_types::globals::data_dir;
 use tracing::error;
+
+use crate::pages::page::Page;
 
 static WEB_FEATURES: LazyLock<Option<WebFeatures>> = LazyLock::new(|| {
     let web_features = WebFeatures::from_file(&data_dir().join("web-features/package/data.json"));
@@ -38,6 +40,14 @@ pub(crate) fn get_baseline<'a>(browser_compat: &[String]) -> Option<Baseline<'a>
     None
 }
 
+pub(crate) fn get_baseline_status(page: &Page) -> Option<BaselineStatus> {
+    let doc = match page {
+        Page::Doc(doc) => doc,
+        _ => return None,
+    };
+    get_baseline(&doc.meta.browser_compat).map(|baseline| baseline.status())
+}
+
 fn get_baseline_from<'a>(
     browser_compat: &[String],
     web_features: &'a WebFeatures,
@@ -56,8 +66,10 @@ fn get_baseline_from<'a>(
 #[cfg(test)]
 mod tests {
     use rari_data::baseline::BaselineHighLow;
+    use rari_types::locale::Locale;
 
     use super::*;
+    use crate::pages::types::spa::SPA;
 
     static TEST_WEB_FEATURES: LazyLock<WebFeatures> = LazyLock::new(|| {
         let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -96,6 +108,12 @@ mod tests {
     fn single_limited() {
         let b = get(&["api.limited"]).unwrap();
         assert_eq!(b.support.baseline, BaselineHighLow::False);
+    }
+
+    #[test]
+    fn non_doc_pages_have_no_status() {
+        let page = SPA::from_slug("blog", Locale::EnUs).unwrap();
+        assert!(get_baseline_status(&page).is_none());
     }
 
     #[test]

--- a/crates/rari-doc/src/helpers/subpages.rs
+++ b/crates/rari-doc/src/helpers/subpages.rs
@@ -10,6 +10,7 @@ use rari_types::locale::Locale;
 
 use super::l10n::l10n_json_data;
 use super::titles::api_page_title;
+use crate::baseline::get_baseline_status;
 use crate::error::DocError;
 use crate::html::links::{LinkModifier, render_internal_link};
 use crate::pages::page::{Page, PageLike, PageReader};
@@ -82,6 +83,7 @@ pub fn write_li_with_badges(
             badge_locale: locale,
             code,
             only_en_us: locale_page.locale() != locale,
+            baseline: get_baseline_status(page),
         },
         true,
     )?;
@@ -110,6 +112,7 @@ pub fn write_li_with_details(
             badge_locale: locale,
             code,
             only_en_us: page.locale() != locale,
+            baseline: get_baseline_status(page),
         },
         true,
     )?;
@@ -133,6 +136,7 @@ pub fn write_parent_li(out: &mut String, page: &Page, locale: Locale) -> Result<
             badge_locale: locale,
             code: false,
             only_en_us: page.locale() != locale,
+            baseline: get_baseline_status(page),
         },
         true,
     )?;

--- a/crates/rari-doc/src/html/links.rs
+++ b/crates/rari-doc/src/html/links.rs
@@ -14,7 +14,9 @@ use crate::pages::page::{Page, PageLike};
 use crate::redirects::resolve_redirect;
 use crate::resolve::locale_from_url;
 use crate::templ::api::RariApi;
-use crate::templ::templs::badges::{write_deprecated, write_experimental, write_non_standard};
+use crate::templ::templs::badges::{
+    write_baseline, write_deprecated, write_experimental, write_non_standard,
+};
 
 pub struct LinkModifier<'a> {
     pub badges: &'a [FeatureStatus],
@@ -60,6 +62,12 @@ pub fn render_internal_link(
     out.push_str(content);
     if modifier.code {
         out.push_str("</code>");
+    }
+    // Only the discouraged statuses get an icon for now.
+    if let Some(baseline) = modifier.baseline
+        && baseline.is_discouraged()
+    {
+        write_baseline(out, baseline, modifier.badge_locale)?;
     }
     if !modifier.badges.is_empty() {
         if modifier.badges.contains(&FeatureStatus::Experimental) {
@@ -272,7 +280,9 @@ pub fn post_process_templ_links(html: &str) -> Result<String, DocError> {
 
 #[cfg(test)]
 mod tests {
-    use super::post_process_templ_links;
+    use super::{
+        BaselineStatus, LinkModifier, Locale, post_process_templ_links, render_internal_link,
+    };
 
     #[test]
     fn tags_internal_links_so_fix_link_skips_them() {
@@ -308,5 +318,53 @@ mod tests {
         let output = post_process_templ_links(input).unwrap();
         // Still exactly one occurrence (we didn't add another).
         assert_eq!(output.matches("data-templ-link").count(), 1);
+    }
+
+    fn render_with_baseline(baseline: Option<BaselineStatus>) -> String {
+        let mut out = String::new();
+        render_internal_link(
+            &mut out,
+            "/en-US/docs/Web/API/Document/write",
+            None,
+            "write()",
+            None,
+            &LinkModifier {
+                badges: &[],
+                badge_locale: Locale::EnUs,
+                code: false,
+                only_en_us: false,
+                baseline,
+            },
+            true,
+        )
+        .unwrap();
+        out
+    }
+
+    #[test]
+    fn discouraged_renders_a_baseline_icon() {
+        let out = render_with_baseline(Some(BaselineStatus::Discouraged));
+        assert!(
+            out.contains(
+                r#"<span role="img" class="icon icon-baseline discouraged" title="This feature is discouraged." aria-label="Discouraged"></span>"#
+            ),
+            "got: {out}"
+        );
+    }
+
+    #[test]
+    fn removing_renders_a_baseline_icon() {
+        let out = render_with_baseline(Some(BaselineStatus::Removing));
+        assert!(
+            out.contains(
+                r#"<span role="img" class="icon icon-baseline removing" title="This feature is scheduled for removal." aria-label="To be removed"></span>"#
+            ),
+            "got: {out}"
+        );
+    }
+
+    #[test]
+    fn a_link_with_no_baseline_renders_no_icon() {
+        assert!(!render_with_baseline(None).contains("icon"));
     }
 }

--- a/crates/rari-doc/src/html/links.rs
+++ b/crates/rari-doc/src/html/links.rs
@@ -1,11 +1,13 @@
 use std::borrow::Cow;
 
 use lol_html::{RewriteStrSettings, element, rewrite_str};
+use rari_data::baseline::BaselineStatus;
 use rari_md::anchor::anchorize;
 use rari_types::fm_types::FeatureStatus;
 use rari_types::locale::Locale;
 use rari_utils::concat_strs;
 
+use crate::baseline::get_baseline_status;
 use crate::error::DocError;
 use crate::issues::get_issue_counter;
 use crate::pages::page::{Page, PageLike};
@@ -19,6 +21,7 @@ pub struct LinkModifier<'a> {
     pub badge_locale: Locale,
     pub code: bool,
     pub only_en_us: bool,
+    pub baseline: Option<BaselineStatus>,
 }
 
 pub fn render_internal_link(
@@ -147,6 +150,11 @@ pub fn render_link_via_page(
                     badge_locale: locale,
                     code,
                     only_en_us: page.locale() == Locale::EnUs && locale != Locale::EnUs,
+                    baseline: if with_badges {
+                        get_baseline_status(&page)
+                    } else {
+                        None
+                    },
                 },
                 true,
             );

--- a/crates/rari-doc/src/html/sidebar.rs
+++ b/crates/rari-doc/src/html/sidebar.rs
@@ -19,6 +19,7 @@ use tracing::{Level, span};
 use super::links::{LinkFlags, LinkModifier, render_link_from_page, render_link_via_page};
 use super::modifier::insert_attribute;
 use super::rewriter::post_process_html;
+use crate::baseline::get_baseline_status;
 use crate::cached_readers::read_sidebar;
 use crate::error::DocError;
 use crate::helpers;
@@ -703,6 +704,7 @@ impl SidebarMetaEntry {
                         badge_locale: page.locale(),
                         code: self.code,
                         only_en_us: page.locale() != locale,
+                        baseline: get_baseline_status(page),
                     },
                 )?;
             }

--- a/crates/rari-doc/src/pages/build.rs
+++ b/crates/rari-doc/src/pages/build.rs
@@ -12,8 +12,8 @@ use tracing::{Level, span};
 
 use super::json::{
     BuiltPage, Compat, ContributorSpotlightHyData, JsonBlogPostDoc, JsonBlogPostPage,
-    JsonCurriculumPage, JsonDoc, JsonDocPage, JsonGenericHyData, JsonGenericPage, Prose, Section,
-    Source, SpecificationSection, TocEntry,
+    JsonCurriculumPage, JsonDoc, JsonDocPage, JsonGenericHyData, JsonGenericPage, PageStatus,
+    Prose, Section, Source, SpecificationSection, TocEntry,
 };
 use super::page::{Page, PageBuilder, PageLike};
 use super::types::contributors::ContributorSpotlight;
@@ -247,6 +247,9 @@ fn build_doc(doc: &Doc) -> Result<BuiltPage, DocError> {
         build_sidebars(doc)?
     };
     let baseline = get_baseline(&doc.meta.browser_compat);
+    let status = baseline.as_ref().map(|baseline| PageStatus {
+        baseline: Some(baseline.status()),
+    });
     let folder = doc
         .meta
         .path
@@ -320,6 +323,7 @@ fn build_doc(doc: &Doc) -> Result<BuiltPage, DocError> {
             toc,
             fragments,
             baseline,
+            status,
             modified,
             summary,
             popularity,

--- a/crates/rari-doc/src/pages/json.rs
+++ b/crates/rari-doc/src/pages/json.rs
@@ -7,7 +7,7 @@
 use std::path::PathBuf;
 
 use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
-use rari_data::baseline::Baseline;
+use rari_data::baseline::{Baseline, BaselineStatus};
 use rari_types::fm_types::PageType;
 use rari_types::locale::{Locale, Native};
 use schemars::JsonSchema;
@@ -287,6 +287,15 @@ pub struct JsonDoc {
     pub live_samples: Option<Vec<Code>>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub banners: Vec<FmTempl>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<PageStatus>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct PageStatus {
+    // Optional so we can add other statuses in the future.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub baseline: Option<BaselineStatus>,
 }
 
 impl JsonDocMetadata {
@@ -312,6 +321,7 @@ impl JsonDocMetadata {
             baseline,
             browser_compat,
             page_type,
+            status,
             ..
         } = value;
         Self {
@@ -335,6 +345,7 @@ impl JsonDocMetadata {
             baseline,
             browser_compat,
             page_type,
+            status,
             hash,
         }
     }
@@ -374,6 +385,8 @@ pub struct JsonDocMetadata {
     pub browser_compat: Vec<String>,
     #[serde(rename = "pageType")]
     pub page_type: PageType,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<PageStatus>,
     pub hash: String,
 }
 

--- a/crates/rari-doc/src/templ/templs/badges.rs
+++ b/crates/rari-doc/src/templ/templs/badges.rs
@@ -1,3 +1,4 @@
+use rari_data::baseline::BaselineStatus;
 use rari_templ_func::rari_f;
 use rari_types::locale::Locale;
 
@@ -57,6 +58,26 @@ pub fn write_deprecated(out: &mut impl std::fmt::Write, locale: Locale) -> Resul
     let abbreviation = l10n_json_data("Template", "deprecated_badge_abbreviation", locale)?;
 
     Ok(write_badge(out, title, abbreviation, "deprecated")?)
+}
+
+pub fn write_baseline(
+    out: &mut impl std::fmt::Write,
+    baseline: BaselineStatus,
+    locale: Locale,
+) -> Result<(), DocError> {
+    let title = l10n_json_data("Template", &format!("baseline_{baseline}_title"), locale)?;
+    let abbreviation = l10n_json_data(
+        "Template",
+        &format!("baseline_{baseline}_abbreviation"),
+        locale,
+    )?;
+
+    Ok(write_badge(
+        out,
+        title,
+        abbreviation,
+        &format!("baseline {baseline}"),
+    )?)
 }
 
 pub fn write_badge(

--- a/crates/rari-doc/src/templ/templs/list_subpages_for_sidebar.rs
+++ b/crates/rari-doc/src/templ/templs/list_subpages_for_sidebar.rs
@@ -1,6 +1,7 @@
 use rari_templ_func::rari_f;
 use rari_types::AnyArg;
 
+use crate::baseline::get_baseline_status;
 use crate::error::DocError;
 use crate::helpers::subpages::{SubPagesSorter, get_sub_pages};
 use crate::html::links::{LinkModifier, render_internal_link};
@@ -49,6 +50,7 @@ pub fn listsubpagesforsidebar(
                 badge_locale: env.locale,
                 code,
                 only_en_us: locale_page.locale() != env.locale,
+                baseline: get_baseline_status(&page),
             },
             true,
         )?;

--- a/tests/data/content/files/jsondata/L10n-Template.json
+++ b/tests/data/content/files/jsondata/L10n-Template.json
@@ -1,0 +1,6 @@
+{
+  "baseline_discouraged_title": { "en-US": "This feature is discouraged." },
+  "baseline_discouraged_abbreviation": { "en-US": "Discouraged" },
+  "baseline_removing_title": { "en-US": "This feature is scheduled for removal." },
+  "baseline_removing_abbreviation": { "en-US": "To be removed" }
+}


### PR DESCRIPTION
Depends on a content PR adding the l10n keys: https://github.com/mdn/content/pull/45017

Adds discouraged icons to the sidebars. Doing so requires calculating the discouraged statuses in rari - something the previous PR in the stack defers to fred. So, instead of calculating this in both rari and fred, this PR exposes the result of the calculation on `status.baseline` in the `index.json` which fred can consume. This field is outside of the `baseline` object to provide forwards compatibility with the mocked banner work (will be the next PR in this stack).