### PR TITLE
feat(baseline): mock baseline icon in deprecated_inline

### DIFF
--- a/crates/rari-doc/src/baseline.rs
+++ b/crates/rari-doc/src/baseline.rs
@@ -43,7 +43,7 @@ pub(crate) fn get_baseline<'a>(browser_compat: &[String]) -> Option<Baseline<'a>
 
 pub(crate) fn is_mocked_banner_section(slug: &str) -> bool {
     // only mock banners under Web and WebAssembly, as those are the sections we have Baseline banners
-    // don't mock under Web/Accessibility, as we don't
+    // don't mock under Web/Accessibility, as we don't have Baseline banners there
     ["Web/", "WebAssembly/"]
         .iter()
         .any(|prefix| slug.starts_with(prefix))

--- a/crates/rari-doc/src/baseline.rs
+++ b/crates/rari-doc/src/baseline.rs
@@ -41,6 +41,15 @@ pub(crate) fn get_baseline<'a>(browser_compat: &[String]) -> Option<Baseline<'a>
     None
 }
 
+pub(crate) fn is_mocked_banner_section(slug: &str) -> bool {
+    // only mock banners under Web and WebAssembly, as those are the sections we have Baseline banners
+    // don't mock under Web/Accessibility, as we don't
+    ["Web/", "WebAssembly/"]
+        .iter()
+        .any(|prefix| slug.starts_with(prefix))
+        && !slug.starts_with("Web/Accessibility/")
+}
+
 pub(crate) fn get_mocked_baseline_status(
     fm_status: &[FeatureStatus],
     slug: &str,
@@ -48,13 +57,7 @@ pub(crate) fn get_mocked_baseline_status(
     if !fm_status.contains(&FeatureStatus::Deprecated) {
         return None;
     }
-    if !["Web/", "WebAssembly/"]
-        .iter()
-        .any(|prefix| slug.starts_with(prefix))
-        || slug.starts_with("Web/Accessibility/")
-    {
-        // only mock banners under Web and WebAssembly, as those are the sections we have Baseline banners
-        // don't mock under Web/Accessibility, as we don't
+    if !is_mocked_banner_section(slug) {
         return None;
     }
     Some(BaselineStatus::Discouraged)

--- a/crates/rari-doc/src/templ/templs/badges.rs
+++ b/crates/rari-doc/src/templ/templs/badges.rs
@@ -2,6 +2,7 @@ use rari_data::baseline::BaselineStatus;
 use rari_templ_func::rari_f;
 use rari_types::locale::Locale;
 
+use crate::baseline::is_mocked_banner_section;
 use crate::error::DocError;
 use crate::helpers::l10n::l10n_json_data;
 
@@ -27,7 +28,11 @@ pub fn non_standard_inline() -> Result<String, DocError> {
 #[rari_f(register = "crate::Templ")]
 pub fn deprecated_inline() -> Result<String, DocError> {
     let mut out = String::new();
-    write_deprecated(&mut out, env.locale)?;
+    if is_mocked_banner_section(env.slug) {
+        write_baseline(&mut out, BaselineStatus::Discouraged, env.locale)?;
+    } else {
+        write_deprecated(&mut out, env.locale)?;
+    }
     Ok(out)
 }
 
@@ -91,4 +96,45 @@ pub fn write_badge(
         out,
         r#"<span role="img" class="icon icon-{typ}" title="{title}" aria-label="{abbreviation}"></span>"#
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use rari_types::RariEnv;
+
+    use super::*;
+
+    fn deprecated_inline_for(slug: &str) -> String {
+        let env = RariEnv {
+            slug,
+            locale: Locale::EnUs,
+            ..Default::default()
+        };
+        deprecated_inline(&env).unwrap()
+    }
+
+    #[test]
+    fn a_mocked_banner_section_gets_the_baseline_icon() {
+        for slug in [
+            "Web/API/AudioProcessingEvent",
+            "WebAssembly/JavaScript_interface/Memory",
+        ] {
+            let out = deprecated_inline_for(slug);
+            assert!(out.contains("icon-baseline discouraged"), "{slug}: {out}");
+            assert!(!out.contains("icon-deprecated"), "{slug}: {out}");
+        }
+    }
+
+    #[test]
+    fn everywhere_else_keeps_the_deprecated_icon() {
+        for slug in [
+            "Web/Accessibility/ARIA/Reference/Attributes/aria-dropeffect",
+            "Mozilla/Add-ons/WebExtensions/API/tabs",
+            "Learn_web_development/Core/Scripting",
+        ] {
+            let out = deprecated_inline_for(slug);
+            assert!(out.contains("icon-deprecated"), "{slug}: {out}");
+            assert!(!out.contains("icon-baseline"), "{slug}: {out}");
+        }
+    }
 }


### PR DESCRIPTION
Relates to https://github.com/mdn/fred/issues/654 and https://github.com/mdn/rari/issues/503

Rendering next to links is a bit of a larger change - one I'm working on - but as an interim fix, to remove the inline bin icons, I've extended the mock logic here too: if a deprecated_inline macro is used in a section which gets mocked banners, it gets a mocked baseline discouraged icon instead of a bin.

Before:

<img width="828" height="725" alt="image" src="https://github.com/user-attachments/assets/6d011a7a-a225-46b7-b070-eff44defca5e" />

After:

<img width="824" height="694" alt="image" src="https://github.com/user-attachments/assets/4ac9a572-6566-42b3-b654-f1ab1c95c28a" />
