### PR TITLE
fix(csssyntax): skip unrooted pages

### DIFF
--- a/crates/rari-doc/src/templ/templs/csssyntax.rs
+++ b/crates/rari-doc/src/templ/templs/csssyntax.rs
@@ -11,6 +11,7 @@ use crate::error::DocError;
 use crate::helpers::l10n::l10n_json_data;
 use crate::html::links::post_process_templ_links;
 use crate::templ::css_feature_index::resolve_formal_syntax_ref;
+use crate::utils::is_unrooted;
 
 static TOOLTIPS: LazyLock<HashMap<LinkedToken, String>> = LazyLock::new(|| {
     [(LinkedToken::Asterisk, "Asterisk: the entity may occur zero, one or several times".to_string()),
@@ -32,6 +33,10 @@ fn resolve_reference(kind: CssRefKind, slug: &str) -> Option<String> {
 
 #[rari_f(register = "crate::Templ")]
 pub fn csssyntax(name: Option<String>) -> Result<String, DocError> {
+    if is_unrooted(env.slug) {
+        return Ok(String::new());
+    }
+
     let page_type = env.page_type;
     let mut slug_rev_iter = env.slug.rsplitn(3, '/');
     let slug_name = slug_rev_iter.next().unwrap();
@@ -53,17 +58,6 @@ pub fn csssyntax(name: Option<String>) -> Result<String, DocError> {
         | rari_types::fm_types::PageType::CssPseudoElement
         | rari_types::fm_types::PageType::CssSelector => {
             warn!("CSS syntax not supported for {:?}", page_type);
-            return Err(DocError::CssSyntaxError(
-                css_syntax::error::SyntaxError::NoSyntaxFound,
-            ));
-        }
-        rari_types::fm_types::PageType::None
-            if env.slug.starts_with("orphaned/") || env.slug.starts_with("conflicting/") =>
-        {
-            warn!(
-                "CSS syntax not available for conflicting/orphaned page: {}",
-                env.slug
-            );
             return Err(DocError::CssSyntaxError(
                 css_syntax::error::SyntaxError::NoSyntaxFound,
             ));

--- a/crates/rari-doc/src/templ/templs/mod.rs
+++ b/crates/rari-doc/src/templ/templs/mod.rs
@@ -158,6 +158,41 @@ mod test {
     }
 
     #[test]
+    fn test_invoke_skips_csssyntax_on_unrooted_pages() {
+        let cases = vec![
+            ("conflicting/Web/CSS/clip", PageType::None),
+            (
+                "orphaned/Web/CSS/-webkit-overflow-scrolling",
+                PageType::None,
+            ),
+            ("conflicting/Web/CSS/clip", PageType::CssProperty),
+            (
+                "orphaned/Web/CSS/-webkit-overflow-scrolling",
+                PageType::CssProperty,
+            ),
+        ];
+        for (slug, page_type) in cases {
+            let mut env = env_for_slug(slug);
+            env.page_type = page_type;
+            let (rendered, typ) = invoke(&env, "csssyntax", vec![]).expect("invoke succeeds");
+            assert!(
+                rendered.is_empty(),
+                "csssyntax on {slug} ({page_type:?}) rendered {rendered:?}"
+            );
+            assert!(matches!(typ, TemplType::None));
+        }
+    }
+
+    #[test]
+    fn test_invoke_csssyntax_requires_page_type_on_rooted_pages() {
+        let env = env_for_slug("Web/CSS/Reference/Properties/clip");
+        assert!(matches!(
+            invoke(&env, "csssyntax", vec![]),
+            Err(DocError::CssPageTypeRequired)
+        ));
+    }
+
+    #[test]
     fn test_invoke_renders_non_sidebars_on_unrooted_pages() {
         let env = env_for_slug("conflicting/Web/API/Window/showModalDialog");
         let args = vec![Some(Arg::String("hi".to_string(), Quotes::Double))];


### PR DESCRIPTION
### Description

Update `CSSSyntax` to render nothing on conflicting and orphaned pages, using the same `is_unrooted` helper as sidebars.

### Motivation

Prevent CSS syntax flaws on unrooted pages in translated-content.

### Additional details

Regression tests cover conflicting and orphaned pages with and without a CSS page type, plus page-type validation on rooted pages.

All four template invocation tests passed. Formatting and Clippy checks passed.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
