### PR TITLE
ci(dependabot): update cargo cooldown + pull request limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    open-pull-requests-limit: 20
     cooldown:
       exclude:
         - tree-sitter-mdn

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,9 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      exclude:
+        - tree-sitter-mdn
     commit-message:
       prefix: chore
       include: scope


### PR DESCRIPTION
### Description

Update Dependabot config for the `cargo` ecosystem:

- Exclude `tree-sitter-mdn` from the cooldown.
- Raise `open-pull-requests-limit` to 20.

### Motivation

Ensure updates of `tree-sitter-mdn`, which is maintained alongside rari, are proposed immediately, and prevent cargo updates from being withheld because the default limit of 5 open pull requests is reached.

### Additional details

There were 13 cargo updates in a single week, so the default limit of 5 is well below what a weekly run can produce. The cooldown exclusion mirrors the `@mdn/*` exclusions already in place for the npm ecosystems.

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Unblocks the tree-sitter-mdn update that blocks resolution of https://github.com/mdn/rari/issues/881.