### PR TITLE
chore(templ): remove ExperimentalBadge macro

### DIFF
--- a/crates/rari-doc/src/templ/templs/badges.rs
+++ b/crates/rari-doc/src/templ/templs/badges.rs
@@ -14,11 +14,6 @@ pub fn experimental_inline() -> Result<String, DocError> {
 }
 
 #[rari_f(register = "crate::Templ")]
-pub fn experimentalbadge() -> Result<String, DocError> {
-    experimental_inline(env)
-}
-
-#[rari_f(register = "crate::Templ")]
 pub fn non_standard_inline() -> Result<String, DocError> {
     let mut out = String::new();
     write_non_standard(&mut out, env.locale)?;


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Remove the `ExperimentalBadge` macro, which was an alias for `ExperimentalInline`.

### Motivation

Reduce the number of macros that need to be supported, since `ExperimentalBadge` is redundant with `ExperimentalInline`.

### Additional details

Once mdn/translated-content#38248 is merged, there are no remaining occurrences of `ExperimentalBadge` in `mdn/content` or `mdn/translated-content`.

### Related issues and pull requests

Depends on:

- mdn/translated-content#38248