### PR TITLE
chore(deps): bump comrak from 0.52.0 to 0.54.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,9 +396,9 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "comrak"
-version = "0.52.0"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aac0b255932a9cd52fbfd664b67957f9f2e095ae4711cb0e41b4e291edef94c2"
+checksum = "0d5910408554659ed848ff469e67ec83b30f179e72cec286cfdae64d1616f466"
 dependencies = [
  "caseless",
  "entities",

--- a/crates/rari-md/Cargo.toml
+++ b/crates/rari-md/Cargo.toml
@@ -14,4 +14,4 @@ rari-types.workspace = true
 itertools.workspace = true
 base64.workspace = true
 
-comrak = { version = "0.52", default-features = false }
+comrak = { version = "0.54", default-features = false }

--- a/crates/rari-md/src/dl.rs
+++ b/crates/rari-md/src/dl.rs
@@ -1,4 +1,5 @@
-use comrak::nodes::{AstNode, NodeValue};
+use comrak::Arena;
+use comrak::nodes::{AstNode, NodeDescriptionItem, NodeValue};
 
 pub(crate) fn is_dl<'a>(list: &'a AstNode<'a>) -> bool {
     list.children().all(|child| {
@@ -25,7 +26,7 @@ pub(crate) fn is_dl<'a>(list: &'a AstNode<'a>) -> bool {
     })
 }
 
-pub(crate) fn convert_dl<'a>(list: &'a AstNode<'a>) {
+pub(crate) fn convert_dl<'a>(arena: &'a Arena<'a>, list: &'a AstNode<'a>) {
     list.data.borrow_mut().value = NodeValue::DescriptionList;
     for child in list.children() {
         child.data.borrow_mut().value = NodeValue::DescriptionTerm;
@@ -34,8 +35,14 @@ pub(crate) fn convert_dl<'a>(list: &'a AstNode<'a>) {
             continue;
         }
         last_child.detach();
-        for item in last_child.reverse_children() {
-            if let Some(i) = item.first_child() {
+
+        let item = arena.alloc(NodeValue::DescriptionItem(NodeDescriptionItem::default()).into());
+        child.insert_before(item);
+        child.detach();
+        item.append(child);
+
+        for details in last_child.children() {
+            if let Some(i) = details.first_child() {
                 if !matches!(i.data.borrow().value, NodeValue::Paragraph) {
                     break;
                 }
@@ -48,9 +55,9 @@ pub(crate) fn convert_dl<'a>(list: &'a AstNode<'a>) {
                     }
                 }
             }
-            item.data.borrow_mut().value = NodeValue::DescriptionDetails;
-            item.detach();
-            child.insert_after(item);
+            details.data.borrow_mut().value = NodeValue::DescriptionDetails;
+            details.detach();
+            item.append(details);
         }
     }
 }

--- a/crates/rari-md/src/html.rs
+++ b/crates/rari-md/src/html.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use std::fmt::Write;
 
 use comrak::create_formatter;
-use comrak::html::{collect_text, render_math_code_block, render_sourcepos, write_opening_tag};
+use comrak::html::{render_math_code_block, render_sourcepos, write_opening_tag};
 use comrak::nodes::NodeValue;
 use itertools::Itertools;
 use rari_types::locale::Locale;
@@ -154,7 +154,7 @@ create_formatter!(CustomFormatter<RariContext>, {
             context.cr()?;
             write!(context, "<h{}", nch.level)?;
             if context.options.extension.header_id_prefix.is_some() {
-                let raw_id = collect_text(node);
+                let raw_id = node.collect_text();
 
                 let is_templ = raw_id.contains(DELIM_START);
                 if is_templ {
@@ -227,7 +227,7 @@ create_formatter!(CustomFormatter<RariContext>, {
                     context.write_str("\" title=\"")?;
                     context.escape(&nl.title)?;
                 }
-                let text_content = collect_text(node);
+                let text_content = node.collect_text();
 
                 if text_content == *nl.url {
                     context.write_str("\" data-autolink=\"")?;

--- a/crates/rari-md/src/lib.rs
+++ b/crates/rari-md/src/lib.rs
@@ -333,6 +333,20 @@ mod test {
     }
 
     #[test]
+    fn templ_only_p() -> Result<(), anyhow::Error> {
+        let out = m2h("⟬0⟭", Locale::EnUs)?;
+        assert_eq!(out, "⟬0⟭");
+        Ok(())
+    }
+
+    #[test]
+    fn templ_only_p_soft_break() -> Result<(), anyhow::Error> {
+        let out = m2h("⟬0⟭\n⟬1⟭", Locale::EnUs)?;
+        assert_eq!(out, "⟬0⟭\n⟬1⟭");
+        Ok(())
+    }
+
+    #[test]
     fn li_p() -> Result<(), anyhow::Error> {
         let out = m2h("- foo\n- bar\n", Locale::EnUs)?;
         assert_eq!(

--- a/crates/rari-md/src/lib.rs
+++ b/crates/rari-md/src/lib.rs
@@ -207,7 +207,7 @@ pub fn m2h_internal(
             _ => (false, false, false),
         };
         if dl {
-            convert_dl(node);
+            convert_dl(&arena, node);
         }
         if templs_p || empty_p {
             fix_p(node)

--- a/crates/rari-md/src/p.rs
+++ b/crates/rari-md/src/p.rs
@@ -33,10 +33,16 @@ pub(crate) fn is_empty_p<'a>(p: &'a AstNode<'a>) -> bool {
 }
 
 pub(crate) fn fix_p<'a>(p: &'a AstNode<'a>) {
-    for child in p.reverse_children() {
-        p.insert_before(child)
+    let mut literal = String::new();
+    for child in p.children() {
+        match &child.data.borrow().value {
+            NodeValue::Text(t) => literal.push_str(t),
+            NodeValue::SoftBreak => literal.push('\n'),
+            _ => {}
+        }
+        child.detach();
     }
-    p.detach();
+    p.data.borrow_mut().value = NodeValue::Raw(literal);
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Replaces https://github.com/mdn/rari/pull/798

comrak changed one import we use, and required a slightly stricter node construction.

The only change to output is fixing the ordering output of two or more macros in their own paragraph on their own lines.