### PR TITLE
feat(templ): report which macro argument is at fault

### DIFF
--- a/crates/rari-doc/src/issues.rs
+++ b/crates/rari-doc/src/issues.rs
@@ -297,6 +297,7 @@ pub enum IssueType {
     TemplIllCasedLink,
     TemplIllCasedArg,
     TemplInvalidArg,
+    TemplArgError,
     TemplMdnDataMissing,
     RedirectedLink,
     BrokenLink,
@@ -315,6 +316,7 @@ impl FromStr for IssueType {
             "templ-ill-cased-link" => Self::TemplIllCasedLink,
             "templ-ill-cased-arg" => Self::TemplIllCasedArg,
             "templ-invalid-arg" => Self::TemplInvalidArg,
+            "templ-arg-error" => Self::TemplArgError,
             "templ-mdn-data-missing" => Self::TemplMdnDataMissing,
             "redirected-link" => Self::RedirectedLink,
             "broken-link" => Self::BrokenLink,
@@ -578,6 +580,17 @@ impl DIssue {
                             .map(|s| s.as_str())
                             .unwrap_or("?")
                     ));
+                    DIssue::Macros {
+                        display_issue: di,
+                        macro_name: source.name,
+                        href: None,
+                    }
+                }
+                IssueType::TemplArgError => {
+                    let source = issue_source(&mut additional);
+                    di.fixed = false;
+                    di.fixable = Some(false);
+                    di.explanation = additional.remove("message");
                     DIssue::Macros {
                         display_issue: di,
                         macro_name: source.name,

--- a/crates/rari-doc/src/templ/parser.rs
+++ b/crates/rari-doc/src/templ/parser.rs
@@ -46,8 +46,18 @@ fn from_node<'a>(
     })
 }
 
+/// Returns `None` for an unparseable argument (a tree-sitter `ERROR` node), but
+/// an empty [`Arg::String`] for a blank one (`""` or `{{foo(,"bar")}}`).
 fn ts_to_arg(value: tree_sitter::Node<'_>, content: &str) -> Option<Arg> {
     match value.kind() {
+        "none" => Some(Arg::String(
+            String::new(),
+            match content[value.start_byte()..].chars().next() {
+                Some('\'') => Quotes::Single,
+                Some('`') => Quotes::Back,
+                _ => Quotes::Double,
+            },
+        )),
         "string" => {
             if let Some(child) = value.child(0) {
                 ts_to_arg(child, content)
@@ -157,11 +167,45 @@ mod test {
     }
 
     #[test]
-    fn with_empty_string_arg() {
-        let p = parse(r#"{{foo("")}}"#);
-        assert!(matches!(
-            p.unwrap().first(),
-            Some(Token::Macro(macro_token)) if macro_token.args.first() == Some(&None)
-        ));
+    fn arg_shapes() {
+        let blank = Some(Arg::String(String::new(), Quotes::Double));
+        let cases: Vec<(&str, &str, Vec<Option<Arg>>)> = vec![
+            (
+                "empty string literal",
+                r#"{{foo("")}}"#,
+                vec![blank.clone()],
+            ),
+            (
+                "empty string literal among others",
+                r#"{{foo('', 'CSS')}}"#,
+                vec![
+                    Some(Arg::String(String::new(), Quotes::Single)),
+                    Some(Arg::String("CSS".into(), Quotes::Single)),
+                ],
+            ),
+            (
+                "omitted argument",
+                r#"{{foo(,"CSS")}}"#,
+                vec![
+                    blank.clone(),
+                    Some(Arg::String("CSS".into(), Quotes::Double)),
+                ],
+            ),
+            ("no parentheses", "{{foo}}", vec![]),
+            ("empty parentheses", "{{foo()}}", vec![]),
+            (
+                "unparseable argument",
+                "{{foo(\u{300c}label\u{300d})}}",
+                vec![None],
+            ),
+        ];
+        for (name, input, expected) in cases {
+            let tokens = parse(input).unwrap();
+            let args = match tokens.first() {
+                Some(Token::Macro(m)) => m.args.clone(),
+                other => panic!("{name}: expected a macro token, got {other:?}"),
+            };
+            assert_eq!(args, expected, "{name}");
+        }
     }
 }

--- a/crates/rari-doc/src/templ/render.rs
+++ b/crates/rari-doc/src/templ/render.rs
@@ -42,11 +42,13 @@ pub(crate) fn render_for_summary(input: &str) -> Result<String, DocError> {
                         .get(1)
                         .or(mac.args.first())
                         .and_then(|f| f.clone())
+                        .filter(|arg| !arg.is_blank())
                         .map(|arg| AnyArg::try_from(arg).unwrap().to_string()),
                     _ => mac
                         .args
                         .first()
                         .and_then(|f| f.clone())
+                        .filter(|arg| !arg.is_blank())
                         .map(|arg| format!("<code>{}</code>", AnyArg::try_from(arg).unwrap())),
                 } {
                     out.push_str(&s)
@@ -102,7 +104,10 @@ pub(crate) fn render(env: &RariEnv, input: &str, offset: usize) -> Result<Render
                     }
                     Err(e) if deny_warnings() => return Err(e),
                     Err(e) => {
-                        warn!("{e}",);
+                        match &e {
+                            DocError::ArgError(_) => warn!(source = "templ-arg-error", "Macro {e}"),
+                            _ => warn!("{e}"),
+                        }
                         encode_ref(templs.len(), &mut out, mac.end - mac.start)?;
                         //templs.push(format!("___ERROR in ({ident}): {e}___"));
                         templs.push(e.to_string())

--- a/crates/rari-doc/src/templ/templs/links/domxref.rs
+++ b/crates/rari-doc/src/templ/templs/links/domxref.rs
@@ -57,7 +57,12 @@ pub fn domxref(
         .replace(".prototype.", ".")
         .replace('.', "/");
     if api.is_empty() {
-        return Err(DocError::ArgError(ArgError::MustBeProvided));
+        return Err(DocError::ArgError(ArgError::at(
+            "domxref",
+            1,
+            "api_name",
+            ArgError::MustNotBeEmpty,
+        )));
     }
     let resolved = resolve_api_name(&api);
     let mut url = format!(

--- a/crates/rari-templ-func/src/lib.rs
+++ b/crates/rari-templ-func/src/lib.rs
@@ -148,7 +148,7 @@ pub fn rari_f(attr: TokenStream, input: TokenStream) -> TokenStream {
     let mapping = args.iter().filter_map(|arg| match arg {
 		syn::FnArg::Typed(ty) => Some(ty),
 		_ => None,
-	}).map(|arg| {
+	}).enumerate().map(|(i, arg)| {
 	let ty = &arg.ty;
 	let option = if let syn::Type::Path(p) = &**ty {
 		is_option(p)
@@ -156,17 +156,31 @@ pub fn rari_f(attr: TokenStream, input: TokenStream) -> TokenStream {
 		false
 	};
 	let ident = &arg.pat;
+	let templ = &name;
+	let pos = i + 1;
+	let arg_name = ident.to_token_stream().to_string();
 	if option {
-		quote! { let #ident: #ty = match args_iter.next().map(|arg| arg.map(TryInto::try_into)) {
+		quote! { let #ident: #ty = match args_iter.next().flatten() {
             None => None,
-			Some(None) => None,
-            Some(Some(Ok(o))) => Some(o),
-            Some(Some(Err(e))) => {
-              return Err(e.into());
-            },
+			Some(arg) if arg.is_blank() => None,
+            Some(arg) => Some(
+                TryInto::try_into(arg).map_err(|e| ArgError::at(#templ, #pos, #arg_name, e))?
+            ),
 		}; }
 	} else {
-		quote! { let #ident: #ty = args_iter.next().flatten().ok_or(ArgError::MustBeProvided).and_then(TryInto::try_into)?; }
+		quote! { let #ident: #ty = match args_iter.next() {
+            None => return Err(
+                ArgError::at(#templ, #pos, #arg_name, ArgError::MustBeProvided).into()
+            ),
+            Some(None) => return Err(
+                ArgError::at(#templ, #pos, #arg_name, ArgError::MustBeParsable).into()
+            ),
+            Some(Some(arg)) if arg.is_blank() => return Err(
+                ArgError::at(#templ, #pos, #arg_name, ArgError::MustNotBeEmpty).into()
+            ),
+            Some(Some(arg)) => TryInto::try_into(arg)
+                .map_err(|e| ArgError::at(#templ, #pos, #arg_name, e))?,
+		}; }
 	}
 	});
     let block = dup.block;

--- a/crates/rari-templ-func/tests/basic.rs
+++ b/crates/rari-templ-func/tests/basic.rs
@@ -52,6 +52,60 @@ fn basic() {
 }
 
 #[test]
+fn arg_errors_name_the_offending_argument() {
+    #[rari_f]
+    fn link(url: String, display: Option<String>) -> Result<String, ArgError> {
+        Ok(format!("{url} {}", display.unwrap_or_default()))
+    }
+
+    let blank = || Some(Arg::String(String::new(), Quotes::Double));
+    let cases: Vec<(&str, Vec<Option<Arg>>, &str)> = vec![
+        (
+            "missing required argument",
+            vec![],
+            "link argument 1 (url) must be provided",
+        ),
+        (
+            "unparseable required argument",
+            vec![None],
+            "link argument 1 (url) could not be parsed",
+        ),
+        (
+            "blank required argument",
+            vec![blank()],
+            "link argument 1 (url) must not be empty",
+        ),
+        (
+            "ill-typed required argument",
+            vec![Some(Arg::Int(1))],
+            "link argument 1 (url) must be a string",
+        ),
+        (
+            "ill-typed optional argument",
+            vec![
+                Some(Arg::String("a".into(), Quotes::Double)),
+                Some(Arg::Int(1)),
+            ],
+            "link argument 2 (display) must be a string",
+        ),
+    ];
+    for (name, args, expected) in cases {
+        let e = link_any(&Default::default(), args).unwrap_err();
+        assert_eq!(e.to_string(), expected, "{name}");
+    }
+
+    // Blank optional arguments count as absent.
+    assert_eq!(
+        link_any(
+            &Default::default(),
+            vec![Some(Arg::String("a".into(), Quotes::Double)), blank()]
+        )
+        .unwrap(),
+        "a "
+    );
+}
+
+#[test]
 fn env() {
     #[rari_f]
     fn something(a: String) -> Result<String, ArgError> {

--- a/crates/rari-types/src/lib.rs
+++ b/crates/rari-types/src/lib.rs
@@ -25,6 +25,31 @@ pub enum ArgError {
     MustBeBool,
     #[error("must be provided")]
     MustBeProvided,
+    #[error("must not be empty")]
+    MustNotBeEmpty,
+    #[error("could not be parsed")]
+    MustBeParsable,
+    /// An [`ArgError`] annotated with the templ and the 1-based position and
+    /// name of the offending parameter.
+    #[error("{templ} argument {pos} ({name}) {source}")]
+    At {
+        templ: &'static str,
+        pos: usize,
+        name: &'static str,
+        #[source]
+        source: Box<ArgError>,
+    },
+}
+
+impl ArgError {
+    pub fn at(templ: &'static str, pos: usize, name: &'static str, source: ArgError) -> Self {
+        ArgError::At {
+            templ,
+            pos,
+            name,
+            source: Box::new(source),
+        }
+    }
 }
 
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
@@ -40,6 +65,14 @@ pub enum Arg {
     Int(i64),
     Float(f64),
     Bool(bool),
+}
+
+impl Arg {
+    /// Whether this is an empty string literal (`""`) or an omitted argument
+    /// (`{{foo(,"bar")}}`).
+    pub fn is_blank(&self) -> bool {
+        matches!(self, Arg::String(s, _) if s.is_empty())
+    }
 }
 
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]

--- a/crates/rari-types/src/lib.rs
+++ b/crates/rari-types/src/lib.rs
@@ -29,8 +29,6 @@ pub enum ArgError {
     MustNotBeEmpty,
     #[error("could not be parsed")]
     MustBeParsable,
-    /// An [`ArgError`] annotated with the templ and the 1-based position and
-    /// name of the offending parameter.
     #[error("{templ} argument {pos} ({name}) {source}")]
     At {
         templ: &'static str,
@@ -68,8 +66,6 @@ pub enum Arg {
 }
 
 impl Arg {
-    /// Whether this is an empty string literal (`""`) or an omitted argument
-    /// (`{{foo(,"bar")}}`).
     pub fn is_blank(&self) -> bool {
         matches!(self, Arg::String(s, _) if s.is_empty())
     }


### PR DESCRIPTION
### Description

Name the macro and the offending argument in templ argument errors, and split the catch-all `must be provided` into three distinct messages:

- `must be provided`: nothing in that slot (`{{cssxref()}}`)
- `must not be empty`: a blank slot (`{{cssxref("")}}`, `{{cssxref(,"CSS")}}`)
- `could not be parsed`: an unparseable token (`{{htmlelement(「label」)}}`)

Reported under a new `templ-arg-error` source, so they land in the `macros` flaw bucket with `macroName` set instead of in `unknown`.

### Motivation

Make a templ argument flaw fixable from the report alone. `must be provided` said neither which argument was at fault nor which of three unrelated content bugs it was, each needing a different fix.

### Additional details

```
must be provided  ->  Macro cssxref argument 1 (name) must be provided
must be provided  ->  Macro domxref argument 1 (api_name) must not be empty
must be provided  ->  Macro htmlelement argument 1 (element_name) could not be parsed
must be a string  ->  Macro jsxref argument 3 (anchor) must be a string
```

A full build reports the same 17469 issues at identical positions as `main`; only these 13 messages change.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

