### PR TITLE
fix(serve): return 404 for unknown top-level paths

### DIFF
--- a/crates/rari-cli/serve.rs
+++ b/crates/rari-cli/serve.rs
@@ -272,7 +272,7 @@ impl IntoResponse for AppError {
                 DocError::RariIoError(_)
                 | DocError::IOError(_)
                 | DocError::PageNotFound(..)
-                | DocError::UrlError(UrlError::InvalidUrl),
+                | DocError::UrlError(UrlError::InvalidUrl | UrlError::LocaleError(_)),
             ) => (StatusCode::NOT_FOUND, "").into_response(),
 
             _ => (StatusCode::INTERNAL_SERVER_ERROR, error!("🤷: {}", self.0)).into_response(),


### PR DESCRIPTION
### Description

Update `AppError::into_response` in `serve.rs` to return a 404 for `UrlError::LocaleError`, in addition to `UrlError::InvalidUrl`.

### Motivation

Prevent unknown top-level paths (e.g. `/static/client/foo.css`) from being treated as server errors.

### Additional details

Previously, such requests fell into the catch-all match arm, returning a 500 and logging `🤷: invalid locale: static` at error level, even though the request is a normal, expected 404 case.

### Related issues and pull requests

Related to mdn/fred#1888.