### PR TITLE
refactor(css-syntax): drop the hardcoded type slug map

### DIFF
--- a/crates/css-syntax/src/syntax.rs
+++ b/crates/css-syntax/src/syntax.rs
@@ -153,10 +153,8 @@ impl Syntax {
     }
 }
 
-/// Types too large to expand inline as a constituent. Governs expansion only,
-/// not linking.
 #[inline]
-fn skip(name: &str) -> bool {
+fn should_skip_expansion(name: &str) -> bool {
     name == "color" || name == "gradient"
 }
 
@@ -174,7 +172,7 @@ fn get_syntax_internal(typ: CssType, scope: Option<&str>, top_level: bool) -> Sy
         }
         CssType::Type(name) => {
             let name = name.trim_end_matches("_value");
-            if skip(name) && !top_level {
+            if should_skip_expansion(name) && !top_level {
                 Syntax::default().to_syntax_line(format!("<{name}>"))
             } else {
                 get_generic_syntax(name, scope, &CSS_REF.types).to_syntax_line(format!("<{name}>"))
@@ -748,7 +746,7 @@ fn get_nodes_for_syntaxes(
             &ast?,
             &WalkOptions::<Vec<Constituent>> {
                 enter: |node: &Node, context: &mut Vec<Constituent>| {
-                    if !skip(node.str_name())
+                    if !should_skip_expansion(node.str_name())
                         && !context.iter().any(|constituent| constituent.node == *node)
                     {
                         context.push(node.clone().into())

--- a/crates/css-syntax/src/syntax.rs
+++ b/crates/css-syntax/src/syntax.rs
@@ -382,8 +382,6 @@ impl SyntaxRenderer<'_> {
             }
             Node::Type(typ) => {
                 let encoded = html_escape::encode_safe(name);
-                // Bare feature name; mapping it onto MDN's page layout is the
-                // resolver's job.
                 let slug = match name {
                     name if name.starts_with('<') && name.ends_with('>') => {
                         &name[1..name.find(" [").or(name.find('[')).unwrap_or(name.len() - 1)]

--- a/crates/css-syntax/src/syntax.rs
+++ b/crates/css-syntax/src/syntax.rs
@@ -153,6 +153,8 @@ impl Syntax {
     }
 }
 
+/// Types too large to expand inline as a constituent. Governs expansion only,
+/// not linking.
 #[inline]
 fn skip(name: &str) -> bool {
     name == "color" || name == "gradient"
@@ -382,24 +384,20 @@ impl SyntaxRenderer<'_> {
             }
             Node::Type(typ) => {
                 let encoded = html_escape::encode_safe(name);
+                // Bare feature name; mapping it onto MDN's page layout is the
+                // resolver's job.
                 let slug = match name {
-                    "<color>" => "color_value",
-                    "<position>" => "position_value",
-                    "<contrast-color()>" => "color_value/contrast-color",
-                    "<device-cmyk()>" => "color_value/device-cmyk",
-                    "<light-dark()>" => "color_value/light-dark",
                     name if name.starts_with('<') && name.ends_with('>') => {
                         &name[1..name.find(" [").or(name.find('[')).unwrap_or(name.len() - 1)]
                     }
                     name => &name[0..name.find(" [").or(name.find('[')).unwrap_or(name.len())],
                 };
 
-                if !skip(slug)
-                    && (self.constituents.contains(node)
-                        || self.constituents.contains(&Node::Type(Type {
-                            name: typ.name.clone(),
-                            opts: None,
-                        })))
+                if self.constituents.contains(node)
+                    || self.constituents.contains(&Node::Type(Type {
+                        name: typ.name.clone(),
+                        opts: None,
+                    }))
                 {
                     // FIXME: this should have the class type but to be compatible we use property
                     format!(r#"<span class="token property">{encoded}</span>"#,)
@@ -874,7 +872,7 @@ mod test {
             let rendered = renderer.render_terms(&group.terms, group.combinator)?;
             assert_eq!(
                 rendered,
-                "  <a href=\"/en-US/docs/Web/CSS/Reference/Values/color-base\"><span class=\"token property\">&lt;color-base&gt;</span></a>        <a href=\"/en-US/docs/Web/CSS/Guides/Values_and_units/Value_definition_syntax#single_bar\" title=\"Single bar: exactly one of the entities must be present\">|</a><br/>  <span class=\"token keyword\">currentColor</span>        <a href=\"/en-US/docs/Web/CSS/Guides/Values_and_units/Value_definition_syntax#single_bar\" title=\"Single bar: exactly one of the entities must be present\">|</a><br/>  <a href=\"/en-US/docs/Web/CSS/Reference/Values/system-color\"><span class=\"token property\">&lt;system-color&gt;</span></a>      <a href=\"/en-US/docs/Web/CSS/Guides/Values_and_units/Value_definition_syntax#single_bar\" title=\"Single bar: exactly one of the entities must be present\">|</a><br/>  <a href=\"/en-US/docs/Web/CSS/Reference/Values/color_value/contrast-color\"><span class=\"token property\">&lt;contrast-color()&gt;</span></a>  <a href=\"/en-US/docs/Web/CSS/Guides/Values_and_units/Value_definition_syntax#single_bar\" title=\"Single bar: exactly one of the entities must be present\">|</a><br/>  <a href=\"/en-US/docs/Web/CSS/Reference/Values/color_value/device-cmyk\"><span class=\"token property\">&lt;device-cmyk()&gt;</span></a>     <a href=\"/en-US/docs/Web/CSS/Guides/Values_and_units/Value_definition_syntax#single_bar\" title=\"Single bar: exactly one of the entities must be present\">|</a><br/>  <a href=\"/en-US/docs/Web/CSS/Reference/Values/light-dark-color\"><span class=\"token property\">&lt;light-dark-color&gt;</span></a>  <br/>"
+                "  <a href=\"/en-US/docs/Web/CSS/Reference/Values/color-base\"><span class=\"token property\">&lt;color-base&gt;</span></a>        <a href=\"/en-US/docs/Web/CSS/Guides/Values_and_units/Value_definition_syntax#single_bar\" title=\"Single bar: exactly one of the entities must be present\">|</a><br/>  <span class=\"token keyword\">currentColor</span>        <a href=\"/en-US/docs/Web/CSS/Guides/Values_and_units/Value_definition_syntax#single_bar\" title=\"Single bar: exactly one of the entities must be present\">|</a><br/>  <a href=\"/en-US/docs/Web/CSS/Reference/Values/system-color\"><span class=\"token property\">&lt;system-color&gt;</span></a>      <a href=\"/en-US/docs/Web/CSS/Guides/Values_and_units/Value_definition_syntax#single_bar\" title=\"Single bar: exactly one of the entities must be present\">|</a><br/>  <a href=\"/en-US/docs/Web/CSS/Reference/Values/contrast-color()\"><span class=\"token property\">&lt;contrast-color()&gt;</span></a>  <a href=\"/en-US/docs/Web/CSS/Guides/Values_and_units/Value_definition_syntax#single_bar\" title=\"Single bar: exactly one of the entities must be present\">|</a><br/>  <a href=\"/en-US/docs/Web/CSS/Reference/Values/device-cmyk()\"><span class=\"token property\">&lt;device-cmyk()&gt;</span></a>     <a href=\"/en-US/docs/Web/CSS/Guides/Values_and_units/Value_definition_syntax#single_bar\" title=\"Single bar: exactly one of the entities must be present\">|</a><br/>  <a href=\"/en-US/docs/Web/CSS/Reference/Values/light-dark-color\"><span class=\"token property\">&lt;light-dark-color&gt;</span></a>  <br/>"
             );
         } else {
             panic!("no group node")

--- a/crates/css-syntax/src/syntax.rs
+++ b/crates/css-syntax/src/syntax.rs
@@ -854,12 +854,22 @@ mod test {
 
     #[test]
     fn test_render_terms() -> Result<(), SyntaxError> {
+        // Stand-in for the page index: only these constituents have a page.
+        let resolver = |kind: CssRefKind, slug: &str| -> Option<String> {
+            assert_eq!(kind, CssRefKind::Type);
+            match slug {
+                "system-color" => Some("Values/system-color".into()),
+                "contrast-color()" => Some("Values/color_value/contrast-color".into()),
+                "device-cmyk()" => Some("Values/color_value/device-cmyk".into()),
+                _ => None,
+            }
+        };
         let renderer = SyntaxRenderer {
             locale_str: "en-US",
             value_definition_url: "/en-US/docs/Web/CSS/Guides/Values_and_units/Value_definition_syntax",
             syntax_tooltip: &TOOLTIPS,
             constituents: Default::default(),
-            resolver: None,
+            resolver: Some(&resolver),
         };
         let SyntaxLine {
             name: _, syntax, ..
@@ -868,7 +878,7 @@ mod test {
             let rendered = renderer.render_terms(&group.terms, group.combinator)?;
             assert_eq!(
                 rendered,
-                "  <a href=\"/en-US/docs/Web/CSS/Reference/Values/color-base\"><span class=\"token property\">&lt;color-base&gt;</span></a>        <a href=\"/en-US/docs/Web/CSS/Guides/Values_and_units/Value_definition_syntax#single_bar\" title=\"Single bar: exactly one of the entities must be present\">|</a><br/>  <span class=\"token keyword\">currentColor</span>        <a href=\"/en-US/docs/Web/CSS/Guides/Values_and_units/Value_definition_syntax#single_bar\" title=\"Single bar: exactly one of the entities must be present\">|</a><br/>  <a href=\"/en-US/docs/Web/CSS/Reference/Values/system-color\"><span class=\"token property\">&lt;system-color&gt;</span></a>      <a href=\"/en-US/docs/Web/CSS/Guides/Values_and_units/Value_definition_syntax#single_bar\" title=\"Single bar: exactly one of the entities must be present\">|</a><br/>  <a href=\"/en-US/docs/Web/CSS/Reference/Values/contrast-color()\"><span class=\"token property\">&lt;contrast-color()&gt;</span></a>  <a href=\"/en-US/docs/Web/CSS/Guides/Values_and_units/Value_definition_syntax#single_bar\" title=\"Single bar: exactly one of the entities must be present\">|</a><br/>  <a href=\"/en-US/docs/Web/CSS/Reference/Values/device-cmyk()\"><span class=\"token property\">&lt;device-cmyk()&gt;</span></a>     <a href=\"/en-US/docs/Web/CSS/Guides/Values_and_units/Value_definition_syntax#single_bar\" title=\"Single bar: exactly one of the entities must be present\">|</a><br/>  <a href=\"/en-US/docs/Web/CSS/Reference/Values/light-dark-color\"><span class=\"token property\">&lt;light-dark-color&gt;</span></a>  <br/>"
+                "  <span class=\"token property\">&lt;color-base&gt;</span>        <a href=\"/en-US/docs/Web/CSS/Guides/Values_and_units/Value_definition_syntax#single_bar\" title=\"Single bar: exactly one of the entities must be present\">|</a><br/>  <span class=\"token keyword\">currentColor</span>        <a href=\"/en-US/docs/Web/CSS/Guides/Values_and_units/Value_definition_syntax#single_bar\" title=\"Single bar: exactly one of the entities must be present\">|</a><br/>  <a href=\"/en-US/docs/Web/CSS/Reference/Values/system-color\"><span class=\"token property\">&lt;system-color&gt;</span></a>      <a href=\"/en-US/docs/Web/CSS/Guides/Values_and_units/Value_definition_syntax#single_bar\" title=\"Single bar: exactly one of the entities must be present\">|</a><br/>  <a href=\"/en-US/docs/Web/CSS/Reference/Values/color_value/contrast-color\"><span class=\"token property\">&lt;contrast-color()&gt;</span></a>  <a href=\"/en-US/docs/Web/CSS/Guides/Values_and_units/Value_definition_syntax#single_bar\" title=\"Single bar: exactly one of the entities must be present\">|</a><br/>  <a href=\"/en-US/docs/Web/CSS/Reference/Values/color_value/device-cmyk\"><span class=\"token property\">&lt;device-cmyk()&gt;</span></a>     <a href=\"/en-US/docs/Web/CSS/Guides/Values_and_units/Value_definition_syntax#single_bar\" title=\"Single bar: exactly one of the entities must be present\">|</a><br/>  <span class=\"token property\">&lt;light-dark-color&gt;</span>  <br/>"
             );
         } else {
             panic!("no group node")


### PR DESCRIPTION
### Description

Remove the five-entry hardcoded type slug map from `SyntaxRenderer::render_node`, along with the now-unreachable `!skip(slug)` guard in the same branch. Rename `skip()` to `should_skip_expansion()` to say what its remaining call sites govern.

### Motivation

The map (`<color>` to `color_value`, `<contrast-color()>` to `color_value/contrast-color`, …) encoded MDN's page layout inside `css-syntax`, which has no business knowing it. The `CSS_FEATURE_INDEX` resolver added in #874 derives all five from the page tree via its `_value`/`_function` and leaf aliases, so the map now only duplicates that knowledge in the wrong crate.

### Additional details

Verified as a no-op: building all 1256 en-US `Web/CSS` pages before and after produces byte-identical `index.json` output. (The only diff is element ordering in `metadata.json`, which is nondeterministic and identical as a set.)

`should_skip_expansion()` (formerly `skip()`) itself stays. Its two other call sites govern constituent *expansion* rather than linking, and because they keep `<color>` and `<gradient>` out of `get_nodes_for_syntaxes`, those types never reach `SyntaxRenderer::constituents` and the `!skip(slug)` guard in `render_node` could never fire.

`test_render_terms` previously rendered with `resolver: None`, whose default-category fallback produced links MDN does not have (e.g. `Values/contrast-color()`). It now resolves through a stub standing in for the page index, so the snapshot shows the nested `color_value/…` paths for the two function types and leaves undocumented types unlinked.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
**Depends on:** #874, which adds the resolver that makes the map redundant.
