### PR TITLE
fix(npm): import `os` for signal exit codes

### DIFF
--- a/rari-npm/lib/cli.js
+++ b/rari-npm/lib/cli.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { spawn } from "node:child_process";
+import os from "node:os";
 import process from "node:process";
 import { rariBin } from "./index.js";
 


### PR DESCRIPTION
### Description

Fix the npm CLI wrapper by importing `os` for its signal exit-code fallback.

### Motivation

Prevent a `ReferenceError` when forwarding a child process's termination signal fails.

### Additional details

Verified with mocked signal-forwarding failure: `SIGTERM` produces exit code 143.

### Related issues and pull requests

Extracted from #925.
