### PR TITLE
feat(baseline): hide deprecated banner/icon when we have a baseline one

### DIFF
--- a/crates/rari-doc/src/html/links.rs
+++ b/crates/rari-doc/src/html/links.rs
@@ -64,9 +64,10 @@ pub fn render_internal_link(
         out.push_str("</code>");
     }
     // Only the discouraged statuses get an icon for now.
-    if let Some(baseline) = modifier.baseline
-        && baseline.is_discouraged()
-    {
+    let discouraged_baseline = modifier
+        .baseline
+        .filter(|baseline| baseline.is_discouraged());
+    if let Some(baseline) = discouraged_baseline {
         write_baseline(out, baseline, modifier.badge_locale)?;
     }
     if !modifier.badges.is_empty() {
@@ -76,7 +77,7 @@ pub fn render_internal_link(
         if modifier.badges.contains(&FeatureStatus::NonStandard) {
             write_non_standard(out, modifier.badge_locale)?;
         }
-        if modifier.badges.contains(&FeatureStatus::Deprecated) {
+        if modifier.badges.contains(&FeatureStatus::Deprecated) && discouraged_baseline.is_none() {
             write_deprecated(out, modifier.badge_locale)?;
         }
     }
@@ -281,7 +282,8 @@ pub fn post_process_templ_links(html: &str) -> Result<String, DocError> {
 #[cfg(test)]
 mod tests {
     use super::{
-        BaselineStatus, LinkModifier, Locale, post_process_templ_links, render_internal_link,
+        BaselineStatus, FeatureStatus, LinkModifier, Locale, post_process_templ_links,
+        render_internal_link,
     };
 
     #[test]
@@ -320,7 +322,7 @@ mod tests {
         assert_eq!(output.matches("data-templ-link").count(), 1);
     }
 
-    fn render_with_baseline(baseline: Option<BaselineStatus>) -> String {
+    fn render_with(badges: &[FeatureStatus], baseline: Option<BaselineStatus>) -> String {
         let mut out = String::new();
         render_internal_link(
             &mut out,
@@ -329,7 +331,7 @@ mod tests {
             "write()",
             None,
             &LinkModifier {
-                badges: &[],
+                badges,
                 badge_locale: Locale::EnUs,
                 code: false,
                 only_en_us: false,
@@ -339,6 +341,10 @@ mod tests {
         )
         .unwrap();
         out
+    }
+
+    fn render_with_baseline(baseline: Option<BaselineStatus>) -> String {
+        render_with(&[], baseline)
     }
 
     #[test]
@@ -366,5 +372,38 @@ mod tests {
     #[test]
     fn a_link_with_no_baseline_renders_no_icon() {
         assert!(!render_with_baseline(None).contains("icon"));
+    }
+
+    #[test]
+    fn a_discouraged_baseline_replaces_the_deprecated_badge() {
+        for baseline in [BaselineStatus::Discouraged, BaselineStatus::Removing] {
+            let out = render_with(&[FeatureStatus::Deprecated], Some(baseline));
+            assert!(out.contains("icon-baseline"), "got: {out}");
+            assert!(!out.contains("icon-deprecated"), "got: {out}");
+        }
+    }
+
+    #[test]
+    fn a_baseline_that_is_not_discouraged_keeps_the_deprecated_badge() {
+        for baseline in [
+            None,
+            Some(BaselineStatus::High),
+            Some(BaselineStatus::Low),
+            Some(BaselineStatus::Limited),
+        ] {
+            let out = render_with(&[FeatureStatus::Deprecated], baseline);
+            assert!(out.contains("icon-deprecated"), "got: {out}");
+            assert!(!out.contains("icon-baseline"), "got: {out}");
+        }
+    }
+
+    #[test]
+    fn a_discouraged_baseline_leaves_the_other_badges_alone() {
+        let out = render_with(
+            &[FeatureStatus::Experimental, FeatureStatus::NonStandard],
+            Some(BaselineStatus::Discouraged),
+        );
+        assert!(out.contains("icon-experimental"), "got: {out}");
+        assert!(out.contains("icon-nonstandard"), "got: {out}");
     }
 }

--- a/crates/rari-doc/src/templ/templs/banners.rs
+++ b/crates/rari-doc/src/templ/templs/banners.rs
@@ -3,6 +3,7 @@ use rari_types::AnyArg;
 use rari_utils::concat_strs;
 use tracing::warn;
 
+use crate::baseline::get_baseline;
 use crate::error::DocError;
 use crate::helpers::l10n::l10n_json_data;
 
@@ -10,6 +11,9 @@ use crate::helpers::l10n::l10n_json_data;
 pub fn deprecated_header(version: Option<AnyArg>) -> Result<String, DocError> {
     if version.is_some() {
         warn!("Do not use deprecated header with parameter!")
+    }
+    if get_baseline(env.browser_compat).is_some_and(|baseline| baseline.status().is_discouraged()) {
+        return Ok(String::new());
     }
     let title = l10n_json_data("Template", "deprecated_badge_abbreviation", env.locale)?;
     let copy = l10n_json_data("Template", "deprecated_header_copy", env.locale)?;

--- a/tests/data/content/files/jsondata/L10n-Template.json
+++ b/tests/data/content/files/jsondata/L10n-Template.json
@@ -2,5 +2,15 @@
   "baseline_discouraged_title": { "en-US": "This feature is discouraged." },
   "baseline_discouraged_abbreviation": { "en-US": "Discouraged" },
   "baseline_removing_title": { "en-US": "This feature is scheduled for removal." },
-  "baseline_removing_abbreviation": { "en-US": "To be removed" }
+  "baseline_removing_abbreviation": { "en-US": "To be removed" },
+  "deprecated_badge_title": { "en-US": "Deprecated. Not for use in new websites." },
+  "deprecated_badge_abbreviation": { "en-US": "Deprecated" },
+  "experimental_badge_title": {
+    "en-US": "Experimental. Expect behavior to change in the future."
+  },
+  "experimental_badge_abbreviation": { "en-US": "Experimental" },
+  "non_standard_badge_title": {
+    "en-US": "Non-standard. Check cross-browser support before using."
+  },
+  "non_standard_badge_abbreviation": { "en-US": "Non-standard" }
 }


### PR DESCRIPTION
Needs to be released after we start rendering icons/banners in fred, otherwise we'll lose any kind of deprecated indication.
