### PR TITLE
feat(templ): report malformed macro syntax as its own flaw

### DIFF
--- a/crates/rari-doc/src/issues.rs
+++ b/crates/rari-doc/src/issues.rs
@@ -298,6 +298,7 @@ pub enum IssueType {
     TemplIllCasedArg,
     TemplInvalidArg,
     TemplArgError,
+    TemplSyntaxError,
     TemplMdnDataMissing,
     RedirectedLink,
     BrokenLink,
@@ -317,6 +318,7 @@ impl FromStr for IssueType {
             "templ-ill-cased-arg" => Self::TemplIllCasedArg,
             "templ-invalid-arg" => Self::TemplInvalidArg,
             "templ-arg-error" => Self::TemplArgError,
+            "templ-syntax-error" => Self::TemplSyntaxError,
             "templ-mdn-data-missing" => Self::TemplMdnDataMissing,
             "redirected-link" => Self::RedirectedLink,
             "broken-link" => Self::BrokenLink,
@@ -586,7 +588,7 @@ impl DIssue {
                         href: None,
                     }
                 }
-                IssueType::TemplArgError => {
+                IssueType::TemplArgError | IssueType::TemplSyntaxError => {
                     let source = issue_source(&mut additional);
                     di.fixed = false;
                     di.fixable = Some(false);

--- a/crates/rari-doc/src/templ/parser.rs
+++ b/crates/rari-doc/src/templ/parser.rs
@@ -16,6 +16,10 @@ pub struct MacroToken {
     pub ident: String,
     pub pos: (usize, usize),
     pub args: Vec<Option<Arg>>,
+    /// Whether the macro contains a syntax error, e.g. a stray parenthesis in
+    /// `{{cssxref(("color")}}`. Its `args` are then whatever tree-sitter managed
+    /// to recover and should not be trusted.
+    pub malformed: bool,
 }
 
 fn from_node<'a>(
@@ -25,7 +29,12 @@ fn from_node<'a>(
 ) -> Option<MacroToken> {
     let ident_node = value.named_child(0).unwrap();
     let ident = content[ident_node.start_byte()..ident_node.end_byte()].to_string();
-    let args = if let Some(args_node) = value.named_child(1) {
+    // Look the arguments up by kind: a syntax error inserts an `ERROR` node,
+    // which would otherwise be mistaken for them.
+    let args = if let Some(args_node) = value
+        .named_children(&mut value.walk())
+        .find(|child| child.kind() == "args")
+    {
         args_node
             .named_children(cursor)
             .map(|arg| ts_to_arg(arg, content))
@@ -43,6 +52,7 @@ fn from_node<'a>(
         pos,
         ident,
         args,
+        malformed: value.has_error(),
     })
 }
 
@@ -206,6 +216,47 @@ mod test {
                 other => panic!("{name}: expected a macro token, got {other:?}"),
             };
             assert_eq!(args, expected, "{name}");
+        }
+    }
+
+    #[test]
+    fn malformed_macros() {
+        let cases: Vec<(&str, &str, bool, Vec<Option<Arg>>)> = vec![
+            (
+                "well-formed",
+                r#"{{cssxref("color")}}"#,
+                false,
+                vec![Some(Arg::String("color".into(), Quotes::Double))],
+            ),
+            (
+                "unparseable argument",
+                "{{htmlelement(\u{300c}label\u{300d})}}",
+                true,
+                vec![None],
+            ),
+            (
+                // The stray `(` inserts an `ERROR` node before the arguments,
+                // which are still recovered by looking them up by kind.
+                "stray opening parenthesis",
+                r#"{{cssxref(("color")}}"#,
+                true,
+                vec![Some(Arg::String("color".into(), Quotes::Double))],
+            ),
+            (
+                "unbalanced quotes",
+                r#"{{WebExtAPIRef("userScripts.,"execute()", "execute()"}}"#,
+                true,
+                vec![],
+            ),
+        ];
+        for (name, input, malformed, expected_args) in cases {
+            let tokens = parse(input).unwrap();
+            let m = match tokens.first() {
+                Some(Token::Macro(m)) => m,
+                other => panic!("{name}: expected a macro token, got {other:?}"),
+            };
+            assert_eq!(m.malformed, malformed, "{name}: malformed");
+            assert_eq!(m.args, expected_args, "{name}: args");
         }
     }
 }

--- a/crates/rari-doc/src/templ/parser.rs
+++ b/crates/rari-doc/src/templ/parser.rs
@@ -16,9 +16,6 @@ pub struct MacroToken {
     pub ident: String,
     pub pos: (usize, usize),
     pub args: Vec<Option<Arg>>,
-    /// Whether the macro contains a syntax error, e.g. a stray parenthesis in
-    /// `{{cssxref(("color")}}`. Its `args` are then whatever tree-sitter managed
-    /// to recover and should not be trusted.
     pub malformed: bool,
 }
 

--- a/crates/rari-doc/src/templ/render.rs
+++ b/crates/rari-doc/src/templ/render.rs
@@ -92,6 +92,12 @@ pub(crate) fn render(env: &RariEnv, input: &str, offset: usize) -> Result<Render
                     end_col = end_col
                 );
                 let _enter = span.enter();
+                if mac.malformed {
+                    warn!(
+                        source = "templ-syntax-error",
+                        "Macro {name} has invalid syntax"
+                    );
+                }
                 match invoke(env, &name, mac.args) {
                     Ok((rendered, TemplType::Sidebar)) => {
                         encode_ref(templs.len(), &mut out, mac.end - mac.start)?;
@@ -105,6 +111,10 @@ pub(crate) fn render(env: &RariEnv, input: &str, offset: usize) -> Result<Render
                     Err(e) if deny_warnings() => return Err(e),
                     Err(e) => {
                         match &e {
+                            // A malformed macro already reported a syntax error and its
+                            // recovered arguments are unreliable, so don't also complain
+                            // about them.
+                            DocError::ArgError(_) if mac.malformed => {}
                             DocError::ArgError(_) => warn!(source = "templ-arg-error", "Macro {e}"),
                             _ => warn!("{e}"),
                         }

--- a/crates/rari-doc/src/templ/render.rs
+++ b/crates/rari-doc/src/templ/render.rs
@@ -95,7 +95,7 @@ pub(crate) fn render(env: &RariEnv, input: &str, offset: usize) -> Result<Render
                 if mac.malformed {
                     warn!(
                         source = "templ-syntax-error",
-                        "Macro {name} has invalid syntax"
+                        "Macro {name} has syntax error"
                     );
                 }
                 match invoke(env, &name, mac.args) {


### PR DESCRIPTION
### Description

Report a macro with a syntax error as its own `templ-syntax-error` flaw instead of a misleading complaint about its arguments.

- Look the `args` node up by kind, so argument recovery is not thrown off by a preceding tree-sitter `ERROR` node.
- Record `MacroToken::malformed` from `Node::has_error`, and suppress the argument error a malformed macro would otherwise produce, since its recovered arguments are not trustworthy.

### Motivation

Point the author at the typo. The stray `(` in `{{cssxref(("color")}}` made rari drop every argument and render `must be provided` into the page, which says nothing about the actual mistake.

### Additional details

`{{cssxref(("color")}}` now renders the `color` link it was meant to produce and reports `Macro cssxref has invalid syntax`.

Against #865, a full build surfaces 26 malformed macros (23 previously silent) and replaces 3 misleading argument errors. Spot checks found no false positives: all are missing `)`, doubled `(`, or unescaped quotes. Rendered output is unchanged on every affected page except the one above.

### Related issues and pull requests

**Depends on:** #865

