### PR TITLE
fix(issues): report correct end position for multi-line macros

### DIFF
--- a/crates/rari-doc/src/templ/parser.rs
+++ b/crates/rari-doc/src/templ/parser.rs
@@ -14,7 +14,10 @@ pub struct MacroToken {
     pub start: usize,
     pub end: usize,
     pub ident: String,
+    /// 0-based `(row, byte column)` of the macro start.
     pub pos: (usize, usize),
+    /// 0-based exclusive `(row, byte column)` of the macro end.
+    pub end_pos: (usize, usize),
     pub args: Vec<Option<Arg>>,
     pub malformed: bool,
 }
@@ -43,10 +46,13 @@ fn from_node<'a>(
     let end = value.end_byte();
     let start_position = value.start_position();
     let pos = (start_position.row, start_position.column);
+    let end_position = value.end_position();
+    let end_pos = (end_position.row, end_position.column);
     Some(MacroToken {
         start,
         end,
         pos,
+        end_pos,
         ident,
         args,
         malformed: value.has_error(),
@@ -170,6 +176,52 @@ mod test {
         for node in tree.root_node().children(&mut cursor) {
             println!("{}", node.grammar_name());
             println!("{node:?}");
+        }
+    }
+
+    #[test]
+    fn test_macro_positions() {
+        struct Case {
+            name: &'static str,
+            input: String,
+            pos: (usize, usize),
+            end_pos: (usize, usize),
+        }
+
+        // A malformed macro from mdn/content, where a stray comma breaks the arguments.
+        let malformed = r#"{{WebExtAPIRef("userScripts.,"execute()", "execute()"}}"#;
+        let cases = vec![
+            Case {
+                name: "single line",
+                input: r#"a {{Compat("api.Foo", 0)}} b"#.to_string(),
+                pos: (0, 2),
+                end_pos: (0, 26),
+            },
+            Case {
+                name: "spans two lines",
+                input: "a {{Compat(\"api.Foo\",\n  0)}} b".to_string(),
+                pos: (0, 2),
+                end_pos: (1, 6),
+            },
+            Case {
+                name: "malformed macro",
+                input: format!("{}{malformed}", "x".repeat(59)),
+                pos: (0, 59),
+                end_pos: (0, 59 + malformed.len()),
+            },
+        ];
+
+        for case in cases {
+            let tokens = parse(&case.input).expect("parse must succeed");
+            let mac = tokens
+                .iter()
+                .find_map(|token| match token {
+                    Token::Macro(mac) => Some(mac),
+                    Token::Text(_) => None,
+                })
+                .unwrap_or_else(|| panic!("{}: expected a macro token", case.name));
+            assert_eq!(mac.pos, case.pos, "{}: pos", case.name);
+            assert_eq!(mac.end_pos, case.end_pos, "{}: end_pos", case.name);
         }
     }
 

--- a/crates/rari-doc/src/templ/render.rs
+++ b/crates/rari-doc/src/templ/render.rs
@@ -78,17 +78,17 @@ pub(crate) fn render(env: &RariEnv, input: &str, offset: usize) -> Result<Render
                 let line = i64::try_from(mac.pos.0 + offset + 1).unwrap_or(-1);
                 // mac.pos.1 is a 0-based byte column from tree-sitter.
                 let col = i64::try_from(mac.pos.1 + 1).unwrap_or(-1);
-                // end_col in bytes: start byte + macro byte length. As a 0-based
-                // exclusive end this already equals the 1-based inclusive end column.
-                let macro_byte_len = mac.end - mac.start;
-                let end_col = i64::try_from(mac.pos.1 + macro_byte_len).unwrap_or(-1);
+                let end_line = i64::try_from(mac.end_pos.0 + offset + 1).unwrap_or(-1);
+                // A 0-based exclusive byte column already equals the 1-based
+                // inclusive end column.
+                let end_col = i64::try_from(mac.end_pos.1).unwrap_or(-1);
                 let span = span!(
                     Level::ERROR,
                     "templ",
                     templ = name,
                     line = line,
                     col = col,
-                    end_line = line,
+                    end_line = end_line,
                     end_col = end_col
                 );
                 let _enter = span.enter();
@@ -251,39 +251,75 @@ mod test {
     }
 
     /// Positions emitted by `render` must be 1-based, matching comrak's
-    /// sourcepos (tree-sitter reports 0-based). The macro sits after a text
-    /// prefix so its column is non-zero, and its invalid `sandbox` argument
-    /// makes `EmbedLiveSample` emit a `templ-invalid-arg` warning through a
-    /// pure code path (no content/link resolution required).
+    /// sourcepos (tree-sitter reports 0-based), and must cover the whole
+    /// macro even when it spans lines. The macro sits after a text prefix so
+    /// its column is non-zero, and its invalid `sandbox` argument makes
+    /// `EmbedLiveSample` emit a `templ-invalid-arg` warning through a pure
+    /// code path (no content/link resolution required).
     #[test]
-    fn test_render_reports_1_based_positions() {
+    fn test_render_reports_macro_positions() {
         use tracing::subscriber::set_default;
         use tracing_subscriber::layer::SubscriberExt;
 
         use crate::issues::InMemoryLayer;
 
-        let layer = InMemoryLayer::default();
-        let subscriber = tracing_subscriber::registry().with(layer.clone());
-        let _guard = set_default(subscriber);
+        struct Case {
+            name: &'static str,
+            input: String,
+            line: i64,
+            col: i64,
+            end_line: i64,
+            end_col: i64,
+        }
 
-        let env = RariEnv {
-            ..Default::default()
-        };
         let prefix = "abc ";
         let mac = r#"{{EmbedLiveSample("x", 100, 100, "", "", "", "", "nope")}}"#;
-        render(&env, &format!("{prefix}{mac}"), 0).expect("render should succeed");
+        let cases = vec![
+            Case {
+                name: "single line",
+                input: format!("{prefix}{mac}"),
+                line: 1,
+                col: prefix.len() as i64 + 1,
+                end_line: 1,
+                // Inclusive 1-based end column == start byte + macro byte length.
+                end_col: (prefix.len() + mac.len()) as i64,
+            },
+            Case {
+                name: "spans two lines",
+                input: format!(
+                    "{prefix}{}",
+                    "{{EmbedLiveSample(\"x\", 100, 100, \"\", \"\", \"\",\n  \"\", \"nope\")}} d"
+                ),
+                line: 1,
+                col: prefix.len() as i64 + 1,
+                end_line: 2,
+                // The second `}` is the 15th byte of `  "", "nope")}} d`.
+                end_col: 15,
+            },
+        ];
 
-        let events = layer.get_events();
-        let issues = events.get("").expect("expected an emitted issue");
-        assert_eq!(issues.len(), 1);
-        let issue = &issues[0];
-        // tree-sitter row 0 (+ offset 0), reported 1-based.
-        assert_eq!(issue.line, 1);
-        assert_eq!(issue.end_line, 1);
-        // 0-based byte column `prefix.len()` -> 1-based start column.
-        assert_eq!(issue.col, prefix.len() as i64 + 1);
-        // Inclusive 1-based end column == start byte + macro byte length.
-        assert_eq!(issue.end_col, (prefix.len() + mac.len()) as i64);
+        for case in cases {
+            let layer = InMemoryLayer::default();
+            let subscriber = tracing_subscriber::registry().with(layer.clone());
+            let guard = set_default(subscriber);
+
+            let env = RariEnv {
+                ..Default::default()
+            };
+            render(&env, &case.input, 0).expect("render should succeed");
+            drop(guard);
+
+            let events = layer.get_events();
+            let issues = events
+                .get("")
+                .unwrap_or_else(|| panic!("{}: expected an emitted issue", case.name));
+            assert_eq!(issues.len(), 1, "{}: issue count", case.name);
+            let issue = &issues[0];
+            assert_eq!(issue.line, case.line, "{}: line", case.name);
+            assert_eq!(issue.col, case.col, "{}: col", case.name);
+            assert_eq!(issue.end_line, case.end_line, "{}: end_line", case.name);
+            assert_eq!(issue.end_col, case.end_col, "{}: end_col", case.name);
+        }
     }
 
     /// An unknown macro name is a `templ-unknown` flaw, and still renders a


### PR DESCRIPTION
### Description

Record a macro's tree-sitter end position in `MacroToken` and report it, instead of deriving the end position from the start position plus the macro's byte length.

### Motivation

Prevent macros spanning multiple lines from reporting the start line as their end line, with an end column running past the end of that line.

### Additional details

Single-line macros keep their exact positions, because `end_position().column == start_position().column + byte_len` within one row; a full en-US build (1052 issues in 397 files) reports identical positions before and after. `rari-lsp` converts `end_line` separately and needs no change, and `rari-tools` doesn't read `end_line`/`end_column` outside tests.

### Related issues and pull requests

Fixes https://github.com/mdn/rari/issues/879.

**Depends on:** #871.
