### PR TITLE
fix(css_ref): list deprecated and non-standard pages with badges

### DIFF
--- a/crates/rari-doc/src/templ/templs/css_ref.rs
+++ b/crates/rari-doc/src/templ/templs/css_ref.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeMap, HashMap};
 
 use itertools::Itertools;
 use rari_templ_func::rari_f;
-use rari_types::fm_types::{FeatureStatus, PageType};
+use rari_types::fm_types::PageType;
 use rari_utils::concat_strs;
 
 use crate::error::DocError;
@@ -54,7 +54,7 @@ pub fn css_ref() -> Result<String, DocError> {
                 Some(&placeholder_label),
                 false,
                 None,
-                false,
+                true,
             )?;
             out.extend([
                 "<li>",
@@ -84,10 +84,7 @@ fn is_indexed_css_ref_page(page: &Page) -> bool {
             | PageType::CssPseudoClass
             | PageType::CssShorthandProperty
             | PageType::CssAtRuleDescriptor
-    ) && !page
-        .status()
-        .iter()
-        .any(|s| matches!(s, FeatureStatus::Deprecated | FeatureStatus::NonStandard))
+    )
 }
 
 fn sort_key(s: &str) -> &str {


### PR DESCRIPTION
Fixes https://github.com/mdn/rari/issues/841

Experimental was shown, but had no badge to distinguish: added that.

Adding both deprecated and non-standard (also with badges) so the list is complete.