### PR TITLE
feat(baseline): mock discouraged banner and sidebar icon

### DIFF
--- a/crates/rari-doc/src/baseline.rs
+++ b/crates/rari-doc/src/baseline.rs
@@ -6,6 +6,7 @@
 use std::sync::LazyLock;
 
 use rari_data::baseline::{Baseline, BaselineStatus, WebFeatures};
+use rari_types::fm_types::FeatureStatus;
 use rari_types::globals::data_dir;
 use tracing::error;
 
@@ -40,12 +41,33 @@ pub(crate) fn get_baseline<'a>(browser_compat: &[String]) -> Option<Baseline<'a>
     None
 }
 
+pub(crate) fn get_mocked_baseline_status(
+    fm_status: &[FeatureStatus],
+    slug: &str,
+) -> Option<BaselineStatus> {
+    if !fm_status.contains(&FeatureStatus::Deprecated) {
+        return None;
+    }
+    if !["Web/", "WebAssembly/"]
+        .iter()
+        .any(|prefix| slug.starts_with(prefix))
+        || slug.starts_with("Web/Accessibility/")
+    {
+        // only mock banners under Web and WebAssembly, as those are the sections we have Baseline banners
+        // don't mock under Web/Accessibility, as we don't
+        return None;
+    }
+    Some(BaselineStatus::Discouraged)
+}
+
 pub(crate) fn get_baseline_status(page: &Page) -> Option<BaselineStatus> {
     let doc = match page {
         Page::Doc(doc) => doc,
         _ => return None,
     };
-    get_baseline(&doc.meta.browser_compat).map(|baseline| baseline.status())
+    get_baseline(&doc.meta.browser_compat)
+        .map(|baseline| baseline.status())
+        .or_else(|| get_mocked_baseline_status(&doc.meta.status, &doc.meta.slug))
 }
 
 fn get_baseline_from<'a>(
@@ -130,5 +152,50 @@ mod tests {
     fn multiple_same_feature() {
         let b = get(&["api.high", "api.high-adjacent"]).unwrap();
         assert_eq!(b.support.baseline, BaselineHighLow::High);
+    }
+
+    fn mocked(slug: &str) -> Option<BaselineStatus> {
+        get_mocked_baseline_status(&[FeatureStatus::Deprecated], slug)
+    }
+
+    #[test]
+    fn a_deprecated_page_in_a_baseline_section_is_discouraged() {
+        for slug in [
+            "Web/API/AudioProcessingEvent",
+            "WebAssembly/JavaScript_interface/Memory",
+        ] {
+            assert_eq!(mocked(slug), Some(BaselineStatus::Discouraged), "{slug}");
+        }
+    }
+
+    #[test]
+    fn a_deprecated_page_outside_the_baseline_sections_is_not_mocked() {
+        for slug in [
+            "Mozilla/Add-ons/WebExtensions/API/tabs",
+            "Games/Techniques/3D_on_the_web",
+            "Learn_web_development/Core/Scripting",
+        ] {
+            assert_eq!(mocked(slug), None, "{slug}");
+        }
+    }
+
+    #[test]
+    fn the_excluded_section_is_not_mocked() {
+        assert_eq!(
+            mocked("Web/Accessibility/ARIA/Reference/Attributes/aria-dropeffect"),
+            None
+        );
+    }
+
+    #[test]
+    fn a_page_without_deprecated_status_is_not_mocked() {
+        let statuses: [&[FeatureStatus]; 2] = [&[], &[FeatureStatus::Experimental]];
+        for status in statuses {
+            assert_eq!(
+                get_mocked_baseline_status(status, "Web/API/Thing"),
+                None,
+                "{status:?}"
+            );
+        }
     }
 }

--- a/crates/rari-doc/src/pages/build.rs
+++ b/crates/rari-doc/src/pages/build.rs
@@ -18,7 +18,7 @@ use super::json::{
 use super::page::{Page, PageBuilder, PageLike};
 use super::types::contributors::ContributorSpotlight;
 use super::types::generic::Generic;
-use crate::baseline::get_baseline;
+use crate::baseline::{get_baseline, get_mocked_baseline_status};
 use crate::error::DocError;
 use crate::helpers::parents::parents;
 use crate::helpers::title::{TitleFormat, page_title, render_title, transform_title};
@@ -247,9 +247,13 @@ fn build_doc(doc: &Doc) -> Result<BuiltPage, DocError> {
         build_sidebars(doc)?
     };
     let baseline = get_baseline(&doc.meta.browser_compat);
-    let status = baseline.as_ref().map(|baseline| PageStatus {
-        baseline: Some(baseline.status()),
-    });
+    let status = baseline
+        .as_ref()
+        .map(|baseline| baseline.status())
+        .or_else(|| get_mocked_baseline_status(&doc.meta.status, &doc.meta.slug))
+        .map(|baseline_status| PageStatus {
+            baseline: Some(baseline_status),
+        });
     let folder = doc
         .meta
         .path

--- a/crates/rari-doc/src/pages/types/blog.rs
+++ b/crates/rari-doc/src/pages/types/blog.rs
@@ -258,6 +258,7 @@ impl PageLike for BlogPost {
             spec_urls: &[],
             page_type: PageType::BlogPost,
             slug: &self.meta.slug,
+            status: &[],
         })
     }
 

--- a/crates/rari-doc/src/pages/types/contributors.rs
+++ b/crates/rari-doc/src/pages/types/contributors.rs
@@ -205,6 +205,7 @@ impl PageLike for ContributorSpotlight {
             spec_urls: &[],
             page_type: PageType::BlogPost,
             slug: &self.meta.slug,
+            status: &[],
         })
     }
 

--- a/crates/rari-doc/src/pages/types/doc.rs
+++ b/crates/rari-doc/src/pages/types/doc.rs
@@ -283,6 +283,7 @@ impl PageLike for Doc {
             spec_urls: &self.meta.spec_urls,
             page_type: self.meta.page_type,
             slug: &self.meta.slug,
+            status: &self.meta.status,
         })
     }
 

--- a/crates/rari-doc/src/templ/templs/banners.rs
+++ b/crates/rari-doc/src/templ/templs/banners.rs
@@ -3,7 +3,7 @@ use rari_types::AnyArg;
 use rari_utils::concat_strs;
 use tracing::warn;
 
-use crate::baseline::get_baseline;
+use crate::baseline::{get_baseline, get_mocked_baseline_status};
 use crate::error::DocError;
 use crate::helpers::l10n::l10n_json_data;
 
@@ -12,7 +12,11 @@ pub fn deprecated_header(version: Option<AnyArg>) -> Result<String, DocError> {
     if version.is_some() {
         warn!("Do not use deprecated header with parameter!")
     }
-    if get_baseline(env.browser_compat).is_some_and(|baseline| baseline.status().is_discouraged()) {
+    if get_baseline(env.browser_compat)
+        .map(|baseline| baseline.status())
+        .or_else(|| get_mocked_baseline_status(env.status, env.slug))
+        .is_some_and(|status| status.is_discouraged())
+    {
         return Ok(String::new());
     }
     let title = l10n_json_data("Template", "deprecated_badge_abbreviation", env.locale)?;

--- a/crates/rari-types/src/lib.rs
+++ b/crates/rari-types/src/lib.rs
@@ -6,7 +6,7 @@ use locale::Locale;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::fm_types::PageType;
+use crate::fm_types::{FeatureStatus, PageType};
 
 pub mod error;
 pub mod fm_types;
@@ -136,6 +136,7 @@ pub struct RariEnv<'a> {
     pub spec_urls: &'a [String],
     pub page_type: PageType,
     pub slug: &'a str,
+    pub status: &'a [FeatureStatus],
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]


### PR DESCRIPTION
For pages in Web/ (but not Web/Accessibility) and WebAssembly/ sections - the sections which currently have Baseline banners - replace deprecated banners with a mocked discouraged baseline status, so fred can render a mocked discouraged baseline banner.

This is (hopefully) a temporary effort, as the web-features project has more and more of these discouraged BCD keys added to their data. Because of that:
- We're not as DRY as we could be, but exposing yet another `get_baseline_status...` variant for a different set of arguments seemed excessive
- Mocked banners lack the `Support` data necessary to render browser check/crosses - I prototyped this, but it required an enormous amount of BCD parsing we currently aren't doing in rari, and this data is far less important for these banners (and always exists on the BCD table at the bottom of page if users need it)