### PR TITLE
fix(serve): log asset requests at debug level

### DIFF
--- a/crates/rari-cli/serve.rs
+++ b/crates/rari-cli/serve.rs
@@ -94,7 +94,7 @@ async fn wrapped_fix_issues(
 
 async fn get_file_handler(req: Request) -> Result<Response, AppError> {
     let url = req.uri().path();
-    tracing::info!("(asset) {}", url);
+    tracing::debug!("(asset) {}", url);
     let UrlMeta {
         page_category,
         slug,


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Change `get_file_handler` in the dev server to log static asset requests via `tracing::debug!` instead of `tracing::info!`.

### Motivation

Prevent every CSS/JS/image fetch under `rari serve` from printing an info line and drowning out useful output.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Extracted from #390.