### PR TITLE
fix(npm): replace `extract-zip` with `yauzl`

### DIFF
--- a/rari-npm/lib/download.js
+++ b/rari-npm/lib/download.js
@@ -4,9 +4,10 @@ import * as https from "https";
 import { createWriteStream } from "fs";
 import { unlink, access, constants, mkdir, chmod } from "fs/promises";
 import path from "node:path";
+import { pipeline } from "node:stream/promises";
 
 import { x } from "tar";
-import extract from "extract-zip";
+import yauzl from "yauzl";
 
 import packageJson from "../package.json" with { type: "json" };
 
@@ -211,13 +212,43 @@ async function getAssetFromGithubApi(opts, assetName, downloadFolder) {
 }
 
 /**
+ * Extract a single regular file from a zip archive, rejecting all other entries.
+ *
+ * @param {string} zipPath
+ * @param {string} fileName
+ * @param {string} destinationDir
+ */
+async function extractZipEntry(zipPath, fileName, destinationDir) {
+  const zipfile = await yauzl.openPromise(zipPath);
+  try {
+    for await (const entry of zipfile.eachEntry()) {
+      if (entry.fileName !== fileName) {
+        throw new Error(`Unexpected zip entry: ${entry.fileName}`);
+      }
+      // Unix mode lives in the upper 16 bits.
+      const fileType = (entry.externalFileAttributes >>> 16) & 0o170000;
+      if (fileType !== 0 && fileType !== 0o100000) {
+        throw new Error(`Zip entry ${entry.fileName} is not a regular file`);
+      }
+      const readStream = await zipfile.openReadStreamPromise(entry);
+      await pipeline(
+        readStream,
+        createWriteStream(path.join(destinationDir, fileName)),
+      );
+    }
+  } finally {
+    zipfile.close();
+  }
+}
+
+/**
  * @param {string} packedFilePath
  * @param {string} destinationDir
  */
 async function unpack(packedFilePath, destinationDir) {
   const rari_name = "rari";
   if (isWindows) {
-    await extract(packedFilePath, { dir: destinationDir });
+    await extractZipEntry(packedFilePath, `${rari_name}.exe`, destinationDir);
   } else {
     await x({ cwd: destinationDir, file: packedFilePath });
   }

--- a/rari-npm/lib/download.js
+++ b/rari-npm/lib/download.js
@@ -212,7 +212,7 @@ async function getAssetFromGithubApi(opts, assetName, downloadFolder) {
 }
 
 /**
- * Extract a single regular file from a zip archive, rejecting all other entries.
+ * Extract a single regular file from a zip archive, skipping all other entries.
  *
  * @param {string} zipPath
  * @param {string} fileName
@@ -223,7 +223,8 @@ async function extractZipEntry(zipPath, fileName, destinationDir) {
   const zipfile = await yauzl.openPromise(zipPath);
   for await (const entry of zipfile.eachEntry()) {
     if (entry.fileName !== fileName) {
-      throw new Error(`Unexpected zip entry: ${entry.fileName}`);
+      console.log(`Skipping zip entry: ${entry.fileName}`);
+      continue;
     }
     // Unix mode lives in the upper 16 bits.
     const fileType = (entry.externalFileAttributes >>> 16) & 0o170000;

--- a/rari-npm/lib/download.js
+++ b/rari-npm/lib/download.js
@@ -219,25 +219,22 @@ async function getAssetFromGithubApi(opts, assetName, downloadFolder) {
  * @param {string} destinationDir
  */
 async function extractZipEntry(zipPath, fileName, destinationDir) {
+  // Closed by `eachEntry()` on end, error, or early exit (`autoClose`).
   const zipfile = await yauzl.openPromise(zipPath);
-  try {
-    for await (const entry of zipfile.eachEntry()) {
-      if (entry.fileName !== fileName) {
-        throw new Error(`Unexpected zip entry: ${entry.fileName}`);
-      }
-      // Unix mode lives in the upper 16 bits.
-      const fileType = (entry.externalFileAttributes >>> 16) & 0o170000;
-      if (fileType !== 0 && fileType !== 0o100000) {
-        throw new Error(`Zip entry ${entry.fileName} is not a regular file`);
-      }
-      const readStream = await zipfile.openReadStreamPromise(entry);
-      await pipeline(
-        readStream,
-        createWriteStream(path.join(destinationDir, fileName)),
-      );
+  for await (const entry of zipfile.eachEntry()) {
+    if (entry.fileName !== fileName) {
+      throw new Error(`Unexpected zip entry: ${entry.fileName}`);
     }
-  } finally {
-    zipfile.close();
+    // Unix mode lives in the upper 16 bits.
+    const fileType = (entry.externalFileAttributes >>> 16) & 0o170000;
+    if (fileType !== 0 && fileType !== 0o100000) {
+      throw new Error(`Zip entry ${entry.fileName} is not a regular file`);
+    }
+    const readStream = await zipfile.openReadStreamPromise(entry);
+    await pipeline(
+      readStream,
+      createWriteStream(path.join(destinationDir, fileName)),
+    );
   }
 }
 

--- a/rari-npm/package-lock.json
+++ b/rari-npm/package-lock.json
@@ -10,11 +10,11 @@
       "hasInstallScript": true,
       "license": "MPL-2.0",
       "dependencies": {
-        "extract-zip": "^2.0.1",
         "https-proxy-agent": "^9.0.0",
         "json-schema-to-typescript": "^16.0.0",
         "proxy-from-env": "^2.0.0",
-        "tar": "^7.4.3"
+        "tar": "^7.4.3",
+        "yauzl": "^3.4.0"
       },
       "bin": {
         "rari": "lib/cli.js"
@@ -92,26 +92,6 @@
       "integrity": "sha512-+K1NIO8I+F9/wNulfVvu23QYd0Pe9/OCqRrim4NoYIf1VoEDL90Ve4ClzpyqBLc7NpGGWRvYNCKZ1BE/Jpf8dQ==",
       "license": "MIT"
     },
-    "node_modules/@types/node": {
-      "version": "22.7.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.6.tgz",
-      "integrity": "sha512-/d7Rnj0/ExXDMcioS78/kf1lMzYk4BZV8MZGTBKzTGZ6/406ukkbYlIsZmMPhcR5KlkunDHQLrtAVmSq7r+mSw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "undici-types": "~6.19.2"
-      }
-    },
-    "node_modules/@types/yauzl": {
-      "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
-      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/agent-base": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-9.0.0.tgz",
@@ -126,15 +106,6 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
-    },
-    "node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/chownr": {
       "version": "3.0.0",
@@ -162,44 +133,6 @@
         }
       }
     },
-    "node_modules/end-of-stream": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "license": "MIT",
-      "dependencies": {
-        "once": "^1.4.0"
-      }
-    },
-    "node_modules/extract-zip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "extract-zip": "cli.js"
-      },
-      "engines": {
-        "node": ">= 10.17.0"
-      },
-      "optionalDependencies": {
-        "@types/yauzl": "^2.9.1"
-      }
-    },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
-      }
-    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -215,21 +148,6 @@
         "picomatch": {
           "optional": true
         }
-      }
-    },
-    "node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -331,15 +249,6 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -399,16 +308,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/pump": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
-      "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
-      "license": "MIT",
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
-    },
     "node_modules/tar": {
       "version": "7.5.22",
       "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
@@ -441,19 +340,6 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "license": "ISC"
-    },
     "node_modules/yallist": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
@@ -464,13 +350,15 @@
       }
     },
     "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
       "license": "MIT",
       "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     }
   }

--- a/rari-npm/package.json
+++ b/rari-npm/package.json
@@ -25,10 +25,10 @@
     "node": ">=20"
   },
   "dependencies": {
-    "yauzl": "^3.4.0",
     "https-proxy-agent": "^9.0.0",
     "proxy-from-env": "^2.0.0",
     "tar": "^7.4.3",
+    "yauzl": "^3.4.0",
     "json-schema-to-typescript": "^16.0.0"
   }
 }

--- a/rari-npm/package.json
+++ b/rari-npm/package.json
@@ -25,7 +25,7 @@
     "node": ">=20"
   },
   "dependencies": {
-    "extract-zip": "^2.0.1",
+    "yauzl": "^3.4.0",
     "https-proxy-agent": "^9.0.0",
     "proxy-from-env": "^2.0.0",
     "tar": "^7.4.3",


### PR DESCRIPTION
### Description

Replace `extract-zip` with `yauzl` in `rari-npm`. On Windows, `unpack` now extracts only the `rari.exe` entry from the release zip, skips any other entry, and rejects a `rari.exe` entry that is not a regular file (e.g. a symlink).

### Motivation

Resolve the two open Dependabot alerts against `extract-zip` (GHSA-jmr9-qjv8-65gv and GHSA-7pqw-9j4j-h8q3, both high severity, symlink path traversal / arbitrary file write). `extract-zip` has no patched version and no commits since 2022, so there is no upgrade path. `yauzl` (which `extract-zip` wraps) is actively maintained, only parses the archive, and leaves all filesystem writes to our code.

### Additional details

Verified on macOS with a copy of the new `extractZipEntry` helper:

| Case | Result |
|---|---|
| `rari-x86_64-pc-windows-msvc.zip` from the latest release | extracted `rari.exe` (17.2 MB) |
| Zip with a symlink entry named `rari.exe` pointing at `/etc/passwd` | rejected: not a regular file |
| Zip with an extra entry `other.txt` | skipped `other.txt`, extracted `rari.exe` |

Dropping `extract-zip` also removes its transitive dependencies (`get-stream`, `debug`, `yauzl@2`) from the lock file; `npm audit` reports no vulnerabilities.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->

