### PR TITLE
fix(csssyntax): only link types that MDN documents

### DIFF
--- a/crates/rari-doc/src/templ/css_feature_index.rs
+++ b/crates/rari-doc/src/templ/css_feature_index.rs
@@ -4,9 +4,14 @@
 //! types, functions, selectors, at-rules, descriptors) to their canonical
 //! sub-path under `Web/CSS/Reference/`, replacing per-call
 //! `RariApi::get_page_nowarn` lookups during URL construction.
+//!
+//! Also used by `csssyntax` (see `resolve_formal_syntax_ref`) to decide whether
+//! a `<type>` in a formal-syntax box is documented at all.
 
 use std::collections::{HashMap, HashSet};
 use std::sync::LazyLock;
+
+use css_syntax::syntax::CssRefKind;
 
 use crate::helpers::subpages::{SubPagesSorter, get_sub_pages};
 use crate::pages::page::PageLike;
@@ -159,6 +164,36 @@ pub(crate) fn resolve_css_feature(category: CssRefCategory, slug: &str) -> Optio
     resolve_from_map(&CSS_FEATURE_INDEX, category, slug)
 }
 
+/// Resolve a formal-syntax `<type>` / `<'property'>` reference to the
+/// `Web/CSS/Reference/` sub-path documenting it, or `None` when none does (many
+/// webref productions are spec-internal). The lookup chain mirrors `cssxref`'s,
+/// so both land on the same page for a given name.
+pub(crate) fn resolve_formal_syntax_ref(kind: CssRefKind, slug: &str) -> Option<&'static str> {
+    resolve_formal_syntax_ref_from_map(&CSS_FEATURE_INDEX, kind, slug)
+}
+
+fn resolve_formal_syntax_ref_from_map<'a>(
+    map: &'a HashMap<String, Vec<String>>,
+    kind: CssRefKind,
+    slug: &str,
+) -> Option<&'a str> {
+    match kind {
+        CssRefKind::Property => resolve_from_map(map, CssRefCategory::Properties, slug),
+        // `_function` first, to prefer it over a same-named `_value` page.
+        // `Properties/` last, for functions documented under a property
+        // (`<palette-mix()>` under `font-palette`).
+        CssRefKind::Type if slug.ends_with("()") => {
+            let bare = slug.trim_end_matches("()");
+            resolve_from_map(map, CssRefCategory::Values, &format!("{bare}_function"))
+                .or_else(|| resolve_from_map(map, CssRefCategory::Values, bare))
+                .or_else(|| resolve_from_map(map, CssRefCategory::Properties, bare))
+        }
+        // No `Properties/` fallback: `rect()`'s `<top>`/`<right>`/`<bottom>`/
+        // `<left>` are positional argument types, not those properties.
+        CssRefKind::Type => resolve_from_map(map, CssRefCategory::Values, slug),
+    }
+}
+
 fn resolve_from_map<'a>(
     map: &'a HashMap<String, Vec<String>>,
     category: CssRefCategory,
@@ -206,6 +241,118 @@ mod tests {
             index_one(&mut map, after_ref);
         }
         map
+    }
+
+    /// The real layout for slugs `csssyntax` emits.
+    fn formal_syntax_fixture() -> HashMap<String, Vec<String>> {
+        let mut map: HashMap<String, Vec<String>> = HashMap::new();
+        for after_ref in [
+            "Properties/box-shadow",
+            "Properties/font-palette/palette-mix",
+            "Properties/padding-top",
+            "Values/color_value",
+            "Values/color_value/contrast-color",
+            "Values/cross-fade",
+            "Values/flex_value",
+            "Values/image/image-set",
+            "Values/length",
+            "Values/url_function",
+            "Values/url_value",
+        ] {
+            index_one(&mut map, after_ref);
+        }
+        map
+    }
+
+    #[test]
+    fn formal_syntax_refs_resolve_to_documented_pages_only() {
+        let map = formal_syntax_fixture();
+        // (label, node kind, slug as `render_node` normalizes it, expected sub-path)
+        let cases = vec![
+            (
+                "plain type",
+                CssRefKind::Type,
+                "length",
+                Some("Values/length"),
+            ),
+            (
+                "type aliased by `_value`, function sibling exists",
+                CssRefKind::Type,
+                "url",
+                Some("Values/url_value"),
+            ),
+            (
+                "type aliased by `_value`, no function sibling",
+                CssRefKind::Type,
+                "flex",
+                Some("Values/flex_value"),
+            ),
+            (
+                "function type nested under its parent type",
+                CssRefKind::Type,
+                "image-set()",
+                Some("Values/image/image-set"),
+            ),
+            (
+                "function type at the top level",
+                CssRefKind::Type,
+                "cross-fade()",
+                Some("Values/cross-fade"),
+            ),
+            (
+                "function type nested under a property",
+                CssRefKind::Type,
+                "palette-mix()",
+                Some("Properties/font-palette/palette-mix"),
+            ),
+            // `rect()`'s `<top>` is an argument type, not the `top` property.
+            (
+                "type with only a same-named property page",
+                CssRefKind::Type,
+                "box-shadow",
+                None,
+            ),
+            (
+                "type pre-normalized to a nested slug by `render_node`",
+                CssRefKind::Type,
+                "color_value/contrast-color",
+                Some("Values/color_value/contrast-color"),
+            ),
+            (
+                "property longhand",
+                CssRefKind::Property,
+                "padding-top",
+                Some("Properties/padding-top"),
+            ),
+            ("syntax production", CssRefKind::Type, "any-value", None),
+            ("tokenizer type", CssRefKind::Type, "number-token", None),
+            (
+                "undocumented function type",
+                CssRefKind::Type,
+                "url-set()",
+                None,
+            ),
+            (
+                "undocumented spec longhand",
+                CssRefKind::Property,
+                "box-shadow-color",
+                None,
+            ),
+            // `<'flex'>` is the shorthand, not the `<flex>` data type.
+            (
+                "property with only a same-named value page",
+                CssRefKind::Property,
+                "flex",
+                None,
+            ),
+        ];
+        for (label, kind, slug, expected) in cases {
+            assert_eq!(
+                resolve_formal_syntax_ref_from_map(&map, kind, slug),
+                expected,
+                "{label}: {kind:?} `{slug}`"
+            );
+        }
     }
 
     #[test]

--- a/crates/rari-doc/src/templ/templs/csssyntax.rs
+++ b/crates/rari-doc/src/templ/templs/csssyntax.rs
@@ -1,13 +1,14 @@
 use std::collections::HashMap;
 use std::sync::LazyLock;
 
-use css_syntax::syntax::{CssType, LinkedToken, SyntaxInput, render_formal_syntax};
+use css_syntax::syntax::{CssRefKind, CssType, LinkedToken, SyntaxInput, render_formal_syntax};
 use rari_templ_func::rari_f;
 use tracing::{error, warn};
 
 use crate::error::DocError;
 use crate::helpers::l10n::l10n_json_data;
 use crate::html::links::post_process_templ_links;
+use crate::templ::css_feature_index::resolve_formal_syntax_ref;
 
 static TOOLTIPS: LazyLock<HashMap<LinkedToken, String>> = LazyLock::new(|| {
     [(LinkedToken::Asterisk, "Asterisk: the entity may occur zero, one or several times".to_string()),
@@ -21,6 +22,11 @@ static TOOLTIPS: LazyLock<HashMap<LinkedToken, String>> = LazyLock::new(|| {
     (LinkedToken::DoubleBar, "Double bar: one or several of the entities must be present, in any order".to_string()),
     (LinkedToken::DoubleAmpersand, "Double ampersand: all of the entities must be present, in any order".to_string())].into_iter().collect()
 });
+
+/// Hands the CSS feature index to the formal-syntax renderer.
+fn resolve_reference(kind: CssRefKind, slug: &str) -> Option<String> {
+    resolve_formal_syntax_ref(kind, slug).map(str::to_string)
+}
 
 #[rari_f(register = "crate::Templ")]
 pub fn csssyntax(name: Option<String>) -> Result<String, DocError> {
@@ -85,7 +91,7 @@ pub fn csssyntax(name: Option<String>) -> Result<String, DocError> {
         ),
         &TOOLTIPS,
         Some(sources_prefix),
-        None,
+        Some(&resolve_reference),
     )?;
     post_process_templ_links(&html)
 }
@@ -103,7 +109,7 @@ pub fn csssyntaxraw(syntax: String) -> Result<String, DocError> {
         ),
         &TOOLTIPS,
         Some(sources_prefix),
-        None,
+        Some(&resolve_reference),
     )?;
     post_process_templ_links(&html)
 }


### PR DESCRIPTION
### Description

Resolve `<type>` and `<'property'>` references in formal-syntax boxes through the `CSS_FEATURE_INDEX` that `cssxref` already uses, and only link a reference when the index resolves it.

Adds `resolve_formal_syntax_ref` next to the index and backs the `CssRefResolver` from #875 with it in `csssyntax` and `csssyntaxraw`.

### Motivation

`csssyntax` linked every type without checking that the target page exists, relying on a five-entry hardcoded slug map and a two-name `skip()` list. That produced **1857 `templ-broken-link` issues over 836 files, 24.5% of all such issues in a full build**, rendered as "page not created" placeholders that invite contributors to write pages which should not exist.

The webref grammars are full of spec-internal productions MDN does not document (`<any-value>`, `<number-token>`, `<'box-shadow-color'>`), so the flaw is unactionable for content authors. Deriving linkability from the page index instead of a hand-maintained name list also makes it self-healing: once content documents `animation-delay-start`, the link returns on its own.

### Additional details

The same bug also hid genuine slug mismatches, where a page exists but under a different slug. Those now resolve:

| reference | before | after |
| --- | --- | --- |
| `<url>` (357×) | `Values/url` (404) | `Values/url_value` |
| `<flex>` (116×) | `Values/flex` (404) | `Values/flex_value` |
| `<image-set()>` | `Values/image-set()` (404) | `Values/image/image-set` |
| `<palette-mix()>` | `Values/palette-mix()` (404) | `Properties/font-palette/palette-mix` |

Measured over the 180 affected en-US pages, comparing built `index.json` output:

| | before | after |
| --- | --- | --- |
| `csssyntax`/`csssyntaxraw` broken links | 393 | **0** |
| dead "page not created" placeholders | 285 | **0** |
| working type links | 553 | **620** |

No reference that linked before renders unlinked now, and no previously-working URL changed.

Two deliberate choices:

- Resolving at render time rather than post-processing the finished HTML leaves `post_process_templ_links` untouched, so a `templ-broken-link` it still reports for `csssyntax` is a genuine bug rather than content noise.
- A bare `<type>` does not fall back to a same-named property. `rect()`'s `<top>`/`<right>`/`<bottom>`/`<left>` are positional argument types (`<length> | auto`), not references to those properties, so linking them there would mislead. The fallback applies only to function types, which is what `<palette-mix()>` needs.

Follow-up, kept out to keep this reviewable: the slug map and `skip()` in `crates/css-syntax/src/syntax.rs` are now redundant, since the index resolves `values/color` to `Values/color_value` itself.

### Related issues and pull requests

Fixes #665.
**Depends on:** #875, which adds the resolver hook this uses.
Relates to #685, which removes the `constituents` short-circuit and so links more aggressively; over-linking can no longer produce broken links once this lands.