### PR TITLE
feat(templ): report unknown macros as `templ-unknown` flaws

### DIFF
--- a/crates/rari-doc/src/issues.rs
+++ b/crates/rari-doc/src/issues.rs
@@ -299,6 +299,7 @@ pub enum IssueType {
     TemplInvalidArg,
     TemplArgError,
     TemplSyntaxError,
+    TemplUnknown,
     TemplMdnDataMissing,
     RedirectedLink,
     BrokenLink,
@@ -319,6 +320,7 @@ impl FromStr for IssueType {
             "templ-invalid-arg" => Self::TemplInvalidArg,
             "templ-arg-error" => Self::TemplArgError,
             "templ-syntax-error" => Self::TemplSyntaxError,
+            "templ-unknown" => Self::TemplUnknown,
             "templ-mdn-data-missing" => Self::TemplMdnDataMissing,
             "redirected-link" => Self::RedirectedLink,
             "broken-link" => Self::BrokenLink,
@@ -593,6 +595,17 @@ impl DIssue {
                     di.fixed = false;
                     di.fixable = Some(false);
                     di.explanation = additional.remove("message");
+                    DIssue::Macros {
+                        display_issue: di,
+                        macro_name: source.name,
+                        href: None,
+                    }
+                }
+                IssueType::TemplUnknown => {
+                    let source = issue_source(&mut additional);
+                    di.fixed = false;
+                    di.fixable = Some(false);
+                    di.explanation = Some(format!("{} does not exist", source.label));
                     DIssue::Macros {
                         display_issue: di,
                         macro_name: source.name,

--- a/crates/rari-doc/src/templ/render.rs
+++ b/crates/rari-doc/src/templ/render.rs
@@ -285,4 +285,40 @@ mod test {
         // Inclusive 1-based end column == start byte + macro byte length.
         assert_eq!(issue.end_col, (prefix.len() + mac.len()) as i64);
     }
+
+    /// An unknown macro name is a `templ-unknown` flaw, and still renders a
+    /// placeholder rather than failing.
+    #[test]
+    fn test_render_reports_unknown_macro() {
+        use tracing::subscriber::set_default;
+        use tracing_subscriber::layer::SubscriberExt;
+
+        use crate::issues::InMemoryLayer;
+
+        let layer = InMemoryLayer::default();
+        let subscriber = tracing_subscriber::registry().with(layer.clone());
+        let _guard = set_default(subscriber);
+
+        let env = RariEnv {
+            ..Default::default()
+        };
+        let Rendered {
+            content, templs, ..
+        } = render(&env, r#"{{domxreg("Element")}}"#, 0).expect("render should succeed");
+        let out = decode_ref(&content, &templs, None).expect("decode should succeed");
+        assert_eq!(out, "<s>unsupported templ: domxreg</s>");
+
+        let events = layer.get_events();
+        let issues = events.get("").expect("expected an emitted issue");
+        assert_eq!(issues.len(), 1);
+        let fields = &issues[0].fields;
+        assert!(
+            fields.contains(&("source", "templ-unknown".to_string())),
+            "expected a templ-unknown source, got {fields:?}"
+        );
+        assert!(
+            fields.contains(&("templ", "domxreg".to_string())),
+            "expected the macro name on the event, got {fields:?}"
+        );
+    }
 }

--- a/crates/rari-doc/src/templ/templs/mod.rs
+++ b/crates/rari-doc/src/templ/templs/mod.rs
@@ -35,6 +35,7 @@ use rari_types::{Arg, RariEnv};
 use tracing::error;
 
 use crate::error::DocError;
+use crate::issues::get_issue_counter;
 use crate::utils::{TEMPL_RECORDER, TemplStatEvent, is_unrooted};
 
 #[derive(Debug)]
@@ -85,6 +86,14 @@ pub fn invoke(
         None if name == "xulelem" => return Ok((Default::default(), TemplType::None)),
         None if deny_warnings() => return Err(DocError::UnknownMacro(name.to_string())),
         None => {
+            let ic = get_issue_counter();
+            // The `banner` span doesn't set `templ`, unlike `render`'s.
+            tracing::warn!(
+                source = "templ-unknown",
+                ic = ic,
+                templ = name.as_str(),
+                "Unknown macro {name}"
+            );
             let rendered = format!("<s>unsupported templ: {name}</s>");
             record_invocation(name, env.locale, false);
             return Ok((rendered, TemplType::None));


### PR DESCRIPTION
### Description

Report unknown macro names as a `templ-unknown` flaw:

- Emit a `templ-unknown` warning from the unknown-name arm of `invoke`, carrying the macro name on the event itself so the issue stays self-describing at call sites whose span doesn't set `templ` (the `banner` path).
- Add `IssueType::TemplUnknown` and map it to a `DIssue::Macros` with the explanation `Macro <name> does not exist` (not auto-fixable).

### Motivation

Ensure typos in macro names (e.g. `{{domxreg("SanitizerConfig")}}`) are surfaced to authors. Previously `invoke` returned `Ok` with an `<s>unsupported templ: …</s>` placeholder and only bumped the `--templ-stats` "invalid" counter, so such macros never appeared in `--issues`, `--json-issues` or `--data-issues` output. The only visible trace was the strikethrough text in the rendered page.

### Additional details

Building the two files behind a `--templ-stats` "templ invalid" report now yields flaws with exact spans, e.g. for `files/ja/web/api/html_sanitizer_api/index.md`:

```json
"macros": [{
  "type": "macros",
  "explanation": "Macro domxreg does not exist",
  "fixable": false,
  "line": 148, "column": 194, "endColumn": 223,
  "name": "TemplUnknown",
  "macroName": "domxreg"
}]
```

Unchanged behavior:

- Under `--deny-warnings`, unknown macros still abort the build via `DocError::UnknownMacro`.
- `xulelem` remains special-cased to render empty without a flaw or a stats entry.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
