### PR TITLE
fix(issues): mark redirects to unrooted pages as unfixable

### DIFF
--- a/crates/rari-doc/src/issues.rs
+++ b/crates/rari-doc/src/issues.rs
@@ -513,12 +513,13 @@ impl DIssue {
                     }
                 }
                 IssueType::RedirectedLink => {
+                    let unrooted = di.suggestion.as_deref().is_some_and(is_unrooted_url);
                     di.fixed = false;
-                    di.fixable = Some(is_fixable_redirect(di.suggestion.as_deref()));
+                    di.fixable = Some(!unrooted);
                     di.explanation = Some(format!(
                         "Link {} is a redirect{}",
                         additional.get("url").map(|s| s.as_str()).unwrap_or("?"),
-                        redirect_target_note(di.suggestion.as_deref())
+                        unrooted_note(unrooted)
                     ));
                     DIssue::BrokenLink {
                         display_issue: di,
@@ -554,16 +555,14 @@ impl DIssue {
                 }
                 IssueType::TemplRedirectedLink => {
                     let source = issue_source(&mut additional);
+                    let unrooted = di.suggestion.as_deref().is_some_and(is_unrooted_url);
                     di.fixed = false;
-                    di.fixable = Some(
-                        is_fixable_template(source.name.as_deref())
-                            && is_fixable_redirect(di.suggestion.as_deref()),
-                    );
+                    di.fixable = Some(is_fixable_template(source.name.as_deref()) && !unrooted);
                     di.explanation = Some(format!(
                         "{} produces link {} which is a redirect{}",
                         source.label,
                         additional.get("url").map(|s| s.as_str()).unwrap_or("?"),
-                        redirect_target_note(di.suggestion.as_deref())
+                        unrooted_note(unrooted)
                     ));
                     DIssue::Macros {
                         display_issue: di,
@@ -717,15 +716,11 @@ fn issue_source(additional: &mut HashMap<&str, String>) -> IssueSource {
 
 /// Redirects into `conflicting/` or `orphaned/` have no real target; rewriting
 /// links to them would only hide the flaw.
-fn is_fixable_redirect(suggestion: Option<&str>) -> bool {
-    !suggestion.is_some_and(is_unrooted_url)
-}
-
-fn redirect_target_note(suggestion: Option<&str>) -> &'static str {
-    if is_fixable_redirect(suggestion) {
-        ""
-    } else {
+fn unrooted_note(unrooted: bool) -> &'static str {
+    if unrooted {
         " to an unrooted (conflicting/orphaned) page"
+    } else {
+        ""
     }
 }
 
@@ -874,27 +869,6 @@ mod tests {
                 "{}",
                 case.name
             );
-        }
-    }
-
-    #[test]
-    fn test_is_fixable_redirect() {
-        let cases = vec![
-            ("no suggestion", None, true),
-            ("regular target", Some("/en-US/docs/Web/API/Window"), true),
-            (
-                "conflicting target",
-                Some("/es/docs/conflicting/Web/API/Window"),
-                false,
-            ),
-            (
-                "orphaned target",
-                Some("/ja/docs/orphaned/Web/API/Window"),
-                false,
-            ),
-        ];
-        for (name, suggestion, expected) in cases {
-            assert_eq!(is_fixable_redirect(suggestion), expected, "{name}");
         }
     }
 

--- a/crates/rari-doc/src/issues.rs
+++ b/crates/rari-doc/src/issues.rs
@@ -714,8 +714,8 @@ fn issue_source(additional: &mut HashMap<&str, String>) -> IssueSource {
     }
 }
 
-/// Redirects into `conflicting/` or `orphaned/` have no real target; rewriting
-/// links to them would only hide the flaw.
+/// Redirects into `conflicting/` or `orphaned/` point at unrooted pages;
+/// rewriting links to them would only hide the flaw.
 fn unrooted_note(unrooted: bool) -> &'static str {
     if unrooted {
         " to an unrooted (conflicting/orphaned) page"

--- a/crates/rari-doc/src/issues.rs
+++ b/crates/rari-doc/src/issues.rs
@@ -16,6 +16,7 @@ use tracing_subscriber::registry::{LookupSpan, SpanRef};
 
 use crate::pages::page::{Page, PageLike};
 use crate::position_utils::byte_to_char_column;
+use crate::utils::is_unrooted_url;
 
 pub static ISSUE_COUNTER_F: OnceLock<fn() -> i64> = OnceLock::new();
 static ISSUE_COUNTER: AtomicI64 = AtomicI64::new(0);
@@ -513,10 +514,11 @@ impl DIssue {
                 }
                 IssueType::RedirectedLink => {
                     di.fixed = false;
-                    di.fixable = Some(true);
+                    di.fixable = Some(is_fixable_redirect(di.suggestion.as_deref()));
                     di.explanation = Some(format!(
-                        "Link {} is a redirect",
-                        additional.get("url").map(|s| s.as_str()).unwrap_or("?")
+                        "Link {} is a redirect{}",
+                        additional.get("url").map(|s| s.as_str()).unwrap_or("?"),
+                        redirect_target_note(di.suggestion.as_deref())
                     ));
                     DIssue::BrokenLink {
                         display_issue: di,
@@ -553,11 +555,15 @@ impl DIssue {
                 IssueType::TemplRedirectedLink => {
                     let source = issue_source(&mut additional);
                     di.fixed = false;
-                    di.fixable = Some(is_fixable_template(source.name.as_deref()));
+                    di.fixable = Some(
+                        is_fixable_template(source.name.as_deref())
+                            && is_fixable_redirect(di.suggestion.as_deref()),
+                    );
                     di.explanation = Some(format!(
-                        "{} produces link {} which is a redirect",
+                        "{} produces link {} which is a redirect{}",
                         source.label,
-                        additional.get("url").map(|s| s.as_str()).unwrap_or("?")
+                        additional.get("url").map(|s| s.as_str()).unwrap_or("?"),
+                        redirect_target_note(di.suggestion.as_deref())
                     ));
                     DIssue::Macros {
                         display_issue: di,
@@ -709,6 +715,20 @@ fn issue_source(additional: &mut HashMap<&str, String>) -> IssueSource {
     }
 }
 
+/// Redirects into `conflicting/` or `orphaned/` have no real target; rewriting
+/// links to them would only hide the flaw.
+fn is_fixable_redirect(suggestion: Option<&str>) -> bool {
+    !suggestion.is_some_and(is_unrooted_url)
+}
+
+fn redirect_target_note(suggestion: Option<&str>) -> &'static str {
+    if is_fixable_redirect(suggestion) {
+        ""
+    } else {
+        " to an unrooted (conflicting/orphaned) page"
+    }
+}
+
 /// Check if a template macro issue can be automatically fixed.
 /// Only navigation templates have fixable slug parameters in the markdown source.
 fn is_fixable_template(macro_name: Option<&str>) -> bool {
@@ -854,6 +874,27 @@ mod tests {
                 "{}",
                 case.name
             );
+        }
+    }
+
+    #[test]
+    fn test_is_fixable_redirect() {
+        let cases = vec![
+            ("no suggestion", None, true),
+            ("regular target", Some("/en-US/docs/Web/API/Window"), true),
+            (
+                "conflicting target",
+                Some("/es/docs/conflicting/Web/API/Window"),
+                false,
+            ),
+            (
+                "orphaned target",
+                Some("/ja/docs/orphaned/Web/API/Window"),
+                false,
+            ),
+        ];
+        for (name, suggestion, expected) in cases {
+            assert_eq!(is_fixable_redirect(suggestion), expected, "{name}");
         }
     }
 

--- a/crates/rari-doc/src/utils.rs
+++ b/crates/rari-doc/src/utils.rs
@@ -353,6 +353,8 @@ mod text {
         let cases = vec![
             ("/es/docs/conflicting/Web/API/Window", true),
             ("/en-US/docs/orphaned/Web/API/GlobalEventHandlers", true),
+            ("/docs/conflicting/Web/API/Window", true),
+            ("/es/docs/orphaned/Web/API/Window#foo", true),
             ("/en-US/docs/Web/API/Window", false),
             ("/es/docs/Web/API/conflicting/foo", false),
             ("/en-US/conflicting/Web/API", false),

--- a/crates/rari-doc/src/utils.rs
+++ b/crates/rari-doc/src/utils.rs
@@ -27,6 +27,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::error::DocError;
 use crate::pages::page::{Page, PageCategory};
+use crate::resolve::strip_locale_from_url;
 
 const FM_START_DELIM: &str = "---\n";
 const FM_START_DELIM_LEN: usize = FM_START_DELIM.len();
@@ -167,6 +168,12 @@ pub fn root_for_locale(locale: Locale) -> Result<&'static Path, EnvError> {
 
 pub fn is_unrooted(slug: &str) -> bool {
     slug.starts_with("conflicting/") || slug.starts_with("orphaned/")
+}
+
+/// Whether a doc URL (e.g. `/es/docs/conflicting/Web/API`) points at an unrooted slug.
+pub fn is_unrooted_url(url: &str) -> bool {
+    let (_, path) = strip_locale_from_url(url);
+    path.strip_prefix("/docs/").is_some_and(is_unrooted)
 }
 
 /// Determines the locale and page category from the given file path.
@@ -338,6 +345,22 @@ mod text {
         ];
         for (slug, expected) in cases {
             assert_eq!(is_unrooted(slug), expected, "is_unrooted({slug:?})");
+        }
+    }
+
+    #[test]
+    fn test_is_unrooted_url() {
+        let cases = vec![
+            ("/es/docs/conflicting/Web/API/Window", true),
+            ("/en-US/docs/orphaned/Web/API/GlobalEventHandlers", true),
+            ("/en-US/docs/Web/API/Window", false),
+            ("/es/docs/Web/API/conflicting/foo", false),
+            ("/en-US/conflicting/Web/API", false),
+            ("conflicting/Web/API", false),
+            ("", false),
+        ];
+        for (url, expected) in cases {
+            assert_eq!(is_unrooted_url(url), expected, "is_unrooted_url({url:?})");
         }
     }
 


### PR DESCRIPTION
### Description

Mark `redirected-link` and `templ-redirected-link` issues as unfixable when their target is a `conflicting/` or `orphaned/` page.

Keep the redirect suggestion and explain why the target is unrooted.

### Motivation

Prevent `content fix-flaws` from rewriting links and navigation macro arguments to unrooted pages, which hides the redirect issue and points readers at non-indexed pages without breadcrumbs or sidebars.

### Additional details

Regular redirects retain their existing fixability. Redirects to unrooted pages remain reported with `fixable: false`.

Helper unit tests cover localized URLs, locale-less URLs, and fragments. End-to-end regression coverage follows in #920.

### Related issues and pull requests

Fixes #918.
